### PR TITLE
arc-mlir: Remove pointless dyn_cast

### DIFF
--- a/arc-mlir/src/include/arc/arc-ops.td
+++ b/arc-mlir/src/include/arc/arc-ops.td
@@ -54,7 +54,7 @@ def MakeVector
     unsigned NumOperands = this->getOperation()->getNumOperands();
     auto ElemTy = this->getOperation()->getOperand(0).getType();
     auto TensorTy =
-        this->getOperation()->getResult(0).getType().dyn_cast<TensorType>();
+        this->getOperation()->getResult(0).getType().cast<TensorType>();
     if (!TensorTy.hasStaticShape())
       return emitOpError("result must have static shape, expected ")
              << RankedTensorType::get({NumOperands}, ElemTy);


### PR DESCRIPTION
There is no need for a dyn_cast as the framework should make sure that
this is a TensorType. Switch to a cast as we want the assert if the
cast fails.