### PR TITLE
Update LLVM submodule

### DIFF
--- a/arc-mlir/src/include/Arc/Arc.h
+++ b/arc-mlir/src/include/Arc/Arc.h
@@ -1,5 +1,4 @@
-//===- Dialect definition for the Rust IR
-//----------------------------------===//
+//===- Dialect definition for the Arc IR ----------------------------------===//
 //
 // Copyright 2019 The MLIR Authors.
 // Copyright 2019 KTH Royal Institute of Technology.
@@ -17,40 +16,31 @@
 // limitations under the License.
 // =============================================================================
 //
-// This file implements the IR Dialect for the Rust language.
+// This file implements the IR Dialect for the Arc language.
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef RUST_DIALECT_H_
-#define RUST_DIALECT_H_
+#ifndef ARC_DIALECT_H_
+#define ARC_DIALECT_H_
 
-#include "Rust/Types.h"
+#include "Arc/Types.h"
 #include <mlir/IR/Builders.h>
 #include <mlir/IR/Dialect.h>
 #include <mlir/IR/Function.h>
 #include <mlir/IR/Operation.h>
+#include <mlir/Interfaces/SideEffects.h>
 
 using namespace mlir;
 
-namespace rust {
+namespace arc {
 
-class RustPrinterStream;
-
-/// This is the definition of the Rust dialect.
-class RustDialect : public mlir::Dialect {
-public:
-  explicit RustDialect(mlir::MLIRContext *ctx);
-
-  static llvm::StringRef getDialectNamespace() { return "rust"; }
-  Type parseType(DialectAsmParser &parser) const override;
-  void printType(Type type, DialectAsmPrinter &os) const override;
-};
+#include "Arc/ArcDialect.h.inc"
 
 /// Include the auto-generated header file containing the declarations of the
-/// rust operations.
+/// arc operations.
 #define GET_OP_CLASSES
-#include "Rust/RustDialect.h.inc"
+#include "Arc/Arc.h.inc"
 
-} // namespace rust
+} // end namespace arc
 
-#endif // RUST_DIALECT_H_
+#endif // ARC_DIALECT_H_

--- a/arc-mlir/src/include/Arc/Arc.td
+++ b/arc-mlir/src/include/Arc/Arc.td
@@ -25,6 +25,7 @@
 
 #ifndef OP_BASE
 include "../../mlir/include/mlir/IR/OpBase.td"
+include "../../mlir/include/mlir/Interfaces/SideEffects.td"
 #endif // OP_BASE
 
 //===----------------------------------------------------------------------===//
@@ -34,6 +35,10 @@ include "../../mlir/include/mlir/IR/OpBase.td"
 def Arc_Dialect : Dialect {
   let name = "arc";
   let cppNamespace = "arc";
+  let extraClassDeclaration = [{
+      Type parseType(DialectAsmParser &parser) const override;
+      void printType(Type type, DialectAsmPrinter &os) const override;
+  }];
 }
 
 //===----------------------------------------------------------------------===//

--- a/arc-mlir/src/include/Arc/CMakeLists.txt
+++ b/arc-mlir/src/include/Arc/CMakeLists.txt
@@ -1,1 +1,6 @@
-add_mlir_dialect(ArcDialect ArcDialect)
+set(MLIR_MAIN_SRC_DIR ${CMAKE_CURRENT_SOURCE_DIR}/../../../llvm-project/mlir/)
+set(MLIR_INCLUDE_DIR
+  ${CMAKE_CURRENT_SOURCE_DIR}/../../../llvm-project/mlir/include/
+)
+
+add_mlir_dialect(Arc arc Arc)

--- a/arc-mlir/src/include/Arc/Opts.td
+++ b/arc-mlir/src/include/Arc/Opts.td
@@ -28,7 +28,7 @@ include "../../mlir/include/mlir/Dialect/StandardOps/IR/Ops.td"
 #endif // STANDARD_OPS
 
 #ifndef ARC_OPS
-include "../../include/Arc/ArcDialect.td"
+include "../../include/Arc/Arc.td"
 #endif // ARC_OPS
 
 def AllValuesAreConstants : Constraint<CPred<"AllValuesAreConstant($0)">>;

