### PR TITLE
Remove GitHub actions for setting up the runner

### DIFF
--- a/.github/workflows/arc-mlir.yml
+++ b/.github/workflows/arc-mlir.yml
@@ -12,17 +12,6 @@ jobs:
     - name: Checkout source
       uses: actions/checkout@v2
 
-    - name: Install JDK 1.8
-      uses: actions/setup-java@v1
-      with:
-        java-version: 1.8
-
-    - name: Install Scala
-      uses: olafurpg/setup-scala@v5
-
-    - name: Install ninja-build tool
-      uses: seanmiddleditch/gha-setup-ninja@v1
-
     - name: Update submodule
       run: git submodule update --init --recursive
 

--- a/.github/workflows/arc-script.yml
+++ b/.github/workflows/arc-script.yml
@@ -20,11 +20,6 @@ jobs:
     - name: checkout
       uses: actions/checkout@v2
     
-    - name: setup
-      uses: actions-rs/toolchain@v1
-      with:
-        toolchain: stable
-        
     - name: cargo-check
       run: cargo check --all-features
 

--- a/docs/src/continuous-integration.md
+++ b/docs/src/continuous-integration.md
@@ -8,9 +8,10 @@ docker run -i -t ubuntu:16.04 /bin/bash
 
 # Install apt dependencies
 
-apt update
-apt upgrade -y
-apt install -y git vim curl z3 libz3-dev curl libssl-dev gcc pkg-config make ninja-build python
+apt update && apt upgrade -y
+apt install -y git vim curl z3 libz3-dev curl libssl-dev gcc pkg-config make ninja-build python zip openjdk-8-jdk python-software-properties software-properties-common
+add-apt-repository ppa:git-core/ppa -y
+apt update && apt upgrade -y
 
 # Install Rust
 
@@ -40,6 +41,13 @@ export LD_LIBRARY_PATH=~/llvm/lib:$LD_LIBRARY_PATH
 echo 'export PATH=~/llvm/bin:$PATH' >> ~/.bashrc
 echo 'export LD_LIBRARY_PATH=~/llvm/lib:$LD_LIBRARY_PATH' >> ~/.bashrc
 
+# Install SBT / Scala / Java
+
+curl https://piccolo.link/sbt-1.3.13.zip -L --output sbt.zip
+unzip sbt.zip
+export PATH=~/sbt/bin:$PATH
+echo 'export PATH=~/sbt/bin:$PATH' >> ~/.bashrc
+
 # Install GitHub Actions Runner
 
 # Follow this tutorial (Which generates a unique token):
@@ -62,8 +70,7 @@ cd ~
 git clone https://github.com/cda-group/arc
 cd ~/arc
 git checkout mlir
-git submodule init
-git submodule update
+git submodule update --init --recursive
 
 # Check if arc-script builds
 


### PR DESCRIPTION
I think we can remove these since they now are installed out-of-the-box. It might improve performance 🤔 