### PR TITLE
WIP: Add keyby iterator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 *.class
 *.log
 /bin/
+*.tokens
 
 # sbt specific
 .cache
@@ -27,6 +28,7 @@ bin/
 .project
 .settings
 .classpath
+.idea/*
 
 etarget/
 
@@ -37,3 +39,87 @@ etarget/
 # OS X
 
 .DS_Store
+
+# Created by https://www.gitignore.io/api/intellij
+
+### Intellij ###
+# Covers JetBrains IDEs: IntelliJ, RubyMine, PhpStorm, AppCode, PyCharm, CLion, Android Studio and WebStorm
+# Reference: https://intellij-support.jetbrains.com/hc/en-us/articles/206544839
+
+# User-specific stuff
+.idea/**/workspace.xml
+.idea/**/tasks.xml
+.idea/**/usage.statistics.xml
+.idea/**/dictionaries
+.idea/**/shelf
+
+# Generated files
+.idea/**/contentModel.xml
+
+# Sensitive or high-churn files
+.idea/**/dataSources/
+.idea/**/dataSources.ids
+.idea/**/dataSources.local.xml
+.idea/**/sqlDataSources.xml
+.idea/**/dynamic.xml
+.idea/**/uiDesigner.xml
+.idea/**/dbnavigator.xml
+
+# Gradle
+.idea/**/gradle.xml
+.idea/**/libraries
+
+# Gradle and Maven with auto-import
+# When using Gradle or Maven with auto-import, you should exclude module files,
+# since they will be recreated, and may cause churn.  Uncomment if using
+# auto-import.
+# .idea/modules.xml
+# .idea/*.iml
+# .idea/modules
+
+# CMake
+cmake-build-*/
+
+# Mongo Explorer plugin
+.idea/**/mongoSettings.xml
+
+# File-based project format
+*.iws
+
+# IntelliJ
+out/
+
+# mpeltonen/sbt-idea plugin
+.idea_modules/
+
+# JIRA plugin
+atlassian-ide-plugin.xml
+
+# Cursive Clojure plugin
+.idea/replstate.xml
+
+# Crashlytics plugin (for Android Studio and IntelliJ)
+com_crashlytics_export_strings.xml
+crashlytics.properties
+crashlytics-build.properties
+fabric.properties
+
+# Editor-based Rest Client
+.idea/httpRequests
+
+# Android studio 3.1+ serialized cache file
+.idea/caches/build_file_checksums.ser
+
+### Intellij Patch ###
+# Comment Reason: https://github.com/joeblau/gitignore.io/issues/186#issuecomment-215987721
+
+*.iml
+modules.xml
+.idea/misc.xml
+*.ipr
+
+# Sonarlint plugin
+.idea/sonarlint
+
+
+# End of https://www.gitignore.io/api/intellij

--- a/src/main/antlr4/Arc.g4
+++ b/src/main/antlr4/Arc.g4
@@ -112,6 +112,7 @@ iterator	: iter=(TScalarIter|TSimdIter|TFringeIter|TNdIter) '(' data=valueExpr '
 			| iter=(TScalarIter|TSimdIter|TFringeIter) '(' data=valueExpr ',' start=valueExpr ',' end=valueExpr ',' stride=valueExpr ')' # FourIter
 			| TNdIter '(' data=valueExpr ',' start=valueExpr ',' end=valueExpr ',' stride=valueExpr ',' shape=valueExpr ',' strides=valueExpr ')' # SixIter
 			| TRangeIter '(' start=valueExpr ',' end=valueExpr ',' stride=valueExpr ')' # RangeIter
+			| TKeyByIter '(' data=valueExpr ',' keyFunc=lambdaExpr ')' # KeyByIter
 			| valueExpr # UnkownIter
 			;
 

--- a/src/main/antlr4/ArcLexerRules.g4
+++ b/src/main/antlr4/ArcLexerRules.g4
@@ -51,6 +51,7 @@ TToVec : 'tovec';
 TZip : 'zip';
 TScalarIter : 'iter';
 TNext : 'next';
+TKeyByIter : 'keyby';
 TSimdIter : 'simditer';
 TFringeIter : 'fringeiter';
 TNdIter : 'nditer';

--- a/src/main/scala/se/kth/cda/arc/AST.scala
+++ b/src/main/scala/se/kth/cda/arc/AST.scala
@@ -135,13 +135,15 @@ object AST {
     NdIter, // multi-dimensional nd-iter
     RangeIter, // An iterator over a range
     NextIter, // An iterator over a function that returns one value at a time
+    KeyByIter, // An iterator over the result of partitioning a vector by key
     UnknownIter // iterator still needs to be inferred from data types
     = Value;
   }
 
   case class Iter(kind: IterKind.IterKind, data: Expr,
                   start: Option[Expr] = None, end: Option[Expr] = None,
-                  stride: Option[Expr] = None, strides: Option[Expr] = None, shape: Option[Expr] = None);
+                  stride: Option[Expr] = None, strides: Option[Expr] = None,
+                  shape: Option[Expr] = None, keyFunc: Option[Expr] = None);
 
   object UnaryOpKind extends Enumeration {
     type UnaryOpKind = Value;

--- a/src/main/scala/se/kth/cda/arc/ASTTranslator.scala
+++ b/src/main/scala/se/kth/cda/arc/ASTTranslator.scala
@@ -582,6 +582,7 @@ class ASTTranslator(val parser: ArcParser) {
         case TFringeIter => FringeIter
         case TNdIter     => NdIter
         case TRangeIter  => RangeIter
+        case TKeyByIter  => KeyByIter
         case _           => UnknownIter
       }
     }
