### PR TITLE
LLVM submodule update

### DIFF
--- a/arc-frontend/src/main/scala/se/kth/cda/arc/ast/printer/MLIRPrinter.scala
+++ b/arc-frontend/src/main/scala/se/kth/cda/arc/ast/printer/MLIRPrinter.scala
@@ -297,10 +297,8 @@ object MLIRPrinter {
 
         case (UnaryOpKind.Cos, F32) => "cos"
         case (UnaryOpKind.Cos, F64) => "cos"
-        case (UnaryOpKind.Sin, F32) =>
-          out.print(s"""${tmp} = "arc.sin"(${exprValue}) : (${ty.toMLIR}) -> ${ty.toMLIR}\n"""); ""
-        case (UnaryOpKind.Sin, F64) =>
-          out.print(s"""${tmp} = "arc.sin"(${exprValue}) : (${ty.toMLIR}) -> ${ty.toMLIR}\n"""); ""
+        case (UnaryOpKind.Sin, F32) => "sin"
+        case (UnaryOpKind.Sin, F64) => "sin"
         case (UnaryOpKind.Tan, F32) =>
           out.print(s"""${tmp} = "arc.tan"(${exprValue}) : (${ty.toMLIR}) -> ${ty.toMLIR}\n"""); ""
         case (UnaryOpKind.Tan, F64) =>

--- a/arc-mlir/src/include/Arc/Arc.td
+++ b/arc-mlir/src/include/Arc/Arc.td
@@ -136,16 +136,6 @@ def ArcKeepOp : Arc_Op<"keep", []> {
   let results = (outs);
 }
 
-def SinOp : Arc_FloatUnaryOp<"sin"> {
-  let summary = "sine of the specified value";
-  let description = [{
-    The `sin` operation computes the sine of a given value.
-    It takes one operand and returns one result of the same type. This type may
-    be a float scalar type, a vector whose element type is float, or a tensor of
-    floats. It has no standard attributes.
-  }];
-}
-
 def TanOp : Arc_FloatUnaryOp<"tan"> {
   let summary = "tangent of the specified value";
   let description = [{

--- a/arc-mlir/src/tests/arc-to-rust/arith.mlir.rust-tests
+++ b/arc-mlir/src/tests/arc-to-rust/arith.mlir.rust-tests
@@ -1,0 +1,7 @@
+#[cfg(test)]
+mod tests {
+  #[test]
+  fn it_works() {
+    assert_eq!(crate::sub_ui16(3,2), 1);
+  }
+}

--- a/arc-mlir/src/tests/conv/unary-ops.arc
+++ b/arc-mlir/src/tests/conv/unary-ops.arc
@@ -43,10 +43,10 @@ let cos_f64 : f64 = cos(c_f64);
 #CHECK: {{%[^ ]+}} = cos {{%[^ ]+}} : f64
 
 let sin_f32 : f32 = sin(c_f32);
-#CHECK: {{%[^ ]+}} = "arc.sin"({{%[^ ]+}}) : (f32) -> f32
+#CHECK: {{%[^ ]+}} = sin {{%[^ ]+}} : f32
 
 let sin_f64 : f64 = sin(c_f64);
-#CHECK: {{%[^ ]+}} = "arc.sin"({{%[^ ]+}}) : (f64) -> f64
+#CHECK: {{%[^ ]+}} = sin {{%[^ ]+}} : f64
 
 let tan_f32 : f32 = tan(c_f32);
 #CHECK: {{%[^ ]+}} = "arc.tan"({{%[^ ]+}}) : (f32) -> f32

--- a/arc-mlir/src/tools/arc-mlir/Main.cpp
+++ b/arc-mlir/src/tools/arc-mlir/Main.cpp
@@ -33,7 +33,6 @@
 #include <llvm/Support/ToolOutputFile.h>
 #include <llvm/Support/raw_ostream.h>
 #include <memory>
-#include <mlir/Analysis/Verifier.h>
 #include <mlir/IR/AsmState.h>
 #include <mlir/IR/MLIRContext.h>
 #include <mlir/IR/Module.h>


### PR DESCRIPTION
Changes needed:

* sin() is now available in the standard dialect, so we can remove our
  Arc dialect implementation.

* The header mlir/Analysis/Verifier.h is removed and no longer needed.