### PR TITLE
LLVM submodule update

### DIFF
--- a/arc-mlir/src/lib/Arc/LowerToRust.cpp
+++ b/arc-mlir/src/lib/Arc/LowerToRust.cpp
@@ -282,7 +282,12 @@ private:
         op.emitError("signless integers are not supported");
         return failure();
       }
-      return returnResult(op, rustTy, v.toString(10, ty.isSigned()), rewriter);
+      {
+        SmallVector<char> tmp;
+        v.toString(tmp, 10, ty.isSigned());
+        std::string str(tmp.begin(), tmp.end());
+        return returnResult(op, rustTy, str, rewriter);
+      }
     default:
       op.emitError("unhandled constant integer width");
       return failure();

--- a/arc-mlir/src/tests/lit.cfg.py
+++ b/arc-mlir/src/tests/lit.cfg.py
@@ -58,7 +58,6 @@ tools = [
     'mlir-opt',
     'mlir-tblgen',
     'mlir-translate',
-    'mlir-edsc-builder-api-test',
     'arc-mlir',
     'arc-script',
 ]


### PR DESCRIPTION
Changes needed:

  * Adapt to changes to APInt::toString(). It no longer returns a
    string, instead it fills a SmallVector<char>.

  * The tool mlir-edsc-builder-api-test has been removed, remove it
    from the Lit-configuration for arc-mlir.