### PR TITLE
LLVM submodule update

### DIFF
--- a/arc-mlir/src/lib/Arc/LowerToRust.cpp
+++ b/arc-mlir/src/lib/Arc/LowerToRust.cpp
@@ -806,7 +806,7 @@ void ArcToRustLoweringPass::runOnOperation() {
 
   ConversionTarget target(getContext());
   target.addLegalDialect<rust::RustDialect>();
-  target.addLegalOp<ModuleOp, ModuleTerminatorOp>();
+  target.addLegalOp<ModuleOp>();
 
   OwningRewritePatternList patterns(&getContext());
   patterns.insert<ReturnOpLowering>(&getContext());


### PR DESCRIPTION
Changes needed:

 * The ModuleTerminatorOp has been
   removed (https://reviews.llvm.org/D98468).