### PR TITLE
Fix the Arc website

### DIFF
--- a/arc-script/wasm/Cargo.toml
+++ b/arc-script/wasm/Cargo.toml
@@ -21,3 +21,6 @@ wasm-bindgen-test = "0.2"
 
 [profile.release]
 opt-level = "s"
+
+[package.metadata.wasm-pack.profile.release]
+wasm-opt = false

--- a/arc-script/wasm/src/lib.rs
+++ b/arc-script/wasm/src/lib.rs
@@ -1,6 +1,5 @@
 mod utils;
 
-use arc_script::pretty::Pretty;
 use arc_script::opt::*;
 use wasm_bindgen::prelude::*;
 


### PR DESCRIPTION
The arc-script online REPL currently fails to compile with the error:

    Exported global cannot be mutable

It is a known error:

    https://github.com/rustwasm/wasm-pack/issues/886

This commit is a fix for the error + a small cleanup of unused code.