### PR TITLE
Update LLVM submodule

### DIFF
--- a/arc-mlir/src/CMakeLists.txt
+++ b/arc-mlir/src/CMakeLists.txt
@@ -17,41 +17,57 @@ add_public_tablegen_target(ArcDialectOptsIncGen)
 set(ARCMLIR_MODULES Main.cpp lib/arc/Dialect.cpp lib/arc/Opts.cpp lib/arc/Types.cpp)
 
 set(LIBS
-  MLIRAnalysis
-  MLIRAffineOps
+  LLVMAsmParser
+  LLVMCore
+  LLVMSupport
   MLIRAffineToStandard
-  MLIRLoopsToGPU
-  MLIRLinalgToLLVM
-
-  MLIRLoopToStandard
+  MLIRAllDialects
+  MLIRAnalysis
+  MLIRDialect
   MLIREDSC
   MLIRFxpMathOps
   MLIRGPU
+  MLIRGPUtoCUDATransforms
   MLIRGPUtoNVVMTransforms
   MLIRGPUtoROCDLTransforms
   MLIRGPUtoSPIRVTransforms
-  MLIRLinalgOps
+  MLIRGPUtoVulkanTransforms
+  MLIRIR
   MLIRLLVMIR
+  MLIRLinalgAnalysis
+  MLIRLinalgEDSC
+  MLIRLinalgOps
+  MLIRLinalgToLLVM
+  MLIRLinalgToSPIRVTransforms
+  MLIRLinalgTransforms
+  MLIRLinalgUtils
+  MLIRLoopAnalysis
   MLIRLoopOps
+  MLIRLoopOpsTransforms
+  MLIRLoopToStandard
+  MLIRLoopsToGPU
   MLIRNVVMIR
-  MLIROptMain
+  MLIROpenMP
+  MLIROptLib
   MLIRParser
   MLIRPass
-  MLIRQuantizerTransforms
   MLIRQuantOps
+  MLIRQuantizerFxpMathConfig
+  MLIRQuantizerSupport
+  MLIRQuantizerTransforms
   MLIRROCDLIR
   MLIRSPIRV
-  MLIRStandardToSPIRVTransforms
   MLIRSPIRVTestPasses
   MLIRSPIRVTransforms
-  MLIRStandardOps
   MLIRStandardToLLVM
-  MLIRTransforms
+  MLIRStandardToSPIRVTransforms
+  MLIRSupport
   MLIRTestDialect
   MLIRTestIR
   MLIRTestPass
   MLIRTestTransforms
-  MLIRSupport
+  MLIRTransformUtils
+  MLIRTransforms
   MLIRVectorOps
   MLIRVectorToLLVM
   MLIRVectorToLoops
@@ -62,8 +78,6 @@ add_dependencies(arc-mlir ArcDialectOpsIncGen)
 add_dependencies(arc-mlir ArcDialectOptsIncGen)
 
 llvm_update_compile_flags(arc-mlir)
-
-whole_archive_link(arc-mlir ${LIBS})
 
 target_link_libraries(arc-mlir PRIVATE ${LIBS} LLVMSupport)
 

--- a/arc-mlir/src/Main.cpp
+++ b/arc-mlir/src/Main.cpp
@@ -34,6 +34,8 @@
 #include <mlir/Analysis/Verifier.h>
 #include <mlir/IR/MLIRContext.h>
 #include <mlir/IR/Module.h>
+#include <mlir/InitAllDialects.h>
+#include <mlir/InitAllPasses.h>
 #include <mlir/Parser.h>
 #include <mlir/Pass/Pass.h>
 #include <mlir/Pass/PassManager.h>
@@ -73,6 +75,8 @@ static cl::opt<bool>
 int main(int argc, char **argv) {
   InitLLVM y(argc, argv);
 
+  mlir::registerAllDialects();
+  mlir::registerAllPasses();
   mlir::registerDialect<ArcDialect>();
 
   // Register any pass manager command line options.

--- a/arc-mlir/src/include/arc/Opts.td
+++ b/arc-mlir/src/include/arc/Opts.td
@@ -24,7 +24,7 @@
 #define ARC_OPTS
 
 #ifndef STANDARD_OPS
-include "mlir/Dialect/StandardOps/Ops.td"
+include "mlir/Dialect/StandardOps/IR/Ops.td"
 #endif // STANDARD_OPS
 
 #ifndef ARC_OPS

--- a/arc-mlir/src/include/arc/Types.h
+++ b/arc-mlir/src/include/arc/Types.h
@@ -64,9 +64,8 @@ public:
   static bool kindof(unsigned kind) { return kind == Appender; }
   static AppenderType get(Type mergeType);
   static AppenderType getChecked(Type mergeType, Location loc);
-  static LogicalResult
-  verifyConstructionInvariants(llvm::Optional<Location> loc, MLIRContext *ctx,
-                               Type mergeType);
+  static LogicalResult verifyConstructionInvariants(Location loc,
+                                                    Type mergeType);
   static Type parse(DialectAsmParser &parser);
   void print(DialectAsmPrinter &os) const;
   Type getMergeType() const;

--- a/arc-mlir/src/lib/arc/Opts.cpp
+++ b/arc-mlir/src/lib/arc/Opts.cpp
@@ -22,7 +22,7 @@
 
 #include "arc/Dialect.h"
 #include <llvm/Support/raw_ostream.h>
-#include <mlir/Dialect/StandardOps/Ops.h>
+#include <mlir/Dialect/StandardOps/IR/Ops.h>
 #include <mlir/IR/BlockAndValueMapping.h>
 #include <mlir/IR/Matchers.h>
 #include <mlir/IR/PatternMatch.h>

--- a/arc-mlir/src/lib/arc/Types.cpp
+++ b/arc-mlir/src/lib/arc/Types.cpp
@@ -101,7 +101,7 @@ AppenderType AppenderType::get(Type mergeType) {
 }
 
 AppenderType AppenderType::getChecked(Type mergeType, Location loc) {
-  return Base::getChecked(loc, mergeType.getContext(), Appender, mergeType);
+  return Base::getChecked(loc, Appender, mergeType);
 }
 
 Type AppenderType::getMergeType() const { return getImpl()->mergeType; }
@@ -122,12 +122,11 @@ void AppenderType::print(DialectAsmPrinter &os) const {
   os << "appender" << '<' << getMergeType() << '>';
 }
 
-LogicalResult
-AppenderType::verifyConstructionInvariants(llvm::Optional<Location> loc,
-                                           MLIRContext *ctx, Type mergeType) {
+LogicalResult AppenderType::verifyConstructionInvariants(Location loc,
+                                                         Type mergeType) {
   if (!isValueType(mergeType)) {
-    emitOptionalError(
-        loc, "appender merge type must be a value type: found ", mergeType);
+    emitOptionalError(loc, "appender merge type must be a value type: found ",
+                      mergeType);
     return failure();
   }
   return success();


### PR DESCRIPTION
Changes needed:

  * The CMake target MLIROptMain (used for arc-mlir) has been renamed
    to MLIROptLib.

  * The whole_archive_link(...) CMake construct is no longer used. Now
    we should link with MLIRAllDialects and call
    mlir::registerAllDialects() and mlir::registerAllPasses().

  * The signature of Base::verifyConstructionInvariants(...) has
    dropped the context and made the Location mandatory.