### PR TITLE
Resolve lsp-types dependency when building with CI

### DIFF
--- a/.github/workflows/arc-script.yml
+++ b/.github/workflows/arc-script.yml
@@ -20,6 +20,11 @@ jobs:
     - name: checkout
       uses: actions/checkout@v2
     
+    - name: cargo-fetch-update
+      run: |
+        cargo fetch
+        cargo update -p lsp-types:0.81.0 --precise 0.79.0
+
     - name: cargo-check
       run: cargo check --all-features
 


### PR DESCRIPTION
Currently arc-script builds fail because there is a version mismatch between two transitive dependencies.

* https://crates.io/crates/tower-lsp
* https://crates.io/crates/codespan-lsp

* `tower-lsp = 0.13.3` depends on `lsp-types >=0.79, <0.82`
* `codespan-lsp = 0.10.1` depends on `lsp-types >=0.70, <0.80`

This should hopefully force the two dependencies to be of the same version.