### PR TITLE
rust: Turn Rust dialect tuples into their own type

### DIFF
--- a/arc-mlir/src/include/Rust/Rust.td
+++ b/arc-mlir/src/include/Rust/Rust.td
@@ -53,7 +53,7 @@ def Rust_Dialect : Dialect {
 class Rust_Op<string mnemonic, list<OpTrait> traits = []>
     : Op<Rust_Dialect, mnemonic, traits>;
 
-def AnyRustType : Type<CPred<"$_self.isa<RustType>() || $_self.isa<RustStructType>()">, "any RustType">;
+def AnyRustType : Type<CPred<"$_self.isa<RustType>() || $_self.isa<RustStructType>() || $_self.isa<RustTupleType>()">, "any RustType">;
 def AnyRustStruct :
     Type<CPred<"$_self.isa<RustStructType>()">, "any RustStruct">;
 def BoolRustType : Type<CPred<"$_self.isa<RustType>() && $_self.cast<RustType>().isBool()">, "a Rust boolean type">;

--- a/arc-mlir/src/include/Rust/Types.h
+++ b/arc-mlir/src/include/Rust/Types.h
@@ -40,7 +40,8 @@ namespace types {
 
 enum Kind {
   RUST_TYPE = Type::Kind::FIRST_PRIVATE_EXPERIMENTAL_1_TYPE,
-  RUST_STRUCT
+  RUST_STRUCT,
+  RUST_TUPLE
 };
 
 //===----------------------------------------------------------------------===//
@@ -49,6 +50,7 @@ enum Kind {
 
 struct RustTypeStorage;
 struct RustStructTypeStorage;
+struct RustTupleTypeStorage;
 
 //===----------------------------------------------------------------------===//
 // Rust Types
@@ -64,16 +66,12 @@ public:
   raw_ostream &printAsRust(raw_ostream &os) const;
   StringRef getRustType() const;
   bool isBool() const;
-  bool isByReference() const;
 
   static RustType getFloatTy(RustDialect *dialect);
   static RustType getDoubleTy(RustDialect *dialect);
   static RustType getIntegerTy(RustDialect *dialect, IntegerType ty);
-  static RustType getTupleTy(RustDialect *dialect, ArrayRef<Type> elements);
 
   typedef std::pair<mlir::StringAttr, Type> StructFieldTy;
-  // static RustType getStructTy(RustDialect *dialect,
-  //                             ArrayRef<StructFieldTy> fieldss);
 };
 
 class RustStructType
@@ -92,6 +90,21 @@ public:
   typedef std::pair<mlir::StringAttr, Type> StructFieldTy;
   static RustStructType get(RustDialect *dialect,
                             ArrayRef<StructFieldTy> fields);
+  void emitNestedTypedefs(rust::RustPrinterStream &ps) const;
+};
+
+class RustTupleType
+    : public Type::TypeBase<RustTupleType, Type, RustTupleTypeStorage> {
+public:
+  using Base::Base;
+
+  static bool kindof(unsigned kind) { return kind == RUST_TUPLE; }
+  void print(DialectAsmPrinter &os) const;
+  rust::RustPrinterStream &printAsRust(rust::RustPrinterStream &os) const;
+  std::string getRustType() const;
+
+  static RustTupleType get(RustDialect *dialect, ArrayRef<Type> fields);
+  void emitNestedTypedefs(rust::RustPrinterStream &ps) const;
 };
 
 } // namespace types

--- a/arc-mlir/src/lib/Arc/LowerToRust.cpp
+++ b/arc-mlir/src/lib/Arc/LowerToRust.cpp
@@ -501,6 +501,7 @@ RustTypeConverter::RustTypeConverter(MLIRContext *ctx)
   // RustType is legal, so add a pass-through conversion.
   addConversion([](rust::types::RustType type) { return type; });
   addConversion([](rust::types::RustStructType type) { return type; });
+  addConversion([](rust::types::RustTupleType type) { return type; });
 }
 
 Type RustTypeConverter::convertFloatType(FloatType type) {
@@ -552,7 +553,7 @@ Type RustTypeConverter::convertTupleType(TupleType type) {
   SmallVector<Type, 4> elements;
   for (Type t : type)
     elements.push_back(convertType(t));
-  return rust::types::RustType::getTupleTy(Dialect, elements);
+  return rust::types::RustTupleType::get(Dialect, elements);
 }
 
 FunctionType

--- a/arc-mlir/src/tests/arc-to-rust/nested-tuples-and-structs.mlir
+++ b/arc-mlir/src/tests/arc-to-rust/nested-tuples-and-structs.mlir
@@ -1,0 +1,17 @@
+// RUN: arc-mlir -arc-to-rust -crate %t %s && cargo test -j 1 --manifest-path=%t/toplevel/Cargo.toml
+// RUN: arc-mlir -canonicalize -arc-to-rust -crate %t %s && cargo test -j 1 --manifest-path=%t/toplevel/Cargo.toml
+
+module @toplevel {
+
+  func @nested0(%in : tuple<si32, tuple<si32, !arc.struct<a : tuple<si32, !arc.struct<b : si32>>>>>) -> si32 {
+    %r = arc.constant 4 : si32
+    return %r : si32
+  }
+
+  func @nested1(%in : !arc.struct<c : tuple<si32, tuple<!arc.struct<d : tuple<si32,si32>>>>>) -> si32 {
+    %r = arc.constant 4 : si32
+    return %r : si32
+  }
+
+}
+

--- a/arc-mlir/src/tests/arc-to-rust/tuples.mlir
+++ b/arc-mlir/src/tests/arc-to-rust/tuples.mlir
@@ -54,4 +54,15 @@ module @toplevel {
 
     return %outer : tuple<si32,si32,!arc.struct<a : si32>>
   }
+
+  func @single_element_tuple0() -> tuple<si32> {
+    %a = arc.constant 7 : si32
+    %r = "arc.make_tuple"(%a) : (si32) -> tuple<si32>
+    return %r : tuple<si32>
+  }
+
+  func @single_element_tuple1(%in : tuple<si32>) -> si32 {
+    %r = "arc.index_tuple"(%in) { index = 0 } : (tuple<si32>) -> si32
+    return %r : si32
+  }
 }


### PR DESCRIPTION
This is necessary in order to make nested structs and tuples work
properly.