### PR TITLE
Change Opt into something more useful

### DIFF
--- a/arc-script/Cargo.lock
+++ b/arc-script/Cargo.lock
@@ -76,6 +76,7 @@ dependencies = [
  "codespan-reporting",
  "derive_more",
  "serde_json",
+ "strum",
 ]
 
 [[package]]

--- a/arc-script/arc-script-cli/Cargo.toml
+++ b/arc-script/arc-script-cli/Cargo.toml
@@ -22,3 +22,4 @@ clap               = { git = "https://github.com/clap-rs/clap/", features = ["de
 serde_json         = { version = "1.0.61" }
 codespan-reporting = { version = "=0.9.5" }
 derive_more        = { version = "0.99.11", default-features = false, features = ["constructor", "from", "into"] }
+strum              = { version = "0.20.0", features = ["derive"] }

--- a/arc-script/arc-script-cli/src/from.rs
+++ b/arc-script/arc-script-cli/src/from.rs
@@ -1,4 +1,4 @@
-use crate::repr::{Check, Opt, Parse, Run, SubCmd, Test};
+use crate::repr::{Opt, Run, SubCmd};
 use arc_script_core::prelude::modes::{Input, Mode, Output};
 use arc_script_core::prelude::Result;
 
@@ -8,23 +8,8 @@ use std::io::prelude::*;
 impl From<Opt> for Result<Mode> {
     fn from(opt: Opt) -> Result<Mode> {
         let mut mode = match opt.subcmd {
-            SubCmd::Parse(cmd) => Mode {
-                output: Output::AST,
-                input: Input::File(cmd.main),
-                ..Default::default()
-            },
-            SubCmd::Check(cmd) => Mode {
-                output: Output::HIR,
-                input: Input::File(cmd.main),
-                ..Default::default()
-            },
             SubCmd::Run(cmd) => Mode {
                 output: Output::DFG,
-                input: Input::File(cmd.main),
-                ..Default::default()
-            },
-            SubCmd::Test(cmd) => Mode {
-                output: Output::Rust,
                 input: Input::File(cmd.main),
                 ..Default::default()
             },

--- a/arc-script/arc-script-cli/src/repr.rs
+++ b/arc-script/arc-script-cli/src/repr.rs
@@ -5,6 +5,7 @@ use derive_more::From;
 use std::path::PathBuf;
 
 pub use clap::{ArgEnum, Clap};
+use strum::EnumString;
 
 /// Specification of the Arc-script command-line interface (CLI).
 #[derive(Clap, Debug, Clone, Default)]
@@ -46,19 +47,6 @@ pub enum SubCmd {
     /// Compile and execute source file
     #[clap(name = "run")]
     Run(Run),
-
-    /// Compile and test source file.
-    /// NB: For now, this just generates Rust.
-    #[clap(name = "test")]
-    Test(Test),
-
-    /// Compile and check source file
-    #[clap(name = "check")]
-    Check(Check),
-
-    /// Only parse source file
-    #[clap(name = "parse")]
-    Parse(Parse),
 }
 
 impl Default for SubCmd {
@@ -73,27 +61,22 @@ pub struct Run {
     /// Path to main file
     #[clap(parse(from_os_str))]
     pub main: Option<PathBuf>,
+    /// Output mode: [AST|HIR|DFG|Rust|MLIR]
+    #[clap(long)]
+    pub output: Output,
 }
 
-#[derive(Clap, Default, Debug, Clone, New)]
-pub struct Test {
-    /// Path to main file
-    #[clap(parse(from_os_str))]
-    pub main: Option<PathBuf>,
+#[derive(ArgEnum, Debug, Clone, EnumString)]
+pub enum Output {
+    AST,
+    HIR,
+    DFG,
+    Rust,
+    MLIR,
 }
 
-/// Configuration parameters for the `check` subcommand.
-#[derive(Clap, Default, Debug, Clone, New)]
-pub struct Check {
-    /// Path to main file
-    #[clap(parse(from_os_str))]
-    pub main: Option<PathBuf>,
-}
-
-/// Configuration parameters for the `parse` subcommand.
-#[derive(Clap, Default, Debug, Clone, New)]
-pub struct Parse {
-    /// Path to main file
-    #[clap(parse(from_os_str))]
-    pub main: Option<PathBuf>,
+impl Default for Output {
+    fn default() -> Self {
+        Self::MLIR
+    }
 }


### PR DESCRIPTION
This changes the command-line options into something more convenient. Now there is only two sub-commands by default, `run` and `help`:
```
❯ cargo run -- help
    Finished dev [unoptimized] target(s) in 0.12s
     Running `target/debug/arc-script help`
arc-script-cli
Sub-commands of the CLI

USAGE:
    arc-script [FLAGS] <SUBCOMMAND>

FLAGS:
    -d, --debug             Activate DEBUG mode
    -f, --fail-fast         Fail after the first pass which produces an error
    -h, --help              Prints help information
    -s, --suppress-diags    Mute all diagnostics messages
    -v, --verbosity         Print AST with type information and parentheses
    -V, --version           Prints version information

SUBCOMMANDS:
    help    Prints this message or the help of the given subcommand(s)
    run     Compile and execute source file
```
The `run` command takes an input file and an output mode:
```
❯ cargo run -- run --help
    Finished dev [unoptimized] target(s) in 0.12s
     Running `target/debug/arc-script run --help`
arc-script-run
Compile and execute source file

USAGE:
    arc-script run --output <output> [main]

ARGS:
    <main>    Path to main file

FLAGS:
    -h, --help       Prints help information
    -V, --version    Prints version information

OPTIONS:
        --output <output>    Output mode: [AST|HIR|DFG|Rust|MLIR]
```
The subcommands `lsp` and `repl` can be enabled by compiling with features enabled.