### PR TITLE
Update LLVM submodule

### DIFF
--- a/arc-mlir/src/tests/ops/if.mlir
+++ b/arc-mlir/src/tests/ops/if.mlir
@@ -41,7 +41,7 @@ module @toplevel {
 
     "arc.if"(%a) ( {
     // expected-error@+2 {{'arc.block.result' op requires the same type for all operands and results}}
-    // expected-note@+1 {{see current operation: %0 = "arc.block.result"}}
+    // expected-note@+1 {{see current operation}}
       "arc.block.result"(%b) : (f32) -> f64
     },  {
       "arc.block.result"(%c) : (f64) -> f64

--- a/arc-mlir/src/tests/ops/index_tuple.mlir
+++ b/arc-mlir/src/tests/ops/index_tuple.mlir
@@ -23,7 +23,7 @@ module @toplevel {
     %tuple = "arc.make_tuple"(%a, %b) : (i1, i1) -> tuple<i1,i1>
 
     // expected-error@+2 {{'arc.index_tuple' op element type at index 1 does not match result: expected 'f64' but found 'i1'}}
-    // expected-note@+1 {{see current operation: %0 = "arc.index_tuple"}}
+    // expected-note@+1 {{see current operation:}}
     %elem = "arc.index_tuple"(%tuple) { index = 1 } : (tuple<i1,i1>) -> f64
     return
   }
@@ -38,7 +38,7 @@ module @toplevel {
     %tuple = "arc.make_tuple"(%a, %b) : (i1, i1) -> tuple<i1,i1>
 
     // expected-error@+2 {{'arc.index_tuple' op attribute 'index' failed to satisfy constraint: 64-bit signless integer attribute whose value is non-negative}}
-    // expected-note@+1 {{see current operation: %0 = "arc.index_tuple"}}
+    // expected-note@+1 {{see current operation:}}
     %elem = "arc.index_tuple"(%tuple) { index = -5 } : (tuple<i1,i1>) -> i1
     return
   }
@@ -53,7 +53,7 @@ module @toplevel {
     %tuple = "arc.make_tuple"(%a, %b) : (i1, i1) -> tuple<i1,i1>
 
     // expected-error@+2 {{'arc.index_tuple' op requires attribute 'index'}}
-    // expected-note@+1 {{see current operation: %0 = "arc.index_tuple"}}
+    // expected-note@+1 {{see current operation:}}
     %elem = "arc.index_tuple"(%tuple) : (tuple<i1,i1>) -> i1
     return
   }
@@ -68,7 +68,7 @@ module @toplevel {
     %tuple = "arc.make_tuple"(%a, %b) : (i1, i1) -> tuple<i1,i1>
 
     // expected-error@+2 {{'arc.index_tuple' op index 5 is out-of-bounds for tuple with size 2}}
-    // expected-note@+1 {{see current operation: %0 = "arc.index_tuple"}}
+    // expected-note@+1 {{see current operation:}}
     %elem = "arc.index_tuple"(%tuple) { index = 5 } : (tuple<i1,i1>) -> i1
     return
   }

--- a/arc-mlir/src/tests/ops/merge.mlir
+++ b/arc-mlir/src/tests/ops/merge.mlir
@@ -20,7 +20,7 @@ module @toplevel {
     %0 = "arc.make_appender"() : () -> !arc.appender<i32>
 
     // expected-error@+2 {{'arc.merge' op operand type does not match merge type, found 'i64' but expected 'i32'}}
-    // expected-note@+1 {{see current operation: %0 = "arc.merge"}}
+    // expected-note@+1 {{see current operation:}}
     %1 = "arc.merge"(%0, %v) : (!arc.appender<i32>, i64) -> !arc.appender<i32>
 
     %r = "arc.result"(%1) : (!arc.appender<i32>) -> tensor<i32>
@@ -36,7 +36,7 @@ module @toplevel {
     %v = constant 5 : i32
 
     // expected-error@+2 {{'arc.merge' op result type does not match builder type, found: '!arc.appender<i64>' but expected '!arc.appender<i32>'}}
-    // expected-note@+1 {{see current operation: %0 = "arc.merge"}}
+    // expected-note@+1 {{see current operation:}}
     %1 = "arc.merge"(%0, %v) : (!arc.appender<i32>, i32) -> !arc.appender<i64>
 
     %c = "arc.result"(%1) : (!arc.appender<i64>) -> tensor<i64>

--- a/arc-mlir/src/tests/ops/result.mlir
+++ b/arc-mlir/src/tests/ops/result.mlir
@@ -16,7 +16,7 @@ module @toplevel {
   func @main() {
     %0 = "arc.make_appender"() : () -> !arc.appender<i32>
     // expected-error@+2 {{'arc.result' op result type does not match that of builder, found 'tensor<i64>' but expected 'tensor<i32>'}}
-    // expected-note@+1 {{see current operation: %0 = "arc.result"}}
+    // expected-note@+1 {{see current operation:}}
     %v = "arc.result"(%0) : (!arc.appender<i32>) -> tensor<i64>
     return
   }

--- a/arc-mlir/src/tools/arc-mlir/CMakeLists.txt
+++ b/arc-mlir/src/tools/arc-mlir/CMakeLists.txt
@@ -4,20 +4,15 @@ get_property(conversion_libs GLOBAL PROPERTY MLIR_CONVERSION_LIBS)
 set(LIBS
   ${dialect_libs}
   ${conversion_libs}
-  MLIRLoopOpsTransforms
   MLIRLoopAnalysis
+  MLIRAffineTransformsTestPasses
   MLIRAnalysis
   MLIRDialect
   MLIREDSC
   MLIROptLib
   MLIRParser
   MLIRPass
-  MLIRQuantizerFxpMathConfig
-  MLIRQuantizerSupport
-  MLIRQuantizerTransforms
-  MLIRSPIRV
   MLIRSPIRVTestPasses
-  MLIRSPIRVTransforms
   MLIRTransforms
   MLIRTransformUtils
   MLIRTestDialect

--- a/arc-mlir/src/tools/arc-mlir/Main.cpp
+++ b/arc-mlir/src/tools/arc-mlir/Main.cpp
@@ -33,6 +33,7 @@
 #include <llvm/Support/raw_ostream.h>
 #include <memory>
 #include <mlir/Analysis/Verifier.h>
+#include <mlir/IR/AsmState.h>
 #include <mlir/IR/MLIRContext.h>
 #include <mlir/IR/Module.h>
 #include <mlir/InitAllDialects.h>
@@ -80,7 +81,9 @@ int main(int argc, char **argv) {
   mlir::registerDialect<ArcDialect>();
   mlir::registerDialect<rust::RustDialect>();
 
-  // Register any pass manager command line options.
+  // Register any command line options.
+  registerAsmPrinterCLOptions();
+  registerMLIRContextCLOptions();
   registerPassManagerCLOptions();
   PassPipelineCLParser passPipeline("", "Compiler passes to run");
 


### PR DESCRIPTION
Changes needed:

 * Less brittle matches for notes in errors warnings. It seems like
   every update breaks these.

 * Changed libraries for arc-mlir to match upstream.

 * The asm printer now requires explicit registration in arc-mlir.