### PR TITLE
Weekly LLVM upstream pull

### DIFF
--- a/arc-mlir/src/arc-opts.cpp
+++ b/arc-mlir/src/arc-opts.cpp
@@ -40,7 +40,7 @@ bool AllValuesAreConstant(Operation::operand_range &ops) {
 
 DenseElementsAttr ToDenseAttribs(mlir::OpResult result,
                                  Operation::operand_range &ops) {
-  ShapedType st = result->getType().cast<ShapedType>();
+  ShapedType st = result.getType().cast<ShapedType>();
   std::vector<Attribute> attribs;
   for (const mlir::Value &a : ops) {
     ConstantOp def = cast<ConstantOp>(a.getDefiningOp());

--- a/arc-mlir/src/include/arc/arc-ops.td
+++ b/arc-mlir/src/include/arc/arc-ops.td
@@ -52,9 +52,9 @@ def MakeVector
 
   let verifier = [{
     unsigned NumOperands = this->getOperation()->getNumOperands();
-    auto ElemTy = this->getOperation()->getOperand(0)->getType();
+    auto ElemTy = this->getOperation()->getOperand(0).getType();
     auto TensorTy =
-        this->getOperation()->getResult(0)->getType().dyn_cast<TensorType>();
+        this->getOperation()->getResult(0).getType().dyn_cast<TensorType>();
     if (!TensorTy.hasStaticShape())
       return emitOpError("result must have static shape, expected ")
              << RankedTensorType::get({NumOperands}, ElemTy);


### PR DESCRIPTION
Adaptations:

* mlir::OpResult is no longer a pointer.