--- a/arc-mlir/src/include/Rust/CMakeLists.txt
+++ b/arc-mlir/src/include/Rust/CMakeLists.txt
@@ -1,1 +1,6 @@
-add_mlir_dialect(RustDialect RustDialect)
+set(MLIR_MAIN_SRC_DIR ${CMAKE_CURRENT_SOURCE_DIR}/../../../llvm-project/mlir/)
+set(MLIR_INCLUDE_DIR
+  ${CMAKE_CURRENT_SOURCE_DIR}/../../../llvm-project/mlir/include/
+)
+
+add_mlir_dialect(Rust rust Rust)

--- a/arc-mlir/src/include/Rust/Rust.h
+++ b/arc-mlir/src/include/Rust/Rust.h
@@ -1,4 +1,5 @@
-//===- Dialect definition for the Arc IR ----------------------------------===//
+//===- Dialect definition for the Rust IR
+//----------------------------------===//
 //
 // Copyright 2019 The MLIR Authors.
 // Copyright 2019 KTH Royal Institute of Technology.
@@ -16,38 +17,33 @@
 // limitations under the License.
 // =============================================================================
 //
-// This file implements the IR Dialect for the Arc language.
+// This file implements the IR Dialect for the Rust language.
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef ARC_DIALECT_H_
-#define ARC_DIALECT_H_
+#ifndef RUST_DIALECT_H_
+#define RUST_DIALECT_H_
 
-#include "Arc/Types.h"
+#include "Rust/Types.h"
 #include <mlir/IR/Builders.h>
 #include <mlir/IR/Dialect.h>
 #include <mlir/IR/Function.h>
 #include <mlir/IR/Operation.h>
+#include <mlir/Interfaces/SideEffects.h>
 
 using namespace mlir;
 
-namespace arc {
+namespace rust {
 
-/// This is the definition of the Arc dialect.
-class ArcDialect : public mlir::Dialect {
-public:
-  explicit ArcDialect(mlir::MLIRContext *ctx);
+class RustPrinterStream;
 
-  static llvm::StringRef getDialectNamespace() { return "arc"; }
-  Type parseType(DialectAsmParser &parser) const override;
-  void printType(Type type, DialectAsmPrinter &os) const override;
-};
+#include "Rust/RustDialect.h.inc"
 
 /// Include the auto-generated header file containing the declarations of the
-/// arc operations.
+/// rust operations.
 #define GET_OP_CLASSES
-#include "Arc/ArcDialect.h.inc"
+#include "Rust/Rust.h.inc"
 
-} // end namespace arc
+} // namespace rust
 
-#endif // ARC_DIALECT_H_
+#endif // RUST_DIALECT_H_

--- a/arc-mlir/src/include/Rust/Rust.td
+++ b/arc-mlir/src/include/Rust/Rust.td
@@ -25,6 +25,7 @@
 
 #ifndef OP_BASE
 include "../../mlir/include/mlir/IR/OpBase.td"
+include "../../mlir/include/mlir/Interfaces/SideEffects.td"
 #endif // OP_BASE
 
 //===----------------------------------------------------------------------===//
@@ -34,6 +35,11 @@ include "../../mlir/include/mlir/IR/OpBase.td"
 def Rust_Dialect : Dialect {
   let name = "rust";
   let cppNamespace = "rust";
+  let extraClassDeclaration = [{
+      Type parseType(DialectAsmParser &parser) const override;
+      void printType(Type type, DialectAsmPrinter &os) const override;
+  }];
+
 }
 
 //===----------------------------------------------------------------------===//

--- a/arc-mlir/src/lib/Arc/CMakeLists.txt
+++ b/arc-mlir/src/lib/Arc/CMakeLists.txt
@@ -6,7 +6,7 @@ add_mlir_dialect_library(ArcDialect
   ${MLIR_MAIN_INCLUDE_DIR}/mlir/ArcOps
 
   DEPENDS
-  MLIRArcDialectIncGen
+  MLIRArcIncGen
   ArcDialectOptsIncGen
 )
 

--- a/arc-mlir/src/lib/Arc/Dialect.cpp
+++ b/arc-mlir/src/lib/Arc/Dialect.cpp
@@ -21,7 +21,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include "Arc/ArcDialect.h"
+#include "Arc/Arc.h"
 #include <llvm/Support/raw_ostream.h>
 #include <mlir/IR/DialectImplementation.h>
 #include <mlir/IR/StandardTypes.h>
