### PR TITLE
Fix continuous integration for `cargo insta`

### DIFF
--- a/.github/workflows/arc-script.yml
+++ b/.github/workflows/arc-script.yml
@@ -28,7 +28,9 @@ jobs:
       run: cargo clean
 
     - name: cargo-test
-      run: cargo insta test --package=arc-script-test-compile
+      run: |
+        cargo insta test --package=arc-script-test-compile
+        cargo insta accept
 
     - name: cargo-clippy
       run: cargo clippy


### PR DESCRIPTION
This commit makes it so changes in snapshots, as a result of running
`cargo insta test`, will be catched and reported during CI.