### PR TITLE
Add codegen for MLIR enums

### DIFF
--- a/arc-script/arc-script-core/src/compiler/mlir/from.rs
+++ b/arc-script/arc-script-core/src/compiler/mlir/from.rs
@@ -15,7 +15,7 @@ impl MLIR {
         let defs = hir
             .items
             .iter()
-            .filter_map(|x| Some((*x, hir.defs.get(x).unwrap().lower(ctx)?)))
+            .map(|x| (*x, hir.defs.get(x).unwrap().lower(ctx)))
             .collect::<OrdMap<_, _>>();
         Self::new(hir.items.clone(), defs)
     }

--- a/arc-script/arc-script-core/src/compiler/pipeline.rs
+++ b/arc-script/arc-script-core/src/compiler/pipeline.rs
@@ -89,7 +89,7 @@ where
     if matches!(info.mode.output, Output::RustMLIR) {
         // Lower HIR and DFG into Rust via MLIR
         let mlir = MLIR::from(&hir, &mut info);
-        let r = mlir::pretty(&mlir, &info);
+        let r = mlir::pretty(&mlir, &mlir, &info);
 
         let infile = tempfile::NamedTempFile::new().expect("Could not create temporary input file");
         let outfile =
@@ -108,7 +108,7 @@ where
         // Lower HIR and DFG into MLIR
         let mlir = MLIR::from(&hir, &mut info);
 
-        writeln!(f, "{}", mlir::pretty(&mlir, &info))?;
+        writeln!(f, "{}", mlir::pretty(&mlir, &mlir, &info))?;
         return Ok(Report::semantic(info, hir));
     }
 

--- a/arc-script/arc-script-test/compile/src/snapshots/ast@structs.arc.snap
+++ b/arc-script/arc-script-test/compile/src/snapshots/ast@structs.arc.snap
@@ -4,8 +4,12 @@ expression: s
 input_file: arc-script-test/compile/src/tests/expect_pass/structs.arc
 
 ---
+fun foo(a: { c: i32, b: i32 }, b: { b: i32, c: i32 }) -> { a: { c: i32, b: i32 }, xyz: i32, d: { b: i32, c: i32 } } {
+    let r = { a: a, xyz: 4711, d: b } in
+    r
+}
 fun test()  {
-    let x = { a: { c: 1, b: 5 }, xyz: 2, d: { b: 4, c: 2 } } in
+    let x = foo({ c: 1, b: 5 }, { b: 4, c: 2 }) in
     unit
 }
 

--- a/arc-script/arc-script-test/compile/src/snapshots/hir@structs.arc.snap
+++ b/arc-script/arc-script-test/compile/src/snapshots/hir@structs.arc.snap
@@ -4,8 +4,12 @@ expression: s
 input_file: arc-script-test/compile/src/tests/expect_pass/structs.arc
 
 ---
+fun foo(a_0: { b: i32, c: i32 }, b_0: { b: i32, c: i32 }) -> { a: { b: i32, c: i32 }, d: { b: i32, c: i32 }, xyz: i32 } {
+    let r_0: { a: { b: i32, c: i32 }, d: { b: i32, c: i32 }, xyz: i32 } = { a: a_0, xyz: 4711, d: b_0 } in
+    r_0
+}
 fun test() -> unit {
-    let x_0: { a: { b: i32, c: i32 }, d: { b: i32, c: i32 }, xyz: i32 } = { a: { c: 1, b: 5 }, xyz: 2, d: { b: 4, c: 2 } } in
+    let x_0: { a: { b: i32, c: i32 }, d: { b: i32, c: i32 }, xyz: i32 } = crate::foo({ c: 1, b: 5 }, { b: 4, c: 2 }) in
     unit
 }
 

--- a/arc-script/arc-script-test/compile/src/snapshots/mlir@enum_pattern.arc.snap
+++ b/arc-script/arc-script-test/compile/src/snapshots/mlir@enum_pattern.arc.snap
@@ -5,13 +5,14 @@ input_file: arc-script-test/compile/src/tests/expect_pass/enum_pattern.arc
 
 ---
 module @toplevel {
+    !arc.enum<crate_Opt_Some : si32, crate_Opt_None : ()>
     func @crate_x_2() -> () {
         return 
     }
     func @crate_main() -> () {
         %x_4 = arc.constant 5 : si32
-        %x_5 = "arc.enwrap"%x_4 { variant = crate_Opt_Some } : si32 -> crate_Opt
-        %x_6 = "arc.is"%x_5 { variant = crate_Opt_Some } : crate_Opt -> i1
+        %x_5 = "arc.enwrap"(%x_4) { variant = crate_Opt_Some } : si32 -> !arc.enum<crate_Opt_Some : si32, crate_Opt_None : ()>
+        %x_6 = "arc.is"%x_5 { variant = crate_Opt_Some } : !arc.enum<crate_Opt_Some : si32, crate_Opt_None : ()> -> i1
         return 
     }
 }

