### PR TITLE
mlir: Change signature for arc.block.result

### DIFF
--- a/arc-frontend/src/main/scala/se/kth/cda/arc/ast/printer/MLIRPrinter.scala
+++ b/arc-frontend/src/main/scala/se/kth/cda/arc/ast/printer/MLIRPrinter.scala
@@ -361,9 +361,9 @@ object MLIRPrinter {
 
       out.print(s"""${result} = "arc.if"(${condValue}) ({\n""")
       val onTrueResult = onTrue.toMLIR(identifiers)
-      out.print(s""" ${newTmp} = "arc.block.result"(${onTrueResult}) : (${ty.toMLIR}) -> ${ty.toMLIR}\n}, {\n""")
+      out.print(s""" "arc.block.result"(${onTrueResult}) : (${ty.toMLIR}) -> ()\n}, {\n""")
       val onFalseResult = onFalse.toMLIR(identifiers)
-      out.print(s"""  ${newTmp} = "arc.block.result"(${onFalseResult}) : (${ty.toMLIR}) -> ${ty.toMLIR}\n""")
+      out.print(s"""  "arc.block.result"(${onFalseResult}) : (${ty.toMLIR}) -> ()\n""")
       out.print(s"""}) : (${Bool.toMLIR}) -> ${ty.toMLIR}\n""")
       s"${result}"
     }

