### PR TITLE
WIP: Add hash operator

### DIFF
--- a/src/main/antlr4/Arc.g4
+++ b/src/main/antlr4/Arc.g4
@@ -64,6 +64,7 @@ operatorExpr	: literalExpr # Literal
 				| annotations? TDeserialize '[' type ']' '(' valueExpr ')' # Deserialize
 				| annotations? cudfExpr # CUDF
 				| TZip '(' functionParams ')' # Zip
+				| THash '(' functionParams ')' # Hash
 				| annotations? TFor '(' iterator ',' builder=valueExpr ',' body=lambdaExpr ')' # For
 				| TLen '(' valueExpr ')' # Len
 				| TLookup '(' data=valueExpr ',' key=valueExpr ')' # Lookup

--- a/src/main/antlr4/ArcLexerRules.g4
+++ b/src/main/antlr4/ArcLexerRules.g4
@@ -49,6 +49,7 @@ TGroupMerger : 'groupmerger';
 TVecMerger : 'vecmerger';
 TToVec : 'tovec';
 TZip : 'zip';
+THash : 'hash';
 TScalarIter : 'iter';
 TNext : 'next';
 TKeyByIter : 'keyby';

--- a/src/main/scala/se/kth/cda/arc/AST.scala
+++ b/src/main/scala/se/kth/cda/arc/AST.scala
@@ -109,6 +109,7 @@ object AST {
     case class Deserialize(ty: Type, expr: Expr) extends ExprKind;
     case class CUDF(reference: Either[Symbol, Expr], args: Vector[Expr], returnType: Type) extends ExprKind;
     case class Zip(params: Vector[Expr]) extends ExprKind;
+    case class Hash(params: Vector[Expr]) extends ExprKind;
     case class For(iterator: Iter, builder: Expr, body: Expr) extends ExprKind;
     case class Len(expr: Expr) extends ExprKind;
     case class Lookup(data: Expr, key: Expr) extends ExprKind;

--- a/src/main/scala/se/kth/cda/arc/ASTTranslator.scala
+++ b/src/main/scala/se/kth/cda/arc/ASTTranslator.scala
@@ -135,6 +135,11 @@ class ASTTranslator(val parser: ArcParser) {
       Expr(ExprKind.Zip(params), Types.unknown, ctx)
     }
 
+    override def visitHash(ctx: ArcParser.HashContext): Expr = {
+      val params = ctx.functionParams().params.asScala.map(this.visitChecked(_)).toVector;
+      Expr(ExprKind.Hash(params), Types.unknown, ctx)
+    }
+
     override def visitFor(ctx: ArcParser.ForContext): Expr = {
       val annot = AnnotationVisitor.visitChecked(ctx.annotations());
       val iter = IterVisitor.visitChecked(ctx.iterator());

--- a/src/main/scala/se/kth/cda/arc/PrettyPrint.scala
+++ b/src/main/scala/se/kth/cda/arc/PrettyPrint.scala
@@ -233,6 +233,20 @@ object PrettyPrint {
           printType(expr.ty, out);
         }
       }
+      case Hash(params) => {
+        out.append("hash(");
+        for ((e, i) <- params.view.zipWithIndex) {
+          printExpr(e, out, false, indent + 4, false);
+          if (i != (params.length - 1)) {
+            out.append(',');
+          }
+        }
+        out.append(')');
+        if (typed) {
+          out.append(':');
+          printType(expr.ty, out);
+        }
+      }
       case For(iterator, builder, body) => {
         out.append("for(");
         printIter(iterator, out, indent + 4);

--- a/src/main/scala/se/kth/cda/arc/transform/Transformer.scala
+++ b/src/main/scala/se/kth/cda/arc/transform/Transformer.scala
@@ -127,6 +127,7 @@ class Transformer[Env](
           }
         }
         case Zip(params) => transform(params, env0, newParams => Zip(newParams))
+        case Hash(params) => transform(params, env0, newParams => Hash(newParams))
         case For(iterator, builder, body) =>
           transform((iterator.data, builder, body), env0)((newData, newBuilder, newBody) =>
             For(iterator.copy(data = newData), newBuilder, newBody))

--- a/src/main/scala/se/kth/cda/arc/typeinference/ConstraintGenerator.scala
+++ b/src/main/scala/se/kth/cda/arc/typeinference/ConstraintGenerator.scala
@@ -146,6 +146,16 @@ class ConstraintGenerator(val rootExpr: Expr) {
           Zip(newParams)
         })
       }
+      case Hash(params) => {
+        val paramTy = Types.unknown;
+        params.foreach {
+          case p => constrainEq(p.ty, paramTy);
+        }
+        constrainEq(e.ty, I64);
+        discoverDown(params, env).map(_.map { newParams =>
+          Hash(newParams)
+        })
+      }
       case For(iterator, builder, body) => {
         val elemTy = Types.unknown;
         constrainNorm(TypeConstraints.IterableKind(iterator.data.ty, elemTy));

--- a/src/main/scala/se/kth/cda/arc/typeinference/Typer.scala
+++ b/src/main/scala/se/kth/cda/arc/typeinference/Typer.scala
@@ -96,6 +96,7 @@ object Typer {
         newReturnType <- substitute(returnType)
       } yield CUDF(Right(newPointer), newArgs, newReturnType)
       case Zip(elems) => substituteTypes(elems, substitute)(newElems => Zip(newElems))
+      case Hash(elems) => substituteTypes(elems, substitute)(newElems => Hash(newElems))
       case For(iterator, builder, body) => for {
         newIterator <- substituteTypes(iterator, substitute);
         newBuilder <- substituteTypes(builder, substitute);

--- a/src/test/scala/se/kth/cda/arc/FrontEndTests.scala
+++ b/src/test/scala/se/kth/cda/arc/FrontEndTests.scala
@@ -40,6 +40,9 @@ class FrontEndTests extends FunSuite with Matchers {
   test("lookup dict") {
     "lookup(result(for(iter([{1,2},{1,4}]), groupmerger[i32,i32], |b,i,y| merge(b,y))), 1)"
   }
+  test("hash") {
+    "hash(1,2,3)"
+  }
   test("matrix multiplication") {
     """
     let n=2L;


### PR DESCRIPTION
This PR is a continuation of #1 and will add support for a `hash` operator that can be used as syntactic sugar for specifying the key function of the `keyby` operator.