@@ -589,7 +590,7 @@ class ASTTranslator(val parser: ArcParser) {
     override def visitSimpleIter(ctx: ArcParser.SimpleIterContext): Iter = {
       val kind = tokenToIterKind(ctx.iter);
       val data = ExprVisitor.visitChecked(ctx.data);
-      Iter(kind, data)
+      Iter(kind = kind, data = data)
     }
 
     override def visitFourIter(ctx: ArcParser.FourIterContext): Iter = {
@@ -623,9 +624,15 @@ class ASTTranslator(val parser: ArcParser) {
       Iter(kind = kind, data = dummyData, start = Some(start), end = Some(end), stride = Some(stride))
     }
 
+    override def visitKeyByIter(ctx: ArcParser.KeyByIterContext): Iter = {
+      val data = ExprVisitor.visitChecked(ctx.data);
+      val keyFunc = ExprVisitor.visitChecked(ctx.keyFunc);
+      Iter(kind = IterKind.KeyByIter, data = data, keyFunc = Some(keyFunc))
+    }
+
     override def visitUnkownIter(ctx: ArcParser.UnkownIterContext): Iter = {
       val data = ExprVisitor.visitChecked(ctx.valueExpr());
-      Iter(IterKind.UnknownIter, data)
+      Iter(kind = IterKind.UnknownIter, data = data)
     }
   }
 

--- a/src/main/scala/se/kth/cda/arc/PrettyPrint.scala
+++ b/src/main/scala/se/kth/cda/arc/PrettyPrint.scala
@@ -45,15 +45,16 @@ object PrettyPrint {
   def printIter(iter: Iter, out: PrintStream, indent: Int): Unit = {
     import IterKind._;
 
-    val iterStr = (iter.kind match {
-      case ScalarIter  => ""
-      case SimdIter    => "simd"
-      case FringeIter  => "fringe"
-      case NdIter      => "nd"
-      case RangeIter   => "range"
-      case NextIter    => "next"
-      case UnknownIter => "?"
-    }) + "iter";
+    val iterStr = iter.kind match {
+      case ScalarIter  => "iter"
+      case SimdIter    => "simditer"
+      case FringeIter  => "fringeiter"
+      case NdIter      => "nditer"
+      case RangeIter   => "rangeiter"
+      case NextIter    => "nextiter"
+      case KeyByIter   => "keyby"
+      case UnknownIter => "?iter"
+    };
 
     if (iter.kind == NdIter) {
       out.append(iterStr);
@@ -65,6 +66,13 @@ object PrettyPrint {
       printExpr(iter.shape.get, out, true, indent + INDENT_INC, false);
       out.append(',');
       printExpr(iter.strides.get, out, true, indent + INDENT_INC, false);
+      out.append(')');
+    } else if (iter.kind == KeyByIter) {
+      out.append(iterStr);
+      out.append('(');
+      printExpr(iter.data, out, true, indent + INDENT_INC, false);
+      out.append(',');
+      printExpr(iter.keyFunc.get, out, true, indent + INDENT_INC, false);
       out.append(')');
     } else if (iter.start.isDefined) {
       out.append(iterStr);

--- a/src/main/scala/se/kth/cda/arc/typeinference/Typer.scala
+++ b/src/main/scala/se/kth/cda/arc/typeinference/Typer.scala
@@ -166,7 +166,8 @@ object Typer {
       newEnd <- iter.end.map(v => substituteTypes(v, substitute)).invert;
       newStride <- iter.stride.map(v => substituteTypes(v, substitute)).invert;
       newStrides <- iter.strides.map(v => substituteTypes(v, substitute)).invert;
-      newShape <- iter.shape.map(v => substituteTypes(v, substitute)).invert
-    } yield Iter(iter.kind, newData, newStart, newEnd, newStride, newStrides, newShape)
+      newShape <- iter.shape.map(v => substituteTypes(v, substitute)).invert;
+      newKeyFunc <- iter.keyFunc.map(v => substituteTypes(v, substitute)).invert
+    } yield Iter(iter.kind, newData, newStart, newEnd, newStride, newStrides, newShape, newKeyFunc)
   }
 }


### PR DESCRIPTION
This PR adds support for a `keyby` iterator which can be used as:

```
let s = streamappender[i32];
...
let s = result(s);
for(keyby(s, |e| u64(e)), appender[i32], |b,k,v| merge(b,v));
```

`|e| u64(e)` is a function which takes an element and returns a corresponding key, and is used for partitioning elements. For example, `[1,2,3,3]` would in this case be partitioned into: `[1]`, `[2]` and `[3,3]`. The body of the for loop then iterates over each key-value, where `k` is the key and `v` is the value.