### PR TITLE
Update LLVM submodule

### DIFF
--- a/arc-mlir/src/include/arc/Ops.td
+++ b/arc-mlir/src/include/arc/Ops.td
@@ -212,7 +212,7 @@ def IndexTupleOp : Arc_Op<"index_tuple", [NoSideEffect]> {
   let description = [{
     A pure operation which reads a value from a tuple.
   }];
-  let arguments = (ins AnyTuple:$values, NonNegativeI64Attr:$index);
+  let arguments = (ins AnyTuple:$values, Confined<I64Attr, [IntNonNegative]>:$index);
   let results = (outs AnyType);
   let extraClassDeclaration = [{ LogicalResult customVerify(); }];
   let verifier = [{ return customVerify(); }];
@@ -269,7 +269,7 @@ def MakeAppenderOp : Arc_Op<"make_appender", [NoSideEffect, Linear]> {
     %a = arc.make_appender() {size = 10} : () -> !arc.appender<i32>
     ```
   }];
-  let arguments = (NonNegativeI64Attr:$size);
+  let arguments = (Confined<I64Attr, [IntNonNegative]>:$size);
   let results = (outs AnyAppender);
 }
 

--- a/arc-mlir/src/tests/ops/index_tuple.mlir
+++ b/arc-mlir/src/tests/ops/index_tuple.mlir
@@ -36,7 +36,7 @@ module @toplevel {
     %b = constant 1 : i1
     %tuple = "arc.make_tuple"(%a, %b) : (i1, i1) -> tuple<i1,i1>
 
-    // expected-error@+1 {{'arc.index_tuple' op attribute 'index' failed to satisfy constraint: non-negative 64-bit integer attribute}}
+    // expected-error@+1 {{'arc.index_tuple' op attribute 'index' failed to satisfy constraint: 64-bit signless integer attribute whose value is non-negative}}
     %elem = "arc.index_tuple"(%tuple) { index = -5 } : (tuple<i1,i1>) -> i1
     return
   }


### PR DESCRIPTION
Changes needed:

* The NonNegativeI64Attr ODS constraint has been removed and replaced
  with Confined<I64Attr, [IntNonNegative]>.

* Update tests to account for the changed wording in the error message
  due to the change above.