### PR TITLE
Run cargo with CARGO_HTTP_DEBUG=true

### DIFF
--- a/arc-mlir/src/CMakeLists.txt
+++ b/arc-mlir/src/CMakeLists.txt
@@ -17,6 +17,7 @@ configure_file(
     @ONLY
     )
 
+set(ENV{CARGO_HTTP_DEBUG} "true")
 add_subdirectory(include)
 add_subdirectory(lib)
 add_subdirectory(tests)

--- a/arc-mlir/src/tests/arc-to-rust/arc-cmpf.mlir
+++ b/arc-mlir/src/tests/arc-to-rust/arc-cmpf.mlir
@@ -1,4 +1,4 @@
-// RUN: arc-mlir -arc-to-rust -crate %t -extra-rust-trailer %s.rust-tests %s && cargo test -j 1 --manifest-path=%t/toplevel/Cargo.toml
+// RUN: arc-mlir -arc-to-rust -crate %t -extra-rust-trailer %s.rust-tests %s && CARGO_HTTP_DEBUG=true cargo test -j 1 --manifest-path=%t/toplevel/Cargo.toml
 module @toplevel {
 func @oeq_f32(%a : f32, %b : f32) -> i1 {
   %r = cmpf "oeq", %a, %b : f32

--- a/arc-mlir/src/tests/arc-to-rust/arc-cmpi.mlir
+++ b/arc-mlir/src/tests/arc-to-rust/arc-cmpi.mlir
@@ -1,4 +1,4 @@
-// RUN: arc-mlir -arc-to-rust -crate %t -extra-rust-trailer %s.rust-tests %s && cargo test -j 1 --manifest-path=%t/toplevel/Cargo.toml
+// RUN: arc-mlir -arc-to-rust -crate %t -extra-rust-trailer %s.rust-tests %s && CARGO_HTTP_DEBUG=true cargo test -j 1 --manifest-path=%t/toplevel/Cargo.toml
 module @toplevel {
 func @eq_ui8(%a : ui8, %b : ui8) -> i1 {
   %r = arc.cmpi "eq", %a, %b : ui8

--- a/arc-mlir/src/tests/arc-to-rust/calls.mlir
+++ b/arc-mlir/src/tests/arc-to-rust/calls.mlir
@@ -1,5 +1,5 @@
-// RUN: arc-mlir -arc-to-rust -crate %t %s && cargo test -j 1 --manifest-path=%t/toplevel/Cargo.toml
-// RUN: arc-mlir -canonicalize -arc-to-rust -crate %t %s && cargo test -j 1 --manifest-path=%t/toplevel/Cargo.toml
+// RUN: arc-mlir -arc-to-rust -crate %t %s && CARGO_HTTP_DEBUG=true cargo test -j 1 --manifest-path=%t/toplevel/Cargo.toml
+// RUN: arc-mlir -canonicalize -arc-to-rust -crate %t %s && CARGO_HTTP_DEBUG=true cargo test -j 1 --manifest-path=%t/toplevel/Cargo.toml
 
 module @toplevel {
 

--- a/arc-mlir/src/tests/arc-to-rust/float-tensor-arith.mlir
+++ b/arc-mlir/src/tests/arc-to-rust/float-tensor-arith.mlir
@@ -1,4 +1,4 @@
-// RUN: arc-mlir -arc-to-rust -crate %t -extra-rust-trailer %s.rust-tests %s && cargo test -j 1 --manifest-path=%t/toplevel/Cargo.toml
+// RUN: arc-mlir -arc-to-rust -crate %t -extra-rust-trailer %s.rust-tests %s && CARGO_HTTP_DEBUG=true cargo test -j 1 --manifest-path=%t/toplevel/Cargo.toml
 module @toplevel {
 func @addf_tensor2x2xf32(%a : tensor<2x2xf32>, %b : tensor<2x2xf32>) -> tensor<2x2xf32> {
   %c = std.addf %a, %b : tensor<2x2xf32>

--- a/arc-mlir/src/tests/arc-to-rust/foreign-calls.mlir
+++ b/arc-mlir/src/tests/arc-to-rust/foreign-calls.mlir
@@ -1,5 +1,5 @@
-// RUN: arc-mlir -arc-to-rust -crate %t %s && cp -rpf %S/external_crate %t && cargo test -j 1 --manifest-path=%t/toplevel/Cargo.toml
-// RUN: arc-mlir -canonicalize -arc-to-rust -crate %t %s &&  cp -rpf %S/external_crate %t && cargo test -j 1 --manifest-path=%t/toplevel/Cargo.toml
+// RUN: arc-mlir -arc-to-rust -crate %t %s && cp -rpf %S/external_crate %t && CARGO_HTTP_DEBUG=true cargo test -j 1 --manifest-path=%t/toplevel/Cargo.toml
+// RUN: arc-mlir -canonicalize -arc-to-rust -crate %t %s &&  cp -rpf %S/external_crate %t && CARGO_HTTP_DEBUG=true cargo test -j 1 --manifest-path=%t/toplevel/Cargo.toml
 
 module @toplevel attributes {
 

--- a/arc-mlir/src/tests/arc-to-rust/func-arguments.mlir
+++ b/arc-mlir/src/tests/arc-to-rust/func-arguments.mlir
@@ -1,4 +1,4 @@
-// RUN: arc-mlir -arc-to-rust -crate %t -extra-rust-trailer %s.rust-tests %s && cargo test -j 1 --manifest-path=%t/toplevel/Cargo.toml
+// RUN: arc-mlir -arc-to-rust -crate %t -extra-rust-trailer %s.rust-tests %s && CARGO_HTTP_DEBUG=true cargo test -j 1 --manifest-path=%t/toplevel/Cargo.toml
 
 module @toplevel {
   func @zero_args() -> ui16 {

--- a/arc-mlir/src/tests/arc-to-rust/ifs.mlir
+++ b/arc-mlir/src/tests/arc-to-rust/ifs.mlir
@@ -1,4 +1,4 @@
-// RUN: arc-mlir -arc-to-rust -crate %t -extra-rust-trailer %s.rust-tests %s && cargo test -j 1 --manifest-path=%t/toplevel/Cargo.toml
+// RUN: arc-mlir -arc-to-rust -crate %t -extra-rust-trailer %s.rust-tests %s && CARGO_HTTP_DEBUG=true cargo test -j 1 --manifest-path=%t/toplevel/Cargo.toml
 
 module @toplevel {
   func @test_0() -> si32 {

--- a/arc-mlir/src/tests/arc-to-rust/int-arith.mlir
+++ b/arc-mlir/src/tests/arc-to-rust/int-arith.mlir
@@ -1,4 +1,4 @@
-// RUN: arc-mlir -arc-to-rust -crate %t -extra-rust-trailer %s.rust-tests %s && cargo test -j 1 --manifest-path=%t/toplevel/Cargo.toml
+// RUN: arc-mlir -arc-to-rust -crate %t -extra-rust-trailer %s.rust-tests %s && CARGO_HTTP_DEBUG=true cargo test -j 1 --manifest-path=%t/toplevel/Cargo.toml
 module @toplevel {
 func @addi_ui8(%a : ui8, %b : ui8) -> ui8 {
   %c = arc.addi %a, %b : ui8

--- a/arc-mlir/src/tests/arc-to-rust/int-bitops.mlir
+++ b/arc-mlir/src/tests/arc-to-rust/int-bitops.mlir
@@ -1,4 +1,4 @@
-// RUN: arc-mlir -arc-to-rust -crate %t -extra-rust-trailer %s.rust-tests %s && cargo test -j 1 --manifest-path=%t/toplevel/Cargo.toml
+// RUN: arc-mlir -arc-to-rust -crate %t -extra-rust-trailer %s.rust-tests %s && CARGO_HTTP_DEBUG=true cargo test -j 1 --manifest-path=%t/toplevel/Cargo.toml
 
 module @toplevel {
   func @and_ui8(%arg0: ui8, %arg1: ui8) -> ui8 {

--- a/arc-mlir/src/tests/arc-to-rust/int-tensor-arith.mlir
+++ b/arc-mlir/src/tests/arc-to-rust/int-tensor-arith.mlir
@@ -1,4 +1,4 @@
-// RUN: arc-mlir -arc-to-rust -crate %t -extra-rust-trailer %s.rust-tests %s && cargo test -j 1 --manifest-path=%t/toplevel/Cargo.toml
+// RUN: arc-mlir -arc-to-rust -crate %t -extra-rust-trailer %s.rust-tests %s && CARGO_HTTP_DEBUG=true cargo test -j 1 --manifest-path=%t/toplevel/Cargo.toml
 module @toplevel {
 func @addi_tensor2x2xui8(%a : tensor<2x2xui8>, %b : tensor<2x2xui8>) -> tensor<2x2xui8> {
   %c = arc.addi %a, %b : tensor<2x2xui8>

--- a/arc-mlir/src/tests/arc-to-rust/nested-tuples-and-structs.mlir
+++ b/arc-mlir/src/tests/arc-to-rust/nested-tuples-and-structs.mlir
@@ -1,5 +1,5 @@
-// RUN: arc-mlir -arc-to-rust -crate %t %s && cargo test -j 1 --manifest-path=%t/toplevel/Cargo.toml
-// RUN: arc-mlir -canonicalize -arc-to-rust -crate %t %s && cargo test -j 1 --manifest-path=%t/toplevel/Cargo.toml
+// RUN: arc-mlir -arc-to-rust -crate %t %s && CARGO_HTTP_DEBUG=true cargo test -j 1 --manifest-path=%t/toplevel/Cargo.toml
+// RUN: arc-mlir -canonicalize -arc-to-rust -crate %t %s && CARGO_HTTP_DEBUG=true cargo test -j 1 --manifest-path=%t/toplevel/Cargo.toml
 
 module @toplevel {
 

--- a/arc-mlir/src/tests/arc-to-rust/simple.mlir
+++ b/arc-mlir/src/tests/arc-to-rust/simple.mlir
@@ -1,5 +1,5 @@
-// RUN: arc-mlir -arc-to-rust -crate %t -extra-rust-trailer %s.rust-tests %s && cargo test -j 1 --manifest-path=%t/toplevel/Cargo.toml
-// RUN: arc-mlir -canonicalize -arc-to-rust -crate %t -extra-rust-trailer %s.rust-tests %s && cargo test -j 1 --manifest-path=%t/toplevel/Cargo.toml
+// RUN: arc-mlir -arc-to-rust -crate %t -extra-rust-trailer %s.rust-tests %s && CARGO_HTTP_DEBUG=true cargo test -j 1 --manifest-path=%t/toplevel/Cargo.toml
+// RUN: arc-mlir -canonicalize -arc-to-rust -crate %t -extra-rust-trailer %s.rust-tests %s && CARGO_HTTP_DEBUG=true cargo test -j 1 --manifest-path=%t/toplevel/Cargo.toml
 
 module @toplevel {
   func @returnf64() -> f64 {

--- a/arc-mlir/src/tests/arc-to-rust/structs.mlir
+++ b/arc-mlir/src/tests/arc-to-rust/structs.mlir
@@ -1,5 +1,5 @@
-// RUN: arc-mlir -arc-to-rust -crate %t -extra-rust-trailer %s.rust-tests %s && cargo test -j 1 --manifest-path=%t/toplevel/Cargo.toml
-// RUN: arc-mlir -canonicalize -arc-to-rust -crate %t -extra-rust-trailer %s.rust-tests %s && cargo test -j 1 --manifest-path=%t/toplevel/Cargo.toml
+// RUN: arc-mlir -arc-to-rust -crate %t -extra-rust-trailer %s.rust-tests %s && CARGO_HTTP_DEBUG=true cargo test -j 1 --manifest-path=%t/toplevel/Cargo.toml
+// RUN: arc-mlir -canonicalize -arc-to-rust -crate %t -extra-rust-trailer %s.rust-tests %s && CARGO_HTTP_DEBUG=true cargo test -j 1 --manifest-path=%t/toplevel/Cargo.toml
 
 module @toplevel {
 

--- a/arc-mlir/src/tests/arc-to-rust/tensors.mlir
+++ b/arc-mlir/src/tests/arc-to-rust/tensors.mlir
@@ -1,5 +1,5 @@
-// RUN: arc-mlir -arc-to-rust -crate %t -extra-rust-trailer %s.rust-tests %s && cargo test -j 1 --manifest-path=%t/toplevel/Cargo.toml
-// RUN: arc-mlir -canonicalize -arc-to-rust -crate %t -extra-rust-trailer %s.rust-tests %s && cargo test -j 1 --manifest-path=%t/toplevel/Cargo.toml
+// RUN: arc-mlir -arc-to-rust -crate %t -extra-rust-trailer %s.rust-tests %s && CARGO_HTTP_DEBUG=true cargo test -j 1 --manifest-path=%t/toplevel/Cargo.toml
+// RUN: arc-mlir -canonicalize -arc-to-rust -crate %t -extra-rust-trailer %s.rust-tests %s && CARGO_HTTP_DEBUG=true cargo test -j 1 --manifest-path=%t/toplevel/Cargo.toml
 
 module @toplevel {
   func @in_out_0(%0 : tensor<4xsi32>) -> tensor<4xsi32> {

--- a/arc-mlir/src/tests/arc-to-rust/tuples.mlir
+++ b/arc-mlir/src/tests/arc-to-rust/tuples.mlir
@@ -1,5 +1,5 @@
-// RUN: arc-mlir -arc-to-rust -crate %t -extra-rust-trailer %s.rust-tests %s && cargo test -j 1 --manifest-path=%t/toplevel/Cargo.toml
-// RUN: arc-mlir -canonicalize -arc-to-rust -crate %t -extra-rust-trailer %s.rust-tests %s && cargo test -j 1 --manifest-path=%t/toplevel/Cargo.toml
+// RUN: arc-mlir -arc-to-rust -crate %t -extra-rust-trailer %s.rust-tests %s && CARGO_HTTP_DEBUG=true cargo test -j 1 --manifest-path=%t/toplevel/Cargo.toml
+// RUN: arc-mlir -canonicalize -arc-to-rust -crate %t -extra-rust-trailer %s.rust-tests %s && CARGO_HTTP_DEBUG=true cargo test -j 1 --manifest-path=%t/toplevel/Cargo.toml
 
 module @toplevel {
 

--- a/arc-mlir/src/tests/arc-to-rust/unary-ops.mlir
+++ b/arc-mlir/src/tests/arc-to-rust/unary-ops.mlir
@@ -1,4 +1,4 @@
-// RUN: arc-mlir -arc-to-rust -crate %t -extra-rust-trailer %s.rust-tests %s && cargo test -j 1 --manifest-path=%t/toplevel/Cargo.toml
+// RUN: arc-mlir -arc-to-rust -crate %t -extra-rust-trailer %s.rust-tests %s && CARGO_HTTP_DEBUG=true cargo test -j 1 --manifest-path=%t/toplevel/Cargo.toml
 module @toplevel {
 func @acos_f32(%a : f32) -> f32 {
   %r = arc.acos %a : f32


### PR DESCRIPTION
Without this environment variable set, the intitial configuration
fails with:

error: failed to get `platforms` as a dependency of package `corrosion-generator v0.1.0 (...)`

Caused by:
  failed to load source for dependency `platforms`

Caused by:
  Unable to update https://github.com/RustSec/platforms-crate.git?branch=master#dab5f2e6

Caused by:
  failed to fetch into: /local_home/frej/.cargo/git/db/platforms-crate-d65c8a3ec7bbf370

Caused by:
  network failure seems to have happened
  if a proxy or similar is necessary `net.git-fetch-with-cli` may help here
  https://doc.rust-lang.org/cargo/reference/config.html#netgit-fetch-with-cli

Caused by:
  http parser did not consume entire buffer: success; class=Http (34)