### PR TITLE
LLVM submodule update

### DIFF
--- a/arc-mlir/src/tools/arc-mlir/ArcOptMain.cpp
+++ b/arc-mlir/src/tools/arc-mlir/ArcOptMain.cpp
@@ -63,8 +63,13 @@ static LogicalResult performActions(raw_ostream &os, bool verifyDiagnostics,
   pm.enableVerifier(verifyPasses);
   applyPassManagerCLOptions(pm);
 
+  auto errorHandler = [&](const Twine &msg) {
+    emitError(UnknownLoc::get(context)) << msg;
+    return failure();
+  };
+
   // Build the provided pipeline.
-  if (failed(passPipeline.addToPipeline(pm)))
+  if (failed(passPipeline.addToPipeline(pm, errorHandler)))
     return failure();
 
   // Run the pipeline.


### PR DESCRIPTION
Changes needed:

  * PassPipelineCLParser::addToPipeline() now requires an error
    handler.