### PR TITLE
LLVM submodule update

### DIFF
--- a/arc-frontend/src/main/scala/se/kth/cda/arc/ast/printer/MLIRPrinter.scala
+++ b/arc-frontend/src/main/scala/se/kth/cda/arc/ast/printer/MLIRPrinter.scala
@@ -313,9 +313,9 @@ object MLIRPrinter {
         case (UnaryOpKind.ASin, F64) =>
           out.print(s"""${tmp} = "arc.asin"(${exprValue}) : (${ty.toMLIR}) -> ${ty.toMLIR}\n"""); ""
         case (UnaryOpKind.ATan, F32) =>
-          out.print(s"""${tmp} = "arc.atan"(${exprValue}) : (${ty.toMLIR}) -> ${ty.toMLIR}\n"""); ""
+          out.print(s"""${tmp} = atan ${exprValue} : ${ty.toMLIR}\n"""); ""
         case (UnaryOpKind.ATan, F64) =>
-          out.print(s"""${tmp} = "arc.atan"(${exprValue}) : (${ty.toMLIR}) -> ${ty.toMLIR}\n"""); ""
+          out.print(s"""${tmp} = atan ${exprValue} : ${ty.toMLIR}\n"""); ""
 
         case (UnaryOpKind.Cosh, F32) =>
           out.print(s"""${tmp} = "arc.cosh"(${exprValue}) : (${ty.toMLIR}) -> ${ty.toMLIR}\n"""); ""

--- a/arc-mlir/src/include/Arc/Arc.h
+++ b/arc-mlir/src/include/Arc/Arc.h
@@ -35,14 +35,11 @@ using namespace mlir;
 
 #include "Arc/ArcOpsEnums.h.inc"
 
-namespace arc {
+#include "Arc/ArcDialect.h.inc"
 
 /// Include the auto-generated header file containing the declarations of the
 /// arc operations.
 #define GET_OP_CLASSES
 #include "Arc/Arc.h.inc"
-#include "Arc/ArcDialect.h.inc"
-
-} // end namespace arc
 
 #endif // ARC_DIALECT_H_

--- a/arc-mlir/src/include/Arc/Arc.td
+++ b/arc-mlir/src/include/Arc/Arc.td
@@ -172,16 +172,6 @@ def AsinOp : Arc_FloatUnaryOp<"asin"> {
   }];
 }
 
