### PR TITLE
arc-script: Output correct MLIR function arguments

### DIFF
--- a/arc-script/core/src/codegen/mlir/mod.rs
+++ b/arc-script/core/src/codegen/mlir/mod.rs
@@ -306,7 +306,11 @@ impl FunDef {
                 params = self
                     .params
                     .iter()
-                    .map(|id| pr.info.table.get_decl(id).tv.to_ty(pr))
+                    .map(|id| format!(
+                        "{} : {}",
+                        id.to_var(),
+                        pr.info.table.get_decl(id).tv.to_ty(pr)
+                    ))
                     .collect::<Vec<_>>()
                     .join(","),
                 ret_ty = ret_tv.to_ty(&pr),


### PR DESCRIPTION
Function arguments require both an indentifier and a type.