@@ -37,7 +37,7 @@ using namespace types;
 ArcDialect::ArcDialect(mlir::MLIRContext *ctx) : mlir::Dialect("arc", ctx) {
   addOperations<
 #define GET_OP_LIST
-#include "Arc/ArcDialect.cpp.inc"
+#include "Arc/Arc.cpp.inc"
       >();
   addTypes<AppenderType>();
 }
@@ -183,4 +183,4 @@ LogicalResult ResultOp::customVerify() {
 //===----------------------------------------------------------------------===//
 
 #define GET_OP_CLASSES
-#include "Arc/ArcDialect.cpp.inc"
+#include "Arc/Arc.cpp.inc"

--- a/arc-mlir/src/lib/Arc/Opts.cpp
+++ b/arc-mlir/src/lib/Arc/Opts.cpp
@@ -20,7 +20,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include "Arc/ArcDialect.h"
+#include "Arc/Arc.h"
 #include <llvm/Support/raw_ostream.h>
 #include <mlir/Dialect/StandardOps/IR/Ops.h>
 #include <mlir/IR/BlockAndValueMapping.h>

--- a/arc-mlir/src/lib/Rust/CMakeLists.txt
+++ b/arc-mlir/src/lib/Rust/CMakeLists.txt
@@ -6,7 +6,7 @@ add_mlir_dialect_library(RustDialect
   ${MLIR_MAIN_INCLUDE_DIR}/mlir/RustOps
 
   DEPENDS
-  MLIRRustDialectIncGen
+  MLIRRustIncGen
 )
 
 target_link_libraries(RustDialect

--- a/arc-mlir/src/lib/Rust/Dialect.cpp
+++ b/arc-mlir/src/lib/Rust/Dialect.cpp
@@ -21,7 +21,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include "Rust/RustDialect.h"
+#include "Rust/Rust.h"
 #include "Rust/RustPrinterStream.h"
 #include <llvm/Support/FileSystem.h>
 #include <llvm/Support/Path.h>
@@ -40,7 +40,7 @@ using namespace types;
 RustDialect::RustDialect(mlir::MLIRContext *ctx) : mlir::Dialect("rust", ctx) {
   addOperations<
 #define GET_OP_LIST
-#include "Rust/RustDialect.cpp.inc"
+#include "Rust/Rust.cpp.inc"
       >();
   addTypes<RustType>();
 }
@@ -305,4 +305,4 @@ void RustBlockResultOp::writeRust(RustPrinterStream &PS) {
 //===----------------------------------------------------------------------===//
 
 #define GET_OP_CLASSES
-#include "Rust/RustDialect.cpp.inc"
+#include "Rust/Rust.cpp.inc"

--- a/arc-mlir/src/tools/arc-mlir/ArcOptMain.cpp
+++ b/arc-mlir/src/tools/arc-mlir/ArcOptMain.cpp
@@ -13,7 +13,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "Arc/ArcOptMain.h"
-#include "Rust/RustDialect.h"
+#include "Rust/Rust.h"
 #include "mlir/Analysis/Passes.h"
 #include "mlir/IR/Attributes.h"
 #include "mlir/IR/Diagnostics.h"

--- a/arc-mlir/src/tools/arc-mlir/Main.cpp
+++ b/arc-mlir/src/tools/arc-mlir/Main.cpp
@@ -21,9 +21,9 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include "Arc/ArcDialect.h"
+#include "Arc/Arc.h"
 #include "Arc/ArcOptMain.h"
-#include "Rust/RustDialect.h"
+#include "Rust/Rust.h"
 #include <llvm/Support/CommandLine.h>
 #include <llvm/Support/ErrorOr.h>
 #include <llvm/Support/InitLLVM.h>


### PR DESCRIPTION
Changes needed:

  * Dialect classes are now generated with tablegen. The CMake support
    for this generates a header named ${dialect}Dialect.h.inc which
    will clash with our ArcDialect-files. So do the rename circus
    again, rename $<name>Dialect<Foo> to simply <name><foo>.

    Drop manually defined dialect classes, move dialect-specific
    declarations into extraClassDeclaration-blocks in the dialect
    .td-spec.