### PR TITLE
Add tuple indexing operator

### DIFF
--- a/arc-mlir/src/include/arc/arc-ops.td
+++ b/arc-mlir/src/include/arc/arc-ops.td
@@ -213,4 +213,32 @@ def MakeTuple
     return mlir::success();
   }];
 }
+
+def IndexTuple
+    : Arc_Op<"index_tuple", [NoSideEffect]> {
+  let summary = "index into a tuple using a constant value";
+  let description = [{A pure operation which reads a value from a tuple}];
+
+  let arguments = (ins AnyTuple:$values, NonNegativeI64Attr:$index);
+
+  let results = (outs AnyType);
+
+  let verifier = [{
+    auto Operation = this->getOperation();
+    auto ResultTy = Operation->getResult(0).getType();
+    auto TupleTy = Operation->getOperand(0).getType().cast<TupleType>();
+    auto ElemTys = TupleTy.getTypes();
+    auto Index = getAttrOfType<IntegerAttr>("index").getValue().getZExtValue();
+    auto NumElems = TupleTy.size();
+    auto IndexTy = ElemTys[Index];
+    if (Index >= NumElems)
+      return emitOpError("index ") << Index
+        << " is out-of-bounds for tuple with size " << NumElems;
+    if (IndexTy != ResultTy)
+      return emitOpError("element type at index ") << Index
+        << " does not match result, found " << IndexTy
+        << " but expected " << ResultTy;
+    return mlir::success();
+  }];
+}
 #endif // ARC_OPS

--- a/arc-mlir/src/tests/invalid-index-tuple-index-elem-type-mismatch.mlir
+++ b/arc-mlir/src/tests/invalid-index-tuple-index-elem-type-mismatch.mlir
@@ -1,0 +1,14 @@
+// RUN: arc-mlir %s -split-input-file -verify-diagnostics
+
+module @toplevel {
+  func @main() {
+    %a = constant 0 : i1
+    %b = constant 1 : i1
+
+    %tuple = "arc.make_tuple"(%a, %b) : (i1, i1) -> tuple<i1,i1>
+    %elem = "arc.index_tuple"(%tuple) { index = 1 } : (tuple<i1,i1>) -> f64 // expected-error {{'arc.index_tuple' op element type at index 1 does not match result, found 'i1' but expected 'f64'}}
+
+    return
+  }
+}
+

--- a/arc-mlir/src/tests/invalid-index-tuple-negative-index.mlir
+++ b/arc-mlir/src/tests/invalid-index-tuple-negative-index.mlir
@@ -1,0 +1,13 @@
+// RUN: arc-mlir %s -split-input-file -verify-diagnostics
+
+module @toplevel {
+  func @main() {
+    %a = constant 0 : i1
+    %b = constant 1 : i1
+
+    %tuple = "arc.make_tuple"(%a, %b) : (i1, i1) -> tuple<i1,i1>
+    %elem = "arc.index_tuple"(%tuple) { index = -5 } : (tuple<i1,i1>) -> i1 // expected-error {{'arc.index_tuple' op attribute 'index' failed to satisfy constraint: non-negative 64-bit integer attribute}}
+
+    return
+  }
+}

--- a/arc-mlir/src/tests/invalid-index-tuple-no-index.mlir
+++ b/arc-mlir/src/tests/invalid-index-tuple-no-index.mlir
@@ -1,0 +1,14 @@
+// RUN: arc-mlir %s -split-input-file -verify-diagnostics
+
+module @toplevel {
+  func @main() {
+    %a = constant 0 : i1
+    %b = constant 1 : i1
+
+    %tuple = "arc.make_tuple"(%a, %b) : (i1, i1) -> tuple<i1,i1>
+    %elem = "arc.index_tuple"(%tuple) : (tuple<i1,i1>) -> i1 // expected-error {{'arc.index_tuple' op requires attribute 'index'}}
+
+    return
+  }
+}
+

--- a/arc-mlir/src/tests/invalid-index-tuple-out-of-bounds.mlir
+++ b/arc-mlir/src/tests/invalid-index-tuple-out-of-bounds.mlir
@@ -1,0 +1,13 @@
+// RUN: arc-mlir %s -split-input-file -verify-diagnostics
+
+module @toplevel {
+  func @main() {
+    %a = constant 0 : i1
+    %b = constant 1 : i1
+
+    %tuple = "arc.make_tuple"(%a, %b) : (i1, i1) -> tuple<i1,i1>
+    %elem = "arc.index_tuple"(%tuple) { index = 5 } : (tuple<i1,i1>) -> i1 // expected-error {{'arc.index_tuple' op index 5 is out-of-bounds for tuple with size 2}}
+
+    return
+  }
+}

--- a/arc-mlir/src/tests/valid-index-tuple.mlir
+++ b/arc-mlir/src/tests/valid-index-tuple.mlir
@@ -1,0 +1,13 @@
+// RUN: arc-mlir %s -split-input-file -verify-diagnostics
+
+module @toplevel {
+  func @main() {
+    %a = constant 0 : i1
+    %b = constant 1 : i1
+
+    %tuple = "arc.make_tuple"(%a, %b) : (i1, i1) -> tuple<i1,i1>
+    %elem = "arc.index_tuple"(%tuple) { index = 0 } : (tuple<i1,i1>) -> i1
+
+    return
+  }
+}


### PR DESCRIPTION
Adds indexing operator for tuples which takes a constant attribute as index. Also adds tests for the following:

* Out of bounds index (greater than the tuple size).
* Negative index.
* No index specified.
* Indexed element type does not match the expected result type.
* True negative test.