### PR TITLE
Fix problem with lambda expressions and macros

### DIFF
--- a/src/main/antlr4/Arc.g4
+++ b/src/main/antlr4/Arc.g4
@@ -53,7 +53,7 @@ operatorExpr	: literalExpr # Literal
 				| scalar=(TI8|TI16|TI32|TI64|TU8|TU16|TU32|TU64|TF32|TF64|TBool) '(' valueExpr ')' # Cast
 				| TToVec '(' valueExpr ')' # ToVec
 				| TIdentifier # Ident
-				| '(' valueExpr ')' # ParenExpr
+				| '(' expr ')' # ParenExpr
 				| '[' entries+=valueExpr (',' entries+=valueExpr)* ']' # MakeVec
 				| '{' entries+=valueExpr (',' entries+=valueExpr)* '}' # MakeStruct
 				| annotations? TIf '(' cond=valueExpr ',' onTrue=valueExpr ',' onFalse=valueExpr ')' # If
@@ -120,7 +120,7 @@ cudfExpr	: TCUDF '[' TStar funcPointer=valueExpr ',' returnType=type ']' '(' fun
 			| TCUDF '[' name=TIdentifier ',' returnType=type ']' '(' functionParams ')' # NameUDF
 			;
 
-functionParams : params+=valueExpr (',' params+=valueExpr)*;
+functionParams : params+=expr (',' params+=expr)*;
 
 commutativeBinop	: TPlus # SumOp
 					| TStar # ProductOp

--- a/src/main/scala/se/kth/cda/arc/ASTTranslator.scala
+++ b/src/main/scala/se/kth/cda/arc/ASTTranslator.scala
@@ -87,7 +87,7 @@ class ASTTranslator(val parser: ArcParser) {
     }
 
     override def visitParenExpr(ctx: ParenExprContext): Expr = {
-      this.visitChecked(ctx.valueExpr())
+      this.visitChecked(ctx.expr())
     }
 
     override def visitLetExpr(ctx: LetExprContext): Expr = {

--- a/src/test/scala/se/kth/cda/arc/ParserTests.scala
+++ b/src/test/scala/se/kth/cda/arc/ParserTests.scala
@@ -46,7 +46,7 @@ class ParserTests extends FunSuite with Matchers {
       "(expr (valueExpr (letExpr let x (typeAnnot : (type i32)) = (operatorExpr (literalExpr 5)) ; (valueExpr (operatorExpr x)))))"
 
     "|x:i32, y:f32| x".expr() shouldBe
-      "(expr (lambdaExpr | (lambdaParams (param x (typeAnnot : (type i32))) , (param y (typeAnnot : (type f32)))) | (expr (operatorExpr x))))";
+      "(expr (lambdaExpr | (lambdaParams (param x (typeAnnot : (type i32))) , (param y (typeAnnot : (type f32)))) | (valueExpr (operatorExpr x))))";
 
     "stream[vec[i32]]".`type`() shouldBe
       "(type stream [ (type vec [ (type i32) ]) ])";


### PR DESCRIPTION
This PR solves an issue in #2 where the parser always expected `valueExpr` in the argument position. However, macros should be able to accept lambdas as arguments. Hence, the parser would for example falsely reject:

```
map([1,2,3], |x| x + 5)
```

Because `|x| x+5` is not a value expression.