### PR TITLE
Update LLVM submodule

### DIFF
--- a/arc-mlir/src/tests/ops/if.mlir
+++ b/arc-mlir/src/tests/ops/if.mlir
@@ -24,7 +24,8 @@ module @toplevel {
     %a = constant 0 : i1
     %f = constant 3.14 : f64
 
-    // expected-error@+1 {{'arc.block.result' op expects parent op 'arc.if'}}
+    // expected-error@+2 {{'arc.block.result' op expects parent op 'arc.if'}}
+    // expected-note@+1 {{see current operation: %0 = "arc.block.result"}}
     "arc.block.result"(%f) : (f64) -> f64
     return
   }
@@ -39,7 +40,8 @@ module @toplevel {
     %c = constant 0.693 : f64
 
     "arc.if"(%a) ( {
-    // expected-error@+1 {{'arc.block.result' op requires the same type for all operands and results}}
+    // expected-error@+2 {{'arc.block.result' op requires the same type for all operands and results}}
+    // expected-note@+1 {{see current operation: %0 = "arc.block.result"}}
       "arc.block.result"(%b) : (f32) -> f64
     },  {
       "arc.block.result"(%c) : (f64) -> f64
@@ -68,7 +70,8 @@ module @toplevel {
     %a = constant 0 : i1
     %b = constant 3.14 : f32
     %c = constant 0.693 : f64
-    // expected-error@+1 {{'arc.if' op has incorrect number of regions: expected 2 but found 1}}
+    // expected-error@+2 {{'arc.if' op expected 2 regions}}
+    // expected-note@+1 {{see current operation: %0 = "arc.if"}}
     "arc.if"(%a) ({}) : (i1) -> f64
     return
   }
@@ -81,7 +84,8 @@ module @toplevel {
     %a = constant 0 : i1
     %b = constant 3.14 : f32
     %c = constant 0.693 : f64
-    // expected-error@+1 {{'arc.if' op has incorrect number of regions: expected 2 but found 3}}
+    // expected-error@+2 {{'arc.if' op expected 2 regions}}
+    // expected-note@+1 {{see current operation: %0 = "arc.if"}}
     "arc.if"(%a) ({},{},{}) : (i1) -> f64
     return
   }
@@ -94,7 +98,8 @@ module @toplevel {
     %a = constant 0 : i1
     %b = constant 3.14 : f32
     %c = constant 0.693 : f64
-    // expected-error@+1 {{'arc.if' op region #0 ('thenRegion') failed to verify constraint: region with 1 blocks}}
+    // expected-error@+2 {{'arc.if' op region #0 ('thenRegion') failed to verify constraint: region with 1 blocks}}
+    // expected-note@+1 {{see current operation: %0 = "arc.if"}}
     "arc.if"(%a) ({},{}) : (i1) -> f64
     return
   }
@@ -107,7 +112,8 @@ module @toplevel {
     %a = constant 0 : i1
     %b = constant 3.14 : f64
     %c = constant 0.693 : f64
-    // expected-error@+1 {{'arc.if' op region #1 ('elseRegion') failed to verify constraint: region with 1 blocks}}
+    // expected-error@+2 {{'arc.if' op region #1 ('elseRegion') failed to verify constraint: region with 1 blocks}}
+    // expected-note@+1 {{see current operation: %0 = "arc.if"}}
     "arc.if"(%a) ({
       "arc.block.result"(%b) : (f64) -> f64
     },{}) : (i1) -> f64
@@ -123,8 +129,9 @@ module @toplevel {
     %b = constant 3.14 : f64
     %c = constant 0.693 : f64
 
-    // expected-error@+2 {{'arc.if' op expects regions to end with 'arc.block.result', found 'arc.make_tuple'}}
-    // expected-note@+1 {{in custom textual format, the absence of terminator implies 'arc.block.result'}}
+    // expected-error@+3 {{'arc.if' op expects regions to end with 'arc.block.result', found 'arc.make_tuple'}}
+    // expected-note@+2 {{in custom textual format, the absence of terminator implies 'arc.block.result'}}
+    // expected-note@+1 {{see current operation: %0 = "arc.if"}}
     "arc.if"(%a) ( {
       "arc.block.result"(%b) : (f64) -> f64
       %1 = "arc.make_tuple"(%c, %c) : (f64, f64) -> tuple<f64,f64>
@@ -143,7 +150,8 @@ module @toplevel {
     %b = constant 3.14 : f32
     %c = constant 0.693 : f64
 
-    // expected-error@+1 {{'arc.if' op result type does not match the type of the parent: expected 'f64' but found 'f32'}}
+    // expected-error@+2 {{'arc.if' op result type does not match the type of the parent: expected 'f64' but found 'f32'}}
+    // expected-note@+1 {{see current operation: %0 = "arc.if"}}
     "arc.if"(%a) ( {
       "arc.block.result"(%b) : (f32) -> f32
     },  {
@@ -160,7 +168,8 @@ module @toplevel {
     %a = constant 0 : i1
     %b = constant 3.14 : f32
     %c = constant 0.693 : f32
-    // expected-error@+1 {{'arc.if' op result type does not match the type of the parent: expected 'f64' but found 'f32'}}
+    // expected-error@+2 {{'arc.if' op result type does not match the type of the parent: expected 'f64' but found 'f32'}}
+    // expected-note@+1 {{see current operation: %0 = "arc.if"}}
     "arc.if"(%a) ( {
       "arc.block.result"(%b) : (f32) -> f32
     },  {

--- a/arc-mlir/src/tests/ops/index_tuple.mlir
+++ b/arc-mlir/src/tests/ops/index_tuple.mlir
@@ -22,7 +22,8 @@ module @toplevel {
     %b = constant 1 : i1
     %tuple = "arc.make_tuple"(%a, %b) : (i1, i1) -> tuple<i1,i1>
 
-    // expected-error@+1 {{'arc.index_tuple' op element type at index 1 does not match result: expected 'f64' but found 'i1'}}
+    // expected-error@+2 {{'arc.index_tuple' op element type at index 1 does not match result: expected 'f64' but found 'i1'}}
+    // expected-note@+1 {{see current operation: %0 = "arc.index_tuple"}}
     %elem = "arc.index_tuple"(%tuple) { index = 1 } : (tuple<i1,i1>) -> f64
     return
   }
@@ -36,7 +37,8 @@ module @toplevel {
     %b = constant 1 : i1
     %tuple = "arc.make_tuple"(%a, %b) : (i1, i1) -> tuple<i1,i1>
 
-    // expected-error@+1 {{'arc.index_tuple' op attribute 'index' failed to satisfy constraint: 64-bit signless integer attribute whose value is non-negative}}
+    // expected-error@+2 {{'arc.index_tuple' op attribute 'index' failed to satisfy constraint: 64-bit signless integer attribute whose value is non-negative}}
+    // expected-note@+1 {{see current operation: %0 = "arc.index_tuple"}}
     %elem = "arc.index_tuple"(%tuple) { index = -5 } : (tuple<i1,i1>) -> i1
     return
   }
@@ -50,7 +52,8 @@ module @toplevel {
     %b = constant 1 : i1
     %tuple = "arc.make_tuple"(%a, %b) : (i1, i1) -> tuple<i1,i1>
 
-    // expected-error@+1 {{'arc.index_tuple' op requires attribute 'index'}}
+    // expected-error@+2 {{'arc.index_tuple' op requires attribute 'index'}}
+    // expected-note@+1 {{see current operation: %0 = "arc.index_tuple"}}
     %elem = "arc.index_tuple"(%tuple) : (tuple<i1,i1>) -> i1
     return
   }
@@ -64,7 +67,8 @@ module @toplevel {
     %b = constant 1 : i1
     %tuple = "arc.make_tuple"(%a, %b) : (i1, i1) -> tuple<i1,i1>
 
-    // expected-error@+1 {{'arc.index_tuple' op index 5 is out-of-bounds for tuple with size 2}}
+    // expected-error@+2 {{'arc.index_tuple' op index 5 is out-of-bounds for tuple with size 2}}
+    // expected-note@+1 {{see current operation: %0 = "arc.index_tuple"}}
     %elem = "arc.index_tuple"(%tuple) { index = 5 } : (tuple<i1,i1>) -> i1
     return
   }

--- a/arc-mlir/src/tests/ops/make_appender.mlir
+++ b/arc-mlir/src/tests/ops/make_appender.mlir
@@ -16,7 +16,8 @@ module @toplevel {
   func @main() {
     %v = constant 0 : i32
 
-    // expected-error@+1 {{'arc.make_appender' op requires zero operands}}
+    // expected-error@+2 {{'arc.make_appender' op requires zero operands}}
+    // expected-note@+1 {{see current operation: %0 = "arc.make_appender"}}
     %0 = "arc.make_appender"(%v) : (i32) -> !arc.appender<i32>
 
     %r = "arc.result"(%0) : (!arc.appender<i32>) -> tensor<i32>
@@ -39,7 +40,8 @@ module @toplevel {
 
 module @toplevel {
   func @main() {
-    // expected-error@+1 {{'arc.make_appender' op result #0 must be any appender, but got 'i32'}}
+    // expected-error@+2 {{'arc.make_appender' op result #0 must be any appender, but got 'i32'}}
+    // expected-note@+1 {{see current operation: %0 = "arc.make_appender"}}
     %0 = "arc.make_appender"() : () -> i32
     %b = constant 2 : i32
     %c = addi %0, %b : i32

--- a/arc-mlir/src/tests/ops/make_tuple.mlir
+++ b/arc-mlir/src/tests/ops/make_tuple.mlir
@@ -19,7 +19,8 @@ module @toplevel {
   func @main() {
     %a = constant 0 : i1
     %b = constant 1 : i1
-    // expected-error@+1 {{'arc.make_tuple' op operand types do not match: expected 'f32' but found 'i1'}}
+    // expected-error@+2 {{'arc.make_tuple' op operand types do not match: expected 'f32' but found 'i1'}}
+    // expected-note@+1 {{see current operation: %0 = "arc.make_tuple"}}
     %1 = "arc.make_tuple"(%a, %b) : (i1, i1) -> tuple<i1,f32>
     return
   }
@@ -43,7 +44,8 @@ module @toplevel {
   func @main() {
     %a = constant 0 : i1
     %b = constant 1 : i1
-    // expected-error@+1 {{'arc.make_tuple' op result does not match the number of operands: expected 1 but found 2 operands}}
+    // expected-error@+2 {{'arc.make_tuple' op result does not match the number of operands: expected 1 but found 2 operands}}
+    // expected-note@+1 {{see current operation: %0 = "arc.make_tuple"}}
     %1 = "arc.make_tuple"(%a, %b) : (i1, i1) -> tuple<i1>
     return
   }
@@ -53,7 +55,8 @@ module @toplevel {
 
 module @toplevel {
   func @main() {
-    // expected-error@+1 {{'arc.make_tuple' op tuple must contain at least one element}}
+    // expected-error@+2 {{'arc.make_tuple' op tuple must contain at least one element}}
+    // expected-note@+1 {{see current operation: %0 = "arc.make_tuple"}}
     %1 = "arc.make_tuple"() : () -> tuple<>
     return
   }

--- a/arc-mlir/src/tests/ops/make_vector.mlir
+++ b/arc-mlir/src/tests/ops/make_vector.mlir
@@ -21,7 +21,8 @@ module @toplevel {
     %c = constant 1 : i1
     %d = constant 0 : i1
 
-    // expected-error@+1 {{'arc.make_vector' op requires the same element type for all operands and results}}
+    // expected-error@+2 {{'arc.make_vector' op requires the same element type for all operands and results}}
+    // expected-note@+1 {{see current operation: %0 = "arc.make_vector"}}
     %1 = "arc.make_vector"(%b, %b, %c, %d) : (i1, i1, i1, i1) -> tuple<i1,i1,i1,i1>
     return
   }
@@ -35,7 +36,8 @@ module @toplevel {
     %c = constant 1 : i1
     %d = constant 0 : i1
 
-    // expected-error@+1 {{'arc.make_vector' op requires the same element type for all operands and results}}
+    // expected-error@+2 {{'arc.make_vector' op requires the same element type for all operands and results}}
+    // expected-note@+1 {{see current operation: %0 = "arc.make_vector"}}
     %1 = "arc.make_vector"(%b, %b, %c, %d) : (i1, i1, i1, i1) -> tensor<f32>
     return
   }
@@ -49,7 +51,8 @@ module @toplevel {
     %c = constant 1 : i1
     %d = constant 0 : i1
 
-    // expected-error@+1 {{'arc.make_vector' op result #0 must be 1D tensor of any type values, but got 'tensor<4x4xi1>'}}
+    // expected-error@+2 {{'arc.make_vector' op result #0 must be 1D tensor of any type values, but got 'tensor<4x4xi1>'}}
+    // expected-note@+1 {{see current operation: %0 = "arc.make_vector"}}
     %1 = "arc.make_vector"(%b, %b, %c, %d) : (i1, i1, i1, i1) -> tensor<4x4xi1>
     return
   }
@@ -63,7 +66,8 @@ module @toplevel {
     %c = constant 1 : i1
     %d = constant 0 : i1
 
-    // expected-error@+1 {{'arc.make_vector' op result must have static shape: expected 'tensor<4xi1>'}}
+    // expected-error@+2 {{'arc.make_vector' op result must have static shape: expected 'tensor<4xi1>'}}
+    // expected-note@+1 {{see current operation: %0 = "arc.make_vector"}}
     %1 = "arc.make_vector"(%b, %b, %c, %d) : (i1, i1, i1, i1) -> tensor<?xi1>
     return
   }
@@ -77,7 +81,8 @@ module @toplevel {
     %c = constant 1 : i1
     %d = constant 0 : i1
 
-    // expected-error@+1 {{'arc.make_vector' op result does not match the number of operands: expected 5 but found 4 operands}}
+    // expected-error@+2 {{'arc.make_vector' op result does not match the number of operands: expected 5 but found 4 operands}}
+    // expected-note@+1 {{see current operation: %0 = "arc.make_vector"}}
     %1 = "arc.make_vector"(%b, %b, %c, %d) : (i1, i1, i1, i1) -> tensor<5xi1>
     return
   }

--- a/arc-mlir/src/tests/ops/merge.mlir
+++ b/arc-mlir/src/tests/ops/merge.mlir
@@ -19,7 +19,8 @@ module @toplevel {
     %v = constant 5 : i64
     %0 = "arc.make_appender"() : () -> !arc.appender<i32>
 
-    // expected-error@+1 {{'arc.merge' op operand type does not match merge type, found 'i64' but expected 'i32'}}
+    // expected-error@+2 {{'arc.merge' op operand type does not match merge type, found 'i64' but expected 'i32'}}
+    // expected-note@+1 {{see current operation: %0 = "arc.merge"}}
     %1 = "arc.merge"(%0, %v) : (!arc.appender<i32>, i64) -> !arc.appender<i32>
 
     %r = "arc.result"(%1) : (!arc.appender<i32>) -> tensor<i32>
@@ -34,7 +35,8 @@ module @toplevel {
     %0 = "arc.make_appender"() : () -> !arc.appender<i32>
     %v = constant 5 : i32
 
-    // expected-error@+1 {{'arc.merge' op result type does not match builder type, found: '!arc.appender<i64>' but expected '!arc.appender<i32>'}}
+    // expected-error@+2 {{'arc.merge' op result type does not match builder type, found: '!arc.appender<i64>' but expected '!arc.appender<i32>'}}
+    // expected-note@+1 {{see current operation: %0 = "arc.merge"}}
     %1 = "arc.merge"(%0, %v) : (!arc.appender<i32>, i32) -> !arc.appender<i64>
 
     %c = "arc.result"(%1) : (!arc.appender<i64>) -> tensor<i64>
@@ -49,7 +51,8 @@ module @toplevel {
     %v1 = constant 5 : i32
     %v2 = constant 5 : i32
 
-    // expected-error@+1 {{'arc.make_appender' op failed to verify that result must have exactly one use}}
+    // expected-error@+2 {{'arc.make_appender' op failed to verify that result must have exactly one use}}
+    // expected-note@+1 {{see current operation: %0 = "arc.make_appender"}}
     %0 = "arc.make_appender"() : () -> !arc.appender<i32>
 
     %1 = "arc.merge"(%0, %v1) : (!arc.appender<i32>, i32) -> !arc.appender<i32>

--- a/arc-mlir/src/tests/ops/result.mlir
+++ b/arc-mlir/src/tests/ops/result.mlir
@@ -15,7 +15,8 @@ module @toplevel {
 module @toplevel {
   func @main() {
     %0 = "arc.make_appender"() : () -> !arc.appender<i32>
-    // expected-error@+1 {{'arc.result' op result type does not match that of builder, found 'tensor<i64>' but expected 'tensor<i32>'}}
+    // expected-error@+2 {{'arc.result' op result type does not match that of builder, found 'tensor<i64>' but expected 'tensor<i32>'}}
+    // expected-note@+1 {{see current operation: %0 = "arc.result"}}
     %v = "arc.result"(%0) : (!arc.appender<i32>) -> tensor<i64>
     return
   }

--- a/arc-mlir/src/tests/rust/crate.mlir
+++ b/arc-mlir/src/tests/rust/crate.mlir
@@ -26,7 +26,8 @@
 
 "rust.crate"() ( {
 
-// expected-error@+1 {{'rust.func' op requires a type attribute 'type'}}
+// expected-error@+2 {{'rust.func' op requires a type attribute 'type'}}
+// expected-note@+1 {{see current operation: "rust.func"() (}}
 "rust.func"() ( {
  ^bb0(%arg0: !rust<"f32">):
  "rust.return"(%arg0) : (!rust<"f32">) -> (!rust<"f32">)
@@ -38,7 +39,8 @@
 // -----
 
 "rust.crate"() ( {
-// expected-error@+1 {{'rust.func' op expected 1 arguments to body region, found 2}}
+// expected-error@+2 {{'rust.func' op expected 1 arguments to body region, found 2}}
+// expected-note@+1 {{see current operation: "rust.func"() (}}
 "rust.func"() ( {
  ^bb0(%arg0: !rust<"f32">, %arg1: !rust<"f32">):
  "rust.return"(%arg0) : (!rust<"f32">) -> (!rust<"f32">)
@@ -50,7 +52,8 @@
 // -----
 
 "rust.crate"() ( {
-// expected-error@+1 {{'rust.func' op expected body region argument #0 to be of type '!rust.f64', found '!rust.f32'}}
+// expected-error@+2 {{'rust.func' op expected body region argument #0 to be of type '!rust.f64', found '!rust.f32'}}
+// expected-note@+1 {{see current operation: "rust.func"() (}}
 "rust.func"() ( {
  ^bb0(%arg0: !rust<"f32">):
  "rust.return"(%arg0) : (!rust<"f32">) -> (!rust<"f32">)
@@ -64,7 +67,8 @@
 "rust.crate"() ( {
 "rust.func"() ( {
  ^bb0(%arg0: !rust<"f32">):
-// expected-error@+1 {{'rust.return' op result type does not match the type of the function: expected '!rust.f64' but found '!rust.f32'}}
+// expected-error@+2 {{'rust.return' op result type does not match the type of the function: expected '!rust.f64' but found '!rust.f32'}}
+// expected-note@+1 {{see current operation: %0 = "rust.return"}}
  "rust.return"(%arg0) : (!rust<"f32">) -> (!rust<"f32">)
 }) {sym_name = "the-function-name-1", type = (!rust<"f32">) -> !rust<"f64"> } : () -> ()
 


### PR DESCRIPTION
Changes needed:

 * Adapt tests to changed wording in upstream error messages

 * Some errors now produce notes, so we need to account for them in
   the tests.