### PR TITLE
LLVM submodule update

### DIFF
--- a/.github/workflows/arc-mlir.yml
+++ b/.github/workflows/arc-mlir.yml
@@ -2,7 +2,7 @@ name: arc-mlir
 
 on:
   pull_request:
-    branches: [ mlir ]
+    branches: [ master ]
 
 jobs:
   build:

--- a/.github/workflows/arc-script.yml
+++ b/.github/workflows/arc-script.yml
@@ -2,7 +2,7 @@ name: arc-script
 
 on:
   pull_request:
-    branches: [ mlir ]
+    branches: [ master ]
 
 env:
   CARGO_TERM_COLOR: always

--- a/arc-mlir/src/lib/Arc/LowerToRust.cpp
+++ b/arc-mlir/src/lib/Arc/LowerToRust.cpp
@@ -18,6 +18,7 @@
 #include "mlir/IR/MLIRContext.h"
 #include "mlir/Support/LLVM.h"
 #include "mlir/Support/LogicalResult.h"
+#include <mlir/Dialect/Math/IR/Math.h>
 #include <mlir/Dialect/StandardOps/IR/Ops.h>
 #include <mlir/Transforms/DialectConversion.h>
 
@@ -792,9 +793,9 @@ void ArcToRustLoweringPass::runOnOperation() {
   patterns.insert<ArcCmpIOpLowering>(&getContext(), typeConverter);
   patterns.insert<StdCmpFOpLowering>(&getContext(), typeConverter);
 
-  patterns.insert<ArcUnaryFloatOpLowering<mlir::SinOp, ArcUnaryFloatOp::sin>>(
+  patterns.insert<ArcUnaryFloatOpLowering<math::SinOp, ArcUnaryFloatOp::sin>>(
       &getContext(), typeConverter);
-  patterns.insert<ArcUnaryFloatOpLowering<mlir::CosOp, ArcUnaryFloatOp::cos>>(
+  patterns.insert<ArcUnaryFloatOpLowering<math::CosOp, ArcUnaryFloatOp::cos>>(
       &getContext(), typeConverter);
   patterns.insert<ArcUnaryFloatOpLowering<arc::TanOp, ArcUnaryFloatOp::tan>>(
       &getContext(), typeConverter);
@@ -803,21 +804,21 @@ void ArcToRustLoweringPass::runOnOperation() {
       &getContext(), typeConverter);
   patterns.insert<ArcUnaryFloatOpLowering<arc::AcosOp, ArcUnaryFloatOp::acos>>(
       &getContext(), typeConverter);
-  patterns.insert<ArcUnaryFloatOpLowering<mlir::AtanOp, ArcUnaryFloatOp::atan>>(
+  patterns.insert<ArcUnaryFloatOpLowering<math::AtanOp, ArcUnaryFloatOp::atan>>(
       &getContext(), typeConverter);
 
   patterns.insert<ArcUnaryFloatOpLowering<arc::SinhOp, ArcUnaryFloatOp::sinh>>(
       &getContext(), typeConverter);
   patterns.insert<ArcUnaryFloatOpLowering<arc::CoshOp, ArcUnaryFloatOp::cosh>>(
       &getContext(), typeConverter);
-  patterns.insert<ArcUnaryFloatOpLowering<mlir::TanhOp, ArcUnaryFloatOp::tanh>>(
+  patterns.insert<ArcUnaryFloatOpLowering<math::TanhOp, ArcUnaryFloatOp::tanh>>(
       &getContext(), typeConverter);
 
-  patterns.insert<ArcUnaryFloatOpLowering<mlir::LogOp, ArcUnaryFloatOp::log>>(
+  patterns.insert<ArcUnaryFloatOpLowering<math::LogOp, ArcUnaryFloatOp::log>>(
       &getContext(), typeConverter);
-  patterns.insert<ArcUnaryFloatOpLowering<mlir::ExpOp, ArcUnaryFloatOp::exp>>(
+  patterns.insert<ArcUnaryFloatOpLowering<math::ExpOp, ArcUnaryFloatOp::exp>>(
       &getContext(), typeConverter);
-  patterns.insert<ArcUnaryFloatOpLowering<mlir::SqrtOp, ArcUnaryFloatOp::sqrt>>(
+  patterns.insert<ArcUnaryFloatOpLowering<math::SqrtOp, ArcUnaryFloatOp::sqrt>>(
       &getContext(), typeConverter);
 
   patterns.insert<IfOpLowering>(&getContext(), typeConverter);

--- a/arc-mlir/src/tests/arc-to-rust/unary-ops.mlir
+++ b/arc-mlir/src/tests/arc-to-rust/unary-ops.mlir
@@ -11,12 +11,12 @@ func @asin_f32(%a : f32) -> f32 {
 }
 
 func @atan_f32(%a : f32) -> f32 {
-  %r = atan %a : f32
+  %r = math.atan %a : f32
   return %r : f32
 }
 
 func @cos_f32(%a : f32) -> f32 {
-  %r = cos %a : f32
+  %r = math.cos %a : f32
   return %r : f32
 }
 
@@ -26,17 +26,17 @@ func @cosh_f32(%a : f32) -> f32 {
 }
 
 func @exp_f32(%a : f32) -> f32 {
-  %r = exp %a : f32
+  %r = math.exp %a : f32
   return %r : f32
 }
 
 func @log_f32(%a : f32) -> f32 {
-  %r = log %a : f32
+  %r = math.log %a : f32
   return %r : f32
 }
 
 func @sin_f32(%a : f32) -> f32 {
-  %r = sin %a : f32
+  %r = math.sin %a : f32
   return %r : f32
 }
 
@@ -46,7 +46,7 @@ func @sinh_f32(%a : f32) -> f32 {
 }
 
 func @sqrt_f32(%a : f32) -> f32 {
-  %r = sqrt %a : f32
+  %r = math.sqrt %a : f32
   return %r : f32
 }
 
@@ -56,7 +56,7 @@ func @tan_f32(%a : f32) -> f32 {
 }
 
 func @tanh_f32(%a : f32) -> f32 {
-  %r = tanh %a : f32
+  %r = math.tanh %a : f32
   return %r : f32
 }
 
@@ -71,12 +71,12 @@ func @asin_f64(%a : f64) -> f64 {
 }
 
 func @atan_f64(%a : f64) -> f64 {
-  %r = atan %a : f64
+  %r = math.atan %a : f64
   return %r : f64
 }
 
 func @cos_f64(%a : f64) -> f64 {
-  %r = cos %a : f64
+  %r = math.cos %a : f64
   return %r : f64
 }
 
@@ -86,17 +86,17 @@ func @cosh_f64(%a : f64) -> f64 {
 }
 
 func @exp_f64(%a : f64) -> f64 {
-  %r = exp %a : f64
+  %r = math.exp %a : f64
   return %r : f64
 }
 
 func @log_f64(%a : f64) -> f64 {
-  %r = log %a : f64
+  %r = math.log %a : f64
   return %r : f64
 }
 
 func @sin_f64(%a : f64) -> f64 {
-  %r = sin %a : f64
+  %r = math.sin %a : f64
   return %r : f64
 }
 
@@ -106,7 +106,7 @@ func @sinh_f64(%a : f64) -> f64 {
 }
 
 func @sqrt_f64(%a : f64) -> f64 {
-  %r = sqrt %a : f64
+  %r = math.sqrt %a : f64
   return %r : f64
 }
 
@@ -116,7 +116,7 @@ func @tan_f64(%a : f64) -> f64 {
 }
 
 func @tanh_f64(%a : f64) -> f64 {
-  %r = tanh %a : f64
+  %r = math.tanh %a : f64
   return %r : f64
 }
 

--- a/arc-mlir/src/tools/arc-mlir/ArcOptMain.cpp
+++ b/arc-mlir/src/tools/arc-mlir/ArcOptMain.cpp
@@ -99,8 +99,7 @@ static LogicalResult processBuffer(raw_ostream &os,
   sourceMgr.AddNewSourceBuffer(std::move(ownedBuffer), SMLoc());
 
   // Parse the input file.
-  MLIRContext context;
-  registry.appendTo(context.getDialectRegistry());
+  MLIRContext context(registry);
 
   // If we are in verify diagnostics mode then we have a lot of work to do,
   // otherwise just perform the actions without worrying about it.

--- a/arc-mlir/src/tools/arc-mlir/Main.cpp
+++ b/arc-mlir/src/tools/arc-mlir/Main.cpp
@@ -33,6 +33,7 @@
 #include <llvm/Support/ToolOutputFile.h>
 #include <llvm/Support/raw_ostream.h>
 #include <memory>
+#include <mlir/Dialect/Math/IR/Math.h>
 #include <mlir/IR/AsmState.h>
 #include <mlir/IR/BuiltinOps.h>
 #include <mlir/IR/MLIRContext.h>
@@ -80,6 +81,7 @@ int main(int argc, char **argv) {
 
   mlir::DialectRegistry registry;
   registry.insert<mlir::StandardOpsDialect>();
+  registry.insert<math::MathDialect>();
   registry.insert<ArcDialect>();
   registry.insert<rust::RustDialect>();
   arc::registerArcPasses();


### PR DESCRIPTION
Changes needed:

 * The math operations in the standard dialect have moved to their own
   `math` dialect. Update tests, Arc-to-Rust lowering and dialect
   loading in arc-mlir.

 * MLIRContext::getDialectRegistry() now returns a const value. Change
   registration logic in arc-mlir to avoid warning.