--- a/arc-script/arc-script-test/compile/src/snapshots/mlir@enum_pattern_nested.arc.snap
+++ b/arc-script/arc-script-test/compile/src/snapshots/mlir@enum_pattern_nested.arc.snap
@@ -5,14 +5,16 @@ input_file: arc-script-test/compile/src/tests/expect_pass/enum_pattern_nested.ar
 
 ---
 module @toplevel {
+    !arc.enum<crate_Baz_Some : si32, crate_Baz_None : ()>
+    !arc.enum<crate_Foo_Bar : !arc.enum<crate_Baz_Some : si32, crate_Baz_None : ()>, crate_Foo_None : ()>
     func @crate_x_3() -> () {
         return 
     }
     func @crate_main() -> () {
         %x_5 = arc.constant 5 : si32
-        %x_6 = "arc.enwrap"%x_5 { variant = crate_Baz_Some } : si32 -> crate_Baz
-        %x_7 = "arc.enwrap"%x_6 { variant = crate_Foo_Bar } : crate_Baz -> crate_Foo
-        %x_8 = "arc.is"%x_7 { variant = crate_Foo_Bar } : crate_Foo -> i1
+        %x_6 = "arc.enwrap"(%x_5) { variant = crate_Baz_Some } : si32 -> !arc.enum<crate_Baz_Some : si32, crate_Baz_None : ()>
+        %x_7 = "arc.enwrap"(%x_6) { variant = crate_Foo_Bar } : !arc.enum<crate_Baz_Some : si32, crate_Baz_None : ()> -> !arc.enum<crate_Foo_Bar : !arc.enum<crate_Baz_Some : si32, crate_Baz_None : ()>, crate_Foo_None : ()>
+        %x_8 = "arc.is"%x_7 { variant = crate_Foo_Bar } : !arc.enum<crate_Foo_Bar : !arc.enum<crate_Baz_Some : si32, crate_Baz_None : ()>, crate_Foo_None : ()> -> i1
         return 
     }
 }

--- a/arc-script/arc-script-test/compile/src/snapshots/mlir@enums.arc.snap
+++ b/arc-script/arc-script-test/compile/src/snapshots/mlir@enums.arc.snap
@@ -5,13 +5,14 @@ input_file: arc-script-test/compile/src/tests/expect_pass/enums.arc
 
 ---
 module @toplevel {
+    !arc.enum<crate_Foo_Bar : ui32, crate_Foo_Baz : f32>
     func @crate_main() -> () {
         %x_0 = arc.constant 200 : ui32
         %x_1 = constant 2.0 : f32
-        %x_2 = "arc.enwrap"%x_0 { variant = crate_Foo_Bar } : ui32 -> crate_Foo
-        %x_3 = "arc.unwrap"%x_2 { variant = crate_Foo_Bar } : crate_Foo -> ui32
-        %x_4 = "arc.enwrap"%x_1 { variant = crate_Foo_Baz } : f32 -> crate_Foo
-        %x_5 = "arc.is"%x_4 { variant = crate_Foo_Baz } : crate_Foo -> i1
+        %x_2 = "arc.enwrap"(%x_0) { variant = crate_Foo_Bar } : ui32 -> !arc.enum<crate_Foo_Bar : ui32, crate_Foo_Baz : f32>
+        %x_3 = "arc.unwrap"(%x_2) { variant = crate_Foo_Bar } : !arc.enum<crate_Foo_Bar : ui32, crate_Foo_Baz : f32> -> ui32
+        %x_4 = "arc.enwrap"(%x_1) { variant = crate_Foo_Baz } : f32 -> !arc.enum<crate_Foo_Bar : ui32, crate_Foo_Baz : f32>
+        %x_5 = "arc.is"%x_4 { variant = crate_Foo_Baz } : !arc.enum<crate_Foo_Bar : ui32, crate_Foo_Baz : f32> -> i1
         return 
     }
 }

--- a/arc-script/arc-script-test/compile/src/snapshots/mlir@option.arc.snap
+++ b/arc-script/arc-script-test/compile/src/snapshots/mlir@option.arc.snap
@@ -5,13 +5,14 @@ input_file: arc-script-test/compile/src/tests/expect_pass/option.arc
 
 ---
 module @toplevel {
+    !arc.enum<crate_Opt_Some : si32, crate_Opt_None : ()>
     func @crate_x_1() -> () {
         return 
     }
     func @crate_main() -> () {
         %x_3 = arc.constant 3 : si32
-        %x_4 = "arc.enwrap"%x_3 { variant = crate_Opt_Some } : si32 -> crate_Opt
-        %x_5 = "arc.is"%x_4 { variant = crate_Opt_Some } : crate_Opt -> i1
+        %x_4 = "arc.enwrap"(%x_3) { variant = crate_Opt_Some } : si32 -> !arc.enum<crate_Opt_Some : si32, crate_Opt_None : ()>
+        %x_5 = "arc.is"%x_4 { variant = crate_Opt_Some } : !arc.enum<crate_Opt_Some : si32, crate_Opt_None : ()> -> i1
         return 
     }
 }

