### PR TITLE
rust: Add comparison binary operator

### DIFF
--- a/arc-mlir/src/include/Rust/Rust.td
+++ b/arc-mlir/src/include/Rust/Rust.td
@@ -192,6 +192,26 @@ def Rust_RustBinaryOp : Rust_Op<"binaryop", [SameOperandsAndResultType]> {
   }];
 }
 
+def Rust_RustCompOp : Rust_Op<"compop", [SameTypeOperands]> {
+  let summary = "a Rust comparison operation.";
+  let description = [{
+    A Rust comparison operation, the predicate attribute is the string
+    representation of the operator in Rust syntax.
+  }];
+
+  let arguments = (ins StrAttr : $op, AnyRustType : $LHS, AnyRustType : $RHS);
+  let results = (outs BoolRustType);
+
+  let extraClassDeclaration = [{
+    StringRef getOperator() {
+      return getAttr("op").dyn_cast<StringAttr>().getValue();
+    }
+
+    // Write this operation as Rust code to the stream
+    void writeRust(RustPrinterStream &);
+  }];
+}
+
 def Rust_RustBlockResultOp
     : Rust_Op<"block.result",
               [HasParent<"RustIfOp">, Terminator, SameOperandsAndResultType]> {

--- a/arc-mlir/src/lib/Rust/Dialect.cpp
+++ b/arc-mlir/src/lib/Rust/Dialect.cpp
@@ -224,6 +224,8 @@ static RustPrinterStream &writeRust(Operation &operation,
     op.writeRust(PS);
   else if (RustBinaryOp op = dyn_cast<RustBinaryOp>(operation))
     op.writeRust(PS);
+  else if (RustCompOp op = dyn_cast<RustCompOp>(operation))
+    op.writeRust(PS);
   else if (RustIfOp op = dyn_cast<RustIfOp>(operation))
     op.writeRust(PS);
   else if (RustBlockResultOp op = dyn_cast<RustBlockResultOp>(operation))
@@ -278,6 +280,13 @@ void RustUnaryOp::writeRust(RustPrinterStream &PS) {
 }
 
 void RustBinaryOp::writeRust(RustPrinterStream &PS) {
+  auto r = getResult();
+  types::RustType rt = r.getType().cast<types::RustType>();
+  PS << "let " << r << ":" << rt << " = " << LHS() << " " << getOperator()
+     << " " << RHS() << ";\n";
+}
+
+void RustCompOp::writeRust(RustPrinterStream &PS) {
   auto r = getResult();
   types::RustType rt = r.getType().cast<types::RustType>();
   PS << "let " << r << ":" << rt << " = " << LHS() << " " << getOperator()

--- a/arc-mlir/src/tests/rust/rust-output.mlir
+++ b/arc-mlir/src/tests/rust/rust-output.mlir
@@ -52,6 +52,12 @@
 
 }) {sym_name = "this_is_the_name_of_the_seventh_function", type = (!rust<"bool">, !rust<"f64">) -> !rust<"f64"> } : () -> ()
 
+"rust.func"() ( {
+ ^bb0(%a: !rust<"f64">, %b: !rust<"f64">):
+ %x = "rust.compop"(%a, %b) {op="<"} : (!rust<"f64">, !rust<"f64">) -> (!rust<"bool">)
+ "rust.return"(%x) : (!rust<"bool">) -> (!rust<"bool">)
+
+}) {sym_name = "this_is_the_name_of_the_eigth_function", type = (!rust<"f64">, !rust<"f64">) -> !rust<"bool"> } : () -> ()
 
 "rust.crate_end"() : () -> ()
 } ) { sym_name = "this_is_the_name_of_the_crate" }: () -> ()


### PR DESCRIPTION
As a comparison operator returns a boolean we cannot reuse the plain
binop as it has the SameOperandsAndResultType trait.