### PR TITLE
Allow master to be latest released nightly Rust

### DIFF
--- a/arc-script/arc-script-core/src/lib.rs
+++ b/arc-script/arc-script-core/src/lib.rs
@@ -67,7 +67,7 @@
 #![deny(unaligned_references)]
 #![deny(unreachable_pub)]
 #![deny(unsafe_code)]
-#![deny(unstable_features)]
+
 #![allow(unused_crate_dependencies)]
 #![deny(unused_extern_crates)]
 #![deny(unused_import_braces)]
@@ -76,6 +76,9 @@
 #![allow(unused_results)] // Just very annoying, it means every return value must be used
 #![allow(variant_size_differences)] // Good lint, annoying but can be useful for tuning performance
 #![deny(warnings)]
+#![allow(stable_features)]
+
+#![feature(or_patterns)]
 
 /// Module which assembles the compilation pipeline.
 pub mod compiler;


### PR DESCRIPTION
The only thing that stops master from being compiled with the latest
released nightly version of Rust is the use of the experimental
`or_patterns` feature.

This patch enables `or_patterns` and disables the deprecated
`unstable_features` lint for the relevant crate.