--- a/arc-mlir/src/include/Arc/Arc.td
+++ b/arc-mlir/src/include/Arc/Arc.td
@@ -259,7 +259,7 @@ def IndexTupleOp : Arc_Op<"index_tuple", [NoSideEffect]> {
 
 def ArcBlockResultOp :
     Arc_Op<"block.result", [HasParent<"IfOp">,
-                            Terminator, SameOperandsAndResultType]> {
+                            Terminator]> {
   let summary = "specifies the value of a block";
   let description = [{
     "arc.block.result" is a special terminator operation for the block inside
@@ -267,11 +267,10 @@ def ArcBlockResultOp :
     parent if.
 
     ```mlir
-      "arc.block.result"(%b) : (f32) -> f64
+      "arc.block.result"(%b) : (f32) -> ()
     ```
   }];
   let arguments = (ins AnyType:$result);
-  let results = (outs AnyType);
 }
 
 def IfOp : Arc_Op<"if", [SingleBlockImplicitTerminator<"ArcBlockResultOp">]> {

--- a/arc-mlir/src/include/Rust/Rust.td
+++ b/arc-mlir/src/include/Rust/Rust.td
@@ -333,7 +333,7 @@ def Rust_RustCompOp : Rust_Op<"compop", [SameTypeOperands]> {
 
 def Rust_RustBlockResultOp
     : Rust_Op<"block.result",
-              [HasParent<"RustIfOp">, Terminator, SameOperandsAndResultType]> {
+              [HasParent<"RustIfOp">, Terminator]> {
   let summary = "specifies the value of a block";
   let description = [{
     "rust.block.result" is a special terminator operation for the block inside
@@ -341,11 +341,10 @@ def Rust_RustBlockResultOp
     parent if.
 
     ```mlir
-      "rust.block.result"(%b) : (!rust<"f64">) -> !rust<"f64">
+      "rust.block.result"(%b) : (!rust<"f64">) -> ()
     ```
   }];
   let arguments = (ins AnyRustType : $result);
-  let results = (outs AnyRustType);
   let extraClassDeclaration = [{
     // Write this operation as Rust code to the stream
     void writeRust(RustPrinterStream &);

--- a/arc-mlir/src/lib/Arc/Dialect.cpp
+++ b/arc-mlir/src/lib/Arc/Dialect.cpp
@@ -309,14 +309,11 @@ LogicalResult IfOp::customVerify() {
   auto ResultTy = Op->getResult(0).getType();
   bool FoundErrors = false;
   auto CheckResultType = [this, ResultTy, &FoundErrors](ArcBlockResultOp R) {
-    if (R.getOperation()->getNumResults() !=
-        R.getOperation()->getNumOperands()) {
-      // This is an error, but the verifier for ArcBlockResultOp will flag it
-    } else if (R.getResult().getType() != ResultTy) {
+    if (R.getOperand().getType() != ResultTy) {
       FoundErrors = true;
       emitOpError(
           "result type does not match the type of the parent: expected ")
-          << ResultTy << " but found " << R.getResult().getType();
+          << ResultTy << " but found " << R.getOperand().getType();
     }
   };
 

--- a/arc-mlir/src/lib/Arc/LowerToRust.cpp
+++ b/arc-mlir/src/lib/Arc/LowerToRust.cpp
@@ -234,22 +234,15 @@ private:
 };
 
 struct BlockResultOpLowering : public ConversionPattern {
-  BlockResultOpLowering(MLIRContext *ctx, RustTypeConverter &typeConverter)
-      : ConversionPattern(arc::ArcBlockResultOp::getOperationName(), 1, ctx),
-        TypeConverter(typeConverter) {}
+  BlockResultOpLowering(MLIRContext *ctx)
+      : ConversionPattern(arc::ArcBlockResultOp::getOperationName(), 1, ctx) {}
 
   LogicalResult
   matchAndRewrite(Operation *op, ArrayRef<Value> operands,
                   ConversionPatternRewriter &rewriter) const final {
-    ArcBlockResultOp o = cast<ArcBlockResultOp>(op);
-    Type retTy = TypeConverter.convertType(o.getType());
-    rewriter.replaceOpWithNewOp<rust::RustBlockResultOp>(op, retTy,
-                                                         operands[0]);
+    rewriter.replaceOpWithNewOp<rust::RustBlockResultOp>(op, operands[0]);
     return success();
   };
-
-private:
-  RustTypeConverter &TypeConverter;
 };
 
 struct IfOpLowering : public ConversionPattern {
@@ -829,7 +822,7 @@ void ArcToRustLoweringPass::runOnOperation() {
 
   patterns.insert<IfOpLowering>(&getContext(), typeConverter);
   patterns.insert<IndexTupleOpLowering>(&getContext(), typeConverter);
-  patterns.insert<BlockResultOpLowering>(&getContext(), typeConverter);
+  patterns.insert<BlockResultOpLowering>(&getContext());
   patterns.insert<MakeTupleOpLowering>(&getContext(), typeConverter);
   patterns.insert<MakeTensorOpLowering>(&getContext(), typeConverter);
   patterns.insert<MakeStructOpLowering>(&getContext(), typeConverter);

--- a/arc-mlir/src/tests/arc-to-rust/ifs.mlir
+++ b/arc-mlir/src/tests/arc-to-rust/ifs.mlir
@@ -6,17 +6,17 @@ module @toplevel {
     %1 = arc.constant 66 : si32
     %2 = constant 1 : i1
     %3 = "arc.if"(%2) ({
-      %4 = "arc.block.result"(%0) : (si32) -> si32
+      "arc.block.result"(%0) : (si32) -> ()
     }, {
-      %5 = "arc.block.result"(%1) : (si32) -> si32
+      "arc.block.result"(%1) : (si32) -> ()
     }) : (i1) -> si32
     return %3 : si32
   }
   func @test_1(%c: i1, %arg0: ui32, %arg1: ui32) -> ui32 {
     %3 = "arc.if"(%c) ({
-      %4 = "arc.block.result"(%arg0) : (ui32) -> ui32
+      "arc.block.result"(%arg0) : (ui32) -> ()
     }, {
-      %5 = "arc.block.result"(%arg1) : (ui32) -> ui32
+      "arc.block.result"(%arg1) : (ui32) -> ()
     }) : (i1) -> ui32
     return %3 : ui32
   }

--- a/arc-mlir/src/tests/conv/ifs.arc
+++ b/arc-mlir/src/tests/conv/ifs.arc
@@ -16,5 +16,5 @@ let true_bool : bool = true;
 if(true_bool, a_i32, b_i32)
 
 #CHECK: {{%[^ ]+}} = "arc.if"([[COND]]) (
-#CHECK: {{%[^ ]+}} = "arc.block.result"([[A]])
-#CHECK: {{%[^ ]+}} = "arc.block.result"([[B]])
+#CHECK: "arc.block.result"([[A]])
+#CHECK: "arc.block.result"([[B]])

--- a/arc-mlir/src/tests/conv/nested-if.arc
+++ b/arc-mlir/src/tests/conv/nested-if.arc
@@ -20,8 +20,8 @@ let false_bool : bool = false;
 if(true_bool, a_i32, if(false_bool, b_i32, c_i32))
 
 #CHECK: {{%[^ ]+}} = "arc.if"([[CONDOUTER]]) (
-#CHECK: {{%[^ ]+}} = "arc.block.result"([[A]])
+#CHECK: "arc.block.result"([[A]])
 #CHECK: [[INNERRESULT:%[^ ]+]] = "arc.if"([[CONDINNER]]) (
-#CHECK: {{%[^ ]+}} = "arc.block.result"([[B]])
-#CHECK: {{%[^ ]+}} = "arc.block.result"([[C]])
-#CHECK: {{%[^ ]+}} = "arc.block.result"([[INNERRESULT]])
+#CHECK: "arc.block.result"([[B]])
+#CHECK: "arc.block.result"([[C]])
+#CHECK: "arc.block.result"([[INNERRESULT]])

--- a/arc-mlir/src/tests/ops/if.mlir
+++ b/arc-mlir/src/tests/ops/if.mlir
@@ -9,9 +9,9 @@ module @toplevel {
     %c = constant 0.693 : f64
 
     "arc.if"(%a) ( {
-      "arc.block.result"(%b) : (f64) -> f64
+      "arc.block.result"(%b) : (f64) -> ()
     },  {
-      "arc.block.result"(%c) : (f64) -> f64
+      "arc.block.result"(%c) : (f64) -> ()
     }) : (i1) -> f64
     return
   }
@@ -25,8 +25,8 @@ module @toplevel {
     %f = constant 3.14 : f64
 
     // expected-error@+2 {{'arc.block.result' op expects parent op 'arc.if'}}
-    // expected-note@+1 {{see current operation: %0 = "arc.block.result"}}
-    "arc.block.result"(%f) : (f64) -> f64
+    // expected-note@+1 {{see current operation: "arc.block.result"}}
+    "arc.block.result"(%f) : (f64) -> ()
     return
   }
 }
@@ -39,12 +39,12 @@ module @toplevel {
     %b = constant 3.14 : f32
     %c = constant 0.693 : f64
 
+    // expected-error@+2 {{'arc.if' op result type does not match the type of the parent: expected 'f64' but found 'f32'}}
+    // expected-note@+1 {{see current operation: %0 = "arc.if"(%false)}}
     "arc.if"(%a) ( {
-    // expected-error@+2 {{'arc.block.result' op requires the same type for all operands and results}}
-    // expected-note@+1 {{see current operation}}
-      "arc.block.result"(%b) : (f32) -> f64
+    "arc.block.result"(%b) : (f32) -> ()
     },  {
-      "arc.block.result"(%c) : (f64) -> f64
+      "arc.block.result"(%c) : (f64) -> ()
     }) : (i1) -> f64
     return
   }
@@ -115,7 +115,7 @@ module @toplevel {
     // expected-error@+2 {{'arc.if' op region #1 ('elseRegion') failed to verify constraint: region with 1 blocks}}
     // expected-note@+1 {{see current operation: %0 = "arc.if"}}
     "arc.if"(%a) ({
-      "arc.block.result"(%b) : (f64) -> f64
+      "arc.block.result"(%b) : (f64) -> ()
     },{}) : (i1) -> f64
     return
   }
@@ -133,10 +133,10 @@ module @toplevel {
     // expected-note@+2 {{in custom textual format, the absence of terminator implies 'arc.block.result'}}
     // expected-note@+1 {{see current operation: %0 = "arc.if"}}
     "arc.if"(%a) ( {
-      "arc.block.result"(%b) : (f64) -> f64
+      "arc.block.result"(%b) : (f64) -> ()
       %1 = "arc.make_tuple"(%c, %c) : (f64, f64) -> tuple<f64,f64>
     },  {
-      "arc.block.result"(%c) : (f64) -> f64
+      "arc.block.result"(%c) : (f64) -> ()
     }) : (i1) -> f64
     return
   }
@@ -153,9 +153,9 @@ module @toplevel {
     // expected-error@+2 {{'arc.if' op result type does not match the type of the parent: expected 'f64' but found 'f32'}}
     // expected-note@+1 {{see current operation: %0 = "arc.if"}}
     "arc.if"(%a) ( {
-      "arc.block.result"(%b) : (f32) -> f32
+      "arc.block.result"(%b) : (f32) -> ()
     },  {
-      "arc.block.result"(%c) : (f64) -> f64
+      "arc.block.result"(%c) : (f64) -> ()
     }) : (i1) -> f64
     return
   }
@@ -171,9 +171,9 @@ module @toplevel {
     // expected-error@+2 {{'arc.if' op result type does not match the type of the parent: expected 'f64' but found 'f32'}}
     // expected-note@+1 {{see current operation: %0 = "arc.if"}}
     "arc.if"(%a) ( {
-      "arc.block.result"(%b) : (f32) -> f32
+      "arc.block.result"(%b) : (f32) -> ()
     },  {
-      "arc.block.result"(%c) : (f32) -> f32
+      "arc.block.result"(%c) : (f32) -> ()
     }) : (i1) -> f64
     return
   }

--- a/arc-mlir/src/tests/opts/opt-constant-fold-if.mlir
+++ b/arc-mlir/src/tests/opts/opt-constant-fold-if.mlir
@@ -14,67 +14,67 @@ module @toplevel {
 
     %r0 = "arc.if"(%false) ( {
       %b = constant 100 : i32
-      "arc.block.result"(%b) : (i32) -> i32
+      "arc.block.result"(%b) : (i32) -> ()
     },  {
       %c = constant 200 : i32
-      "arc.block.result"(%c) : (i32) -> i32
+      "arc.block.result"(%c) : (i32) -> ()
     }) : (i1) -> i32
     "arc.keep"(%r0) : (i32) -> ()
 //CHECK: "arc.keep"([[C200]])
 
     %r1 = "arc.if"(%true) ( {
       %d = constant 300 : i32
-      "arc.block.result"(%d) : (i32) -> i32
+      "arc.block.result"(%d) : (i32) -> ()
     },  {
       %e = constant 400 : i32
-      "arc.block.result"(%e) : (i32) -> i32
+      "arc.block.result"(%e) : (i32) -> ()
     }) : (i1) -> i32
     "arc.keep"(%r1) : (i32) -> ()
 //CHECK: "arc.keep"([[C300]])
 
     %r2 = "arc.if"(%arg0) ( {
       %d = constant 300 : i32
-      "arc.block.result"(%d) : (i32) -> i32
+      "arc.block.result"(%d) : (i32) -> ()
     },  {
       %e = constant 400 : i32
-      "arc.block.result"(%e) : (i32) -> i32
+      "arc.block.result"(%e) : (i32) -> ()
     }) : (i1) -> i32
     "arc.keep"(%r2) : (i32) -> ()
-//CHECK: {{%[^ ]+}} = "arc.block.result"([[C300]])
-//CHECK: {{%[^ ]+}} = "arc.block.result"([[C400]])
+//CHECK: "arc.block.result"([[C300]])
+//CHECK: "arc.block.result"([[C400]])
 
     %r3 = "arc.if"(%true) ( {
       %d = constant 500 : i32
-      "arc.block.result"(%d) : (i32) -> i32
+      "arc.block.result"(%d) : (i32) -> ()
     },  {
       %e = "arc.if"(%arg0) ( {
         %d = constant 600 : i32
-        "arc.block.result"(%d) : (i32) -> i32
+        "arc.block.result"(%d) : (i32) -> ()
       },  {
         %e = constant 700 : i32
-        "arc.block.result"(%e) : (i32) -> i32
+        "arc.block.result"(%e) : (i32) -> ()
       }) : (i1) -> i32
-      "arc.block.result"(%e) : (i32) -> i32
+      "arc.block.result"(%e) : (i32) -> ()
     }) : (i1) -> i32
     "arc.keep"(%r3) : (i32) -> ()
 //CHECK: "arc.keep"([[C500]])
 
     %r4 = "arc.if"(%false) ( {
       %d = constant 800 : i32
-      "arc.block.result"(%d) : (i32) -> i32
+      "arc.block.result"(%d) : (i32) -> ()
     },  {
       %e = "arc.if"(%arg0) ( {
         %d = constant 900 : i32
-        "arc.block.result"(%d) : (i32) -> i32
+        "arc.block.result"(%d) : (i32) -> ()
       },  {
         %e = constant 1000 : i32
-        "arc.block.result"(%e) : (i32) -> i32
+        "arc.block.result"(%e) : (i32) -> ()
       }) : (i1) -> i32
-      "arc.block.result"(%e) : (i32) -> i32
+      "arc.block.result"(%e) : (i32) -> ()
     }) : (i1) -> i32
     "arc.keep"(%r4) : (i32) -> ()
-//CHECK: {{%[^ ]+}} = "arc.block.result"([[C900]])
-//CHECK: {{%[^ ]+}} = "arc.block.result"([[C1000]])
+//CHECK: "arc.block.result"([[C900]])
+//CHECK: "arc.block.result"([[C1000]])
     return
   }
 }

--- a/arc-mlir/src/tests/rust/rust-output.mlir
+++ b/arc-mlir/src/tests/rust/rust-output.mlir
@@ -44,9 +44,9 @@ module @"this_is_the_name_of_the_crate" {
    %all = "rust.if"(%arg0) ( {
        	%x = "rust.unaryop"(%r) {op="-"} : (!rust<"f64">) -> (!rust<"f64">)
        	%y = "rust.binaryop"(%arg1, %x) {op="+"} : (!rust<"f64">, !rust<"f64">) -> (!rust<"f64">)
-       	"rust.block.result"(%y) : (!rust<"f64">) -> !rust<"f64">
+       	"rust.block.result"(%y) : (!rust<"f64">) -> ()
        },  {
-       	"rust.block.result"(%r) : (!rust<"f64">) -> !rust<"f64">
+       	"rust.block.result"(%r) : (!rust<"f64">) -> ()
        }) : (!rust<"bool">) -> !rust<"f64">
  "rust.return"(%all) : (!rust<"f64">) -> ()
 


### PR DESCRIPTION
Make arc.block.result have the same signature as std.return, ie
"arc.block.result"(%val) : (<type>) -> ()