-def AtanOp : Arc_FloatUnaryOp<"atan"> {
-  let summary = "arcus tangent of the specified value";
-  let description = [{
-    The `tan` operation computes the arcus tangent of a given value.
-    It takes one operand and returns one result of the same type. This type may
-    be a float scalar type, a vector whose element type is float, or a tensor of
-    floats. It has no standard attributes.
-  }];
-}
-
 def CoshOp : Arc_FloatUnaryOp<"cosh"> {
   let summary = "hyperbolic cosine of the specified value";
   let description = [{

--- a/arc-mlir/src/include/Rust/Rust.h
+++ b/arc-mlir/src/include/Rust/Rust.h
@@ -33,16 +33,11 @@
 
 using namespace mlir;
 
+#include "Rust/RustDialect.h.inc"
+
 namespace rust {
 
 class RustPrinterStream;
-
-#include "Rust/RustDialect.h.inc"
-
-/// Include the auto-generated header file containing the declarations of the
-/// rust operations.
-#define GET_OP_CLASSES
-#include "Rust/Rust.h.inc"
 
 LogicalResult writeModuleAsCrate(ModuleOp module, std::string top_dir,
                                  std::string rust_trailer,
@@ -56,5 +51,10 @@ struct CrateVersions {
 };
 
 } // namespace rust
+
+/// Include the auto-generated header file containing the declarations of the
+/// rust operations.
+#define GET_OP_CLASSES
+#include "Rust/Rust.h.inc"
 
 #endif // RUST_DIALECT_H_

--- a/arc-mlir/src/lib/Arc/CMakeLists.txt
+++ b/arc-mlir/src/lib/Arc/CMakeLists.txt
@@ -16,6 +16,6 @@ target_link_libraries(ArcDialect
   PUBLIC
   MLIREDSC
   MLIRIR
-  MLIRStandardOps
+  MLIRStandard
   LLVMSupport
   )

--- a/arc-mlir/src/lib/Arc/LowerToRust.cpp
+++ b/arc-mlir/src/lib/Arc/LowerToRust.cpp
@@ -287,10 +287,8 @@ struct IndexTupleOpLowering : public ConversionPattern {
                   ConversionPatternRewriter &rewriter) const final {
     IndexTupleOp o = cast<IndexTupleOp>(op);
     Type retTy = TypeConverter.convertType(o.getType());
-    APInt i = o.index();
-    std::string idx_str = i.toString(10, false);
-    rewriter.replaceOpWithNewOp<rust::RustFieldAccessOp>(op, retTy, operands[0],
-                                                         idx_str);
+    rewriter.replaceOpWithNewOp<rust::RustFieldAccessOp>(
+        op, retTy, operands[0], std::to_string(o.index()));
     return success();
   };
 
@@ -753,7 +751,7 @@ void ArcToRustLoweringPass::runOnOperation() {
       &getContext(), typeConverter);
   patterns.insert<ArcUnaryFloatOpLowering<arc::AcosOp, ArcUnaryFloatOp::acos>>(
       &getContext(), typeConverter);
-  patterns.insert<ArcUnaryFloatOpLowering<arc::AtanOp, ArcUnaryFloatOp::atan>>(
+  patterns.insert<ArcUnaryFloatOpLowering<mlir::AtanOp, ArcUnaryFloatOp::atan>>(
       &getContext(), typeConverter);
 
   patterns.insert<ArcUnaryFloatOpLowering<arc::SinhOp, ArcUnaryFloatOp::sinh>>(

--- a/arc-mlir/src/lib/Arc/Opts.cpp
+++ b/arc-mlir/src/lib/Arc/Opts.cpp
@@ -107,7 +107,7 @@ struct ConstantFoldIndexTuple
     arc::MakeTupleOp mt = def ? dyn_cast<arc::MakeTupleOp>(def) : nullptr;
     if (!mt)
       return failure();
-    rewriter.replaceOp(op, mt.values()[op.index().getZExtValue()]);
+    rewriter.replaceOp(op, mt.values()[op.index()]);
     return success();
   }
 };

--- a/arc-mlir/src/lib/Rust/CMakeLists.txt
+++ b/arc-mlir/src/lib/Rust/CMakeLists.txt
@@ -13,6 +13,6 @@ target_link_libraries(RustDialect
   PUBLIC
   MLIREDSC
   MLIRIR
-  MLIRStandardOps
+  MLIRStandard
   LLVMSupport
 )

--- a/arc-mlir/src/tests/arc-to-rust/unary-ops.mlir
+++ b/arc-mlir/src/tests/arc-to-rust/unary-ops.mlir
@@ -11,7 +11,7 @@ func @asin_f32(%a : f32) -> f32 {
 }
 
 func @atan_f32(%a : f32) -> f32 {
-  %r = arc.atan %a : f32
+  %r = atan %a : f32
   return %r : f32
 }
 
@@ -71,7 +71,7 @@ func @asin_f64(%a : f64) -> f64 {
 }
 
 func @atan_f64(%a : f64) -> f64 {
-  %r = arc.atan %a : f64
+  %r = atan %a : f64
   return %r : f64
 }
 

--- a/arc-mlir/src/tests/conv/unary-ops.arc
+++ b/arc-mlir/src/tests/conv/unary-ops.arc
@@ -67,10 +67,10 @@ let asin_f64 : f64 = asin(c_f64);
 #CHECK: {{%[^ ]+}} = "arc.asin"({{%[^ ]+}}) : (f64) -> f64
 
 let atan_f32 : f32 = atan(c_f32);
-#CHECK: {{%[^ ]+}} = "arc.atan"({{%[^ ]+}}) : (f32) -> f32
+#CHECK: {{%[^ ]+}} =  atan {{%[^ ]+}} : f32
 
 let atan_f64 : f64 = atan(c_f64);
-#CHECK: {{%[^ ]+}} = "arc.atan"({{%[^ ]+}}) : (f64) -> f64
+#CHECK: {{%[^ ]+}} = atan {{%[^ ]+}} : f64
 
 let cosh_f32 : f32 = cosh(c_f32);
 #CHECK: {{%[^ ]+}} = "arc.cosh"({{%[^ ]+}}) : (f32) -> f32

--- a/arc-mlir/src/tools/arc-mlir/Main.cpp
+++ b/arc-mlir/src/tools/arc-mlir/Main.cpp
@@ -76,6 +76,7 @@ static cl::opt<bool>
 int main(int argc, char **argv) {
   InitLLVM y(argc, argv);
 
+  mlir::enableGlobalDialectRegistry(true);
   mlir::registerAllDialects();
   mlir::registerAllPasses();
   mlir::registerDialect<ArcDialect>();


### PR DESCRIPTION
Changes needed:

  * atan is now in the standard dialect, use it instead of our own
    implementation in the arc dialect.

  * The tablegen-generated dialect headers now include the dialect
    namespace, so stop double wrapping the inclusion.

  * The library implementing the standard operations has been renamed
    from MLIRStandardOps to MLIRStandard.

  * Operation::index() noew returns a uint64_t instead of an APInt.

  * A call to mlir::enableGlobalDialectRegistry(true) is now needed to
    automatically register all dialects with the LLVMContext.