--- a/arc-script/arc-script-test/compile/src/snapshots/mlir@structs.arc.snap
+++ b/arc-script/arc-script-test/compile/src/snapshots/mlir@structs.arc.snap
@@ -5,15 +5,19 @@ input_file: arc-script-test/compile/src/tests/expect_pass/structs.arc
 
 ---
 module @toplevel {
+    func @crate_foo(%a_0: !arc.struct<b : si32, c : si32>, %b_0: !arc.struct<b : si32, c : si32>) -> !arc.struct<a : !arc.struct<b : si32, c : si32>, d : !arc.struct<b : si32, c : si32>, xyz : si32> {
+        %x_1 = arc.constant 4711 : si32
+        %x_2 = arc.make_struct(%a_0, %b_0, %x_1 : !arc.struct<b : si32, c : si32>, !arc.struct<b : si32, c : si32>, si32) : !arc.struct<a : !arc.struct<b : si32, c : si32>, d : !arc.struct<b : si32, c : si32>, xyz : si32>
+        return %x_2 : !arc.struct<a : !arc.struct<b : si32, c : si32>, d : !arc.struct<b : si32, c : si32>, xyz : si32>
+    }
     func @crate_test() -> () {
-        %x_1 = arc.constant 1 : si32
-        %x_2 = arc.constant 5 : si32
-        %x_3 = arc.make_struct(%x_2, %x_1 : si32, si32) : !arc.struct<b : si32, c : si32>
-        %x_4 = arc.constant 2 : si32
-        %x_5 = arc.constant 4 : si32
-        %x_6 = arc.constant 2 : si32
-        %x_7 = arc.make_struct(%x_5, %x_6 : si32, si32) : !arc.struct<b : si32, c : si32>
-        %x_8 = arc.make_struct(%x_3, %x_7, %x_4 : !arc.struct<b : si32, c : si32>, !arc.struct<b : si32, c : si32>, si32) : !arc.struct<a : !arc.struct<b : si32, c : si32>, d : !arc.struct<b : si32, c : si32>, xyz : si32>
+        %x_3 = arc.constant 1 : si32
+        %x_4 = arc.constant 5 : si32
+        %x_5 = arc.make_struct(%x_4, %x_3 : si32, si32) : !arc.struct<b : si32, c : si32>
+        %x_6 = arc.constant 4 : si32
+        %x_7 = arc.constant 2 : si32
+        %x_8 = arc.make_struct(%x_6, %x_7 : si32, si32) : !arc.struct<b : si32, c : si32>
+        %x_9 = call @crate_foo(%x_5, %x_8) : (!arc.struct<b : si32, c : si32>, !arc.struct<b : si32, c : si32>) -> !arc.struct<a : !arc.struct<b : si32, c : si32>, d : !arc.struct<b : si32, c : si32>, xyz : si32>
         return 
     }
 }

--- a/arc-script/arc-script-test/compile/src/snapshots/rust@structs.arc.snap
+++ b/arc-script/arc-script-test/compile/src/snapshots/rust@structs.arc.snap
@@ -15,21 +15,28 @@ pub mod defs {
     pub use arc_script::arcorn;
     pub use arc_script::arcorn::state::{ArcMapOps, ArcRefOps, ArcSetOps, ArcVecOps};
     pub use arcon::prelude::*;
+    pub fn foo(
+        a_0: Struct1bi321ci32End,
+        b_0: Struct1bi321ci32End,
+    ) -> Struct1aStruct1bi321ci32End1dStruct1bi321ci32End3xyzi32End {
+        let y_1_0 = 4711i32;
+        let y_1_1 = Struct1aStruct1bi321ci32End1dStruct1bi321ci32End3xyzi32End {
+            a: a_0,
+            xyz: y_1_0,
+            d: b_0,
+        };
+        y_1_1
+    }
     pub fn test() -> () {
         let y_1_0 = 1i32;
         let y_1_1 = 5i32;
         let y_1_2 = Struct1bi321ci32End { c: y_1_0, b: y_1_1 };
-        let y_1_3 = 2i32;
-        let y_1_4 = 4i32;
-        let y_1_5 = 2i32;
-        let y_1_6 = Struct1bi321ci32End { b: y_1_4, c: y_1_5 };
-        let y_1_7 = Struct1aStruct1bi321ci32End1dStruct1bi321ci32End3xyzi32End {
-            a: y_1_2,
-            xyz: y_1_3,
-            d: y_1_6,
-        };
-        let y_1_8 = ();
-        y_1_8
+        let y_1_3 = 4i32;
+        let y_1_4 = 2i32;
+        let y_1_5 = Struct1bi321ci32End { b: y_1_3, c: y_1_4 };
+        let y_1_6 = foo(y_1_2, y_1_5);
+        let y_1_7 = ();
+        y_1_7
     }
     #[arcorn::rewrite]
     #[derive(Copy)]


### PR DESCRIPTION
Credit for most of these changes goes to Frej!

All types in MLIR are structural. Therefore this commit adds a
conversion from nominal enums into structural enums.

The Arc-Script code:

```
    enum Foo {
        Bar(i32),
        Baz(f32),
    }
```

Becomes the MLIR type:
```
    !arc.enum<crate_Foo_Bar : i32 , crate_Foo_Baz : f32>
```