### PR TITLE
Fix problems with expressions

### DIFF
--- a/src/test/scala/se/kth/cda/arc/ParserTests.scala
+++ b/src/test/scala/se/kth/cda/arc/ParserTests.scala
@@ -43,7 +43,7 @@ class ParserTests extends FunSuite with Matchers {
 
   test("raw parsing") {
     "let x: i32 = 5; x".expr() shouldBe
-      "(expr (letExpr let x (typeAnnot : (type i32)) = (operatorExpr (literalExpr 5)) ; (expr (operatorExpr x))))";
+      "(expr (valueExpr (letExpr let x (typeAnnot : (type i32)) = (operatorExpr (literalExpr 5)) ; (valueExpr (operatorExpr x)))))"
 
     "|x:i32, y:f32| x".expr() shouldBe
       "(expr (lambdaExpr | (lambdaParams (param x (typeAnnot : (type i32))) , (param y (typeAnnot : (type f32)))) | (expr (operatorExpr x))))";


### PR DESCRIPTION
This PR corrects the grammar so that it is no longer possible to write things like:
`!let x = 3; x` or `for([1,2,3], appender[i32], 5)`
The previous expression definition:
```
expr : letExpr | lambdaExpr | operatorExpr;
```
Has been changed to:
```
valueExpr : letExpr | operatorExpr;
expr : lambdaExpr | valueExpr;
```
This helps rules distinguish lambda expressions from expressions which evaluate to a value. As an example, for-expressions were before defined as:
```
annotations? TFor '(' iterator ',' builder=expr ',' body=expr ')' # For
```
and are now:
```
annotations? TFor '(' iterator ',' builder=valueExpr ',' body=lambdaExpr ')' # For
```