### PR TITLE
Add self-hosted runner and workflow for continuous integration

### DIFF
--- a/.github/workflows/arc-script.yml
+++ b/.github/workflows/arc-script.yml
@@ -1,0 +1,44 @@
+name: arc-script
+
+on:
+  pull_request:
+    branches: [ mlir ]
+
+env:
+  CARGO_TERM_COLOR: always
+  working-directory: ./arc-script
+
+jobs:
+  build:
+
+    runs-on: self-hosted
+
+    steps:
+    - name: checkout
+      uses: actions/checkout@v2
+    
+    - name: setup
+      uses: actions-rs/toolchain@v1
+      with:
+        toolchain: stable
+        
+    - name: cargo-check
+      run: cargo check --all-features
+
+    - name: cargo-check-tests
+      run: cargo check --all-features --tests
+
+    - name: cargo-check-examples
+      run: cargo check --all-features --examples
+
+    - name: cargo-check-benches
+      run: cargo check --all-features --benches
+    
+    - name: cargo-test
+      run: cargo test --all-features
+
+    - name: cargo-clippy
+      run: cargo clippy --all-features
+
+    - name: cargo-fmt
+      run: cargo fmt -- --check


### PR DESCRIPTION
This PR sets up a self-hosted runner for GitHub Actions. However, it seems like GitHub currently does not offer the any way to regulate whom can execute code on the machine. Soon enough, it will be possible to restrict runners to only execute code pushed by contributors within the organization:

https://github.community/t5/GitHub-Actions/Expose-self-hosted-runner-to-organization-only/m-p/44176

We could make the repository private, but I think it is best to just wait until the update.