### PR TITLE
LLVM submodule update

### DIFF
--- a/arc-mlir/src/lib/Arc/LowerToRust.cpp
+++ b/arc-mlir/src/lib/Arc/LowerToRust.cpp
@@ -657,7 +657,7 @@ struct FuncOpLowering : public ConversionPattern {
     attributes.push_back(
         NamedAttribute(Identifier::get("type", ctx), TypeAttr::get(funcType)));
     attributes.push_back(NamedAttribute(Identifier::get("sym_name", ctx),
-                                        StringAttr::get(func.getName(), ctx)));
+                                        StringAttr::get(ctx, func.getName())));
 
     if (func.isExternal())
       return buildExternalFun(rewriter, operands, attributes, func, op, sigConv,

--- a/arc-mlir/src/lib/Arc/Types.cpp
+++ b/arc-mlir/src/lib/Arc/Types.cpp
@@ -307,9 +307,8 @@ LogicalResult
 AppenderType::verifyConstructionInvariants(Location loc, Type mergeType,
                                            RankedTensorType resultType) {
   if (!isValueType(mergeType)) {
-    emitOptionalError(loc, "appender merge type must be a value type: found ",
-                      mergeType);
-    return failure();
+    return emitOptionalError(
+        loc, "appender merge type must be a value type: found ", mergeType);
   }
   return success();
 }
@@ -407,7 +406,7 @@ Type StructType::parse(DialectAsmParser &parser) {
       return nullptr;
 
     StructType::FieldTy elementType;
-    elementType.first = StringAttr::get(name, builder.getContext());
+    elementType.first = StringAttr::get(builder.getContext(), name);
     if (parser.parseType(elementType.second))
       return nullptr;
 

--- a/arc-mlir/src/tools/arc-mlir/ArcOptMain.cpp
+++ b/arc-mlir/src/tools/arc-mlir/ArcOptMain.cpp
@@ -115,8 +115,8 @@ static LogicalResult processBuffer(raw_ostream &os,
   // Do any processing requested by command line flags.  We don't care whether
   // these actions succeed or fail, we only care what diagnostics they produce
   // and whether they match our expectations.
-  performActions(os, verifyDiagnostics, verifyPasses, sourceMgr, &context,
-                 passPipeline);
+  (void)performActions(os, verifyDiagnostics, verifyPasses, sourceMgr, &context,
+                       passPipeline);
 
   // Verify the diagnostic handler to make sure that each of the diagnostics
   // matched.


### PR DESCRIPTION
Changes needed:

  * StringAttr::get() has switched the order of the arguments.

  * Methods/functions returning a LogicalResult now expects the result
    to be checked -- make sure we do that.