### PR TITLE
LLVM submodule update

### DIFF
--- a/arc-frontend/src/main/scala/se/kth/cda/arc/ast/printer/MLIRPrinter.scala
+++ b/arc-frontend/src/main/scala/se/kth/cda/arc/ast/printer/MLIRPrinter.scala
@@ -412,7 +412,7 @@ object MLIRPrinter {
         }
         case Literal.Bool(raw, value) => {
           val tmp = newTmp
-          out.print(s"${tmp} = constant ${if (value) 1 else 0} : ${self.ty.toMLIR}\n"); s"${tmp}"
+          out.print(s"""${tmp} = constant ${if (value) "true" else "false"}\n"""); s"""${tmp}"""
         }
         case Literal.UnitL(raw, value) => {
           val tmp = newTmp

--- a/arc-mlir/src/tests/conv/ifs.arc
+++ b/arc-mlir/src/tests/conv/ifs.arc
@@ -11,7 +11,7 @@ let true_bool : bool = true;
 
 #CHECK-DAG: [[A:%[^ ]+]] = arc.constant 65 : si32
 #CHECK-DAG: [[B:%[^ ]+]] = arc.constant 66 : si32
-#CHECK-DAG: [[COND:%[^ ]+]] = constant 1 : i1
+#CHECK-DAG: [[COND:%[^ ]+]] = constant true
 
 if(true_bool, a_i32, b_i32)
 

--- a/arc-mlir/src/tests/conv/literals.arc
+++ b/arc-mlir/src/tests/conv/literals.arc
@@ -44,16 +44,16 @@ let neg_f64 : f64 = -1.7976931348623157e308;
 #CHECK: {{%[^ ]+}} = constant -1.79769313486231{{[0-9]+[Ee]\+?}}308 : f64
 
 let true_bool : bool = true;
-#CHECK: {{%[^ ]+}} = constant 1 : i1
+#CHECK: {{%[^ ]+}} = constant true
 
 let false_bool : bool = false;
-#CHECK: {{%[^ ]+}} = constant 0 : i1
+#CHECK: {{%[^ ]+}} = constant false
 
 let bool_vector : vec[bool] = [true, false, true, false];
-#CHECK-DAG: [[E0:%[^ ]+]] = constant 1 : i1
-#CHECK-DAG: [[E1:%[^ ]+]] = constant 0 : i1
-#CHECK-DAG: [[E2:%[^ ]+]] = constant 1 : i1
-#CHECK-DAG: [[E3:%[^ ]+]] = constant 0 : i1
+#CHECK-DAG: [[E0:%[^ ]+]] = constant true
+#CHECK-DAG: [[E1:%[^ ]+]] = constant false
+#CHECK-DAG: [[E2:%[^ ]+]] = constant true
+#CHECK-DAG: [[E3:%[^ ]+]] = constant false
 #CHECK: {{%[^ ]+}} = "arc.make_vector"([[E0]], [[E1]], [[E2]], [[E3]]) : (i1, i1, i1, i1) -> tensor<4xi1>
 
 let f64_vector : vec[f64] = [0.694, 1.0, 1.4142, 3.14];

--- a/arc-mlir/src/tests/conv/nested-if.arc
+++ b/arc-mlir/src/tests/conv/nested-if.arc
@@ -14,8 +14,8 @@ let false_bool : bool = false;
 #CHECK-DAG: [[A:%[^ ]+]] = arc.constant 65 : si32
 #CHECK-DAG: [[B:%[^ ]+]] = arc.constant 66 : si32
 #CHECK-DAG: [[C:%[^ ]+]] = arc.constant 67 : si32
-#CHECK-DAG: [[CONDOUTER:%[^ ]+]] = constant 1 : i1
-#CHECK-DAG: [[CONDINNER:%[^ ]+]] = constant 0 : i1
+#CHECK-DAG: [[CONDOUTER:%[^ ]+]] = constant true
+#CHECK-DAG: [[CONDINNER:%[^ ]+]] = constant false
 
 if(true_bool, a_i32, if(false_bool, b_i32, c_i32))
 

--- a/arc-mlir/src/tests/ops/index_tuple.mlir
+++ b/arc-mlir/src/tests/ops/index_tuple.mlir
@@ -4,8 +4,8 @@
 
 module @toplevel {
   func @main() {
-    %a = constant 0 : i1
-    %b = constant 1 : i1
+    %a = constant false
+    %b = constant true
 
     %tuple = "arc.make_tuple"(%a, %b) : (i1, i1) -> tuple<i1,i1>
     %elem = "arc.index_tuple"(%tuple) { index = 0 } : (tuple<i1,i1>) -> i1
@@ -18,8 +18,8 @@ module @toplevel {
 
 module @toplevel {
   func @main() {
-    %a = constant 0 : i1
-    %b = constant 1 : i1
+    %a = constant false
+    %b = constant true
     %tuple = "arc.make_tuple"(%a, %b) : (i1, i1) -> tuple<i1,i1>
 
     // expected-error@+2 {{'arc.index_tuple' op element type at index 1 does not match result: expected 'f64' but found 'i1'}}
@@ -33,12 +33,11 @@ module @toplevel {
 
 module @toplevel {
   func @main() {
-    %a = constant 0 : i1
-    %b = constant 1 : i1
+    %a = constant false
+    %b = constant true
     %tuple = "arc.make_tuple"(%a, %b) : (i1, i1) -> tuple<i1,i1>
 
-    // expected-error@+2 {{'arc.index_tuple' op attribute 'index' failed to satisfy constraint: 64-bit signless integer attribute whose value is non-negative}}
-    // expected-note@+1 {{see current operation:}}
+    // expected-error@+1 {{'arc.index_tuple' op attribute 'index' failed to satisfy constraint: 64-bit signless integer attribute whose value is non-negative}}
     %elem = "arc.index_tuple"(%tuple) { index = -5 } : (tuple<i1,i1>) -> i1
     return
   }
@@ -48,12 +47,11 @@ module @toplevel {
 
 module @toplevel {
   func @main() {
-    %a = constant 0 : i1
-    %b = constant 1 : i1
+    %a = constant false
+    %b = constant true
     %tuple = "arc.make_tuple"(%a, %b) : (i1, i1) -> tuple<i1,i1>
 
-    // expected-error@+2 {{'arc.index_tuple' op requires attribute 'index'}}
-    // expected-note@+1 {{see current operation:}}
+    // expected-error@+1 {{'arc.index_tuple' op requires attribute 'index'}}
     %elem = "arc.index_tuple"(%tuple) : (tuple<i1,i1>) -> i1
     return
   }
@@ -63,8 +61,8 @@ module @toplevel {
 
 module @toplevel {
   func @main() {
-    %a = constant 0 : i1
-    %b = constant 1 : i1
+    %a = constant false
+    %b = constant true
     %tuple = "arc.make_tuple"(%a, %b) : (i1, i1) -> tuple<i1,i1>
 
     // expected-error@+2 {{'arc.index_tuple' op index 5 is out-of-bounds for tuple with size 2}}

--- a/arc-mlir/src/tests/opts/icmp-folding.mlir
+++ b/arc-mlir/src/tests/opts/icmp-folding.mlir
@@ -3,8 +3,8 @@ module @toplevel {
   func @main(%arg0 : ui64) {
     %true = constant 1 : i1
     %false = constant 0 : i1
-    // CHECK-DAG: [[TRUE:%[^ ]+]] = constant 1 : i1
-    // CHECK-DAG: [[FALSE:%[^ ]+]] = constant 0 : i1
+    // CHECK-DAG: [[TRUE:%[^ ]+]] = constant true
+    // CHECK-DAG: [[FALSE:%[^ ]+]] = constant false
     %smaller_si8 = arc.constant -64 : si8
     %larger_si8 = arc.constant 64 : si8
     %smaller_ui8 = arc.constant 28 : ui8

--- a/arc-mlir/src/tests/opts/tuples.mlir
+++ b/arc-mlir/src/tests/opts/tuples.mlir
@@ -9,7 +9,7 @@ module @toplevel {
     %elem = "arc.index_tuple"(%tuple) { index = 0 } : (tuple<i1,i1>) -> i1
 
     return %elem : i1
-    // CHECK-DAG: [[FALSE:%[^ ]+]] = constant 0 : i1
+    // CHECK-DAG: [[FALSE:%[^ ]+]] = constant false
     // CHECK: return [[FALSE]] : i1
   }
 }


### PR DESCRIPTION
Changes needed:

  * MLIR now pretty prints i1 as "constant true" / "constant false",
    so change the Scala MLIRPrinter to do the same.

  * Update tests to account for the changed printing of i1.

  * Adapt tests to changed logic for printing verification error
    notes (no note is printed when the error and note would refer to
    the same location).