### PR TITLE
Fix MLIR codegen of unit type

### DIFF
--- a/arc-script/arc-script-core/src/compiler/mlir/display.rs
+++ b/arc-script/arc-script-core/src/compiler/mlir/display.rs
@@ -167,7 +167,7 @@ pretty! {
             Some(var) => {
 		            let ty = node.kind.get_type_specifier(var.t);
 		            if matches!(fmt.types.resolve(ty), hir::repr::TypeKind::Scalar(hir::repr::ScalarKind::Unit)) {
-			              write!(w, "{kind}", kind = node.kind.pretty(fmt))
+			              write!(w, "{kind} ()", kind = node.kind.pretty(fmt))
 			          } else {
 		                write!(w, "{var} = {kind} {ty}",
 			                  var = var.pretty(fmt),

--- a/arc-script/arc-script-test/compile/src/snapshots/mlir@enum_pattern.arc.snap
+++ b/arc-script/arc-script-test/compile/src/snapshots/mlir@enum_pattern.arc.snap
@@ -20,9 +20,9 @@ module @toplevel {
             // No result
         },{
             %x_7 = constant @crate_x_6 : () -> none
-            call_indirect %x_7() : () ->
+            call_indirect %x_7() : () -> ()
             // No result
-        }) : (i1) ->
+        }) : (i1) -> ()
         return
     }
 }

--- a/arc-script/arc-script-test/compile/src/snapshots/mlir@enum_pattern_nested.arc.snap
+++ b/arc-script/arc-script-test/compile/src/snapshots/mlir@enum_pattern_nested.arc.snap
@@ -24,15 +24,15 @@ module @toplevel {
                 // No result
             },{
                 %x_A = constant @crate_x_9 : () -> none
-                call_indirect %x_A() : () ->
+                call_indirect %x_A() : () -> ()
                 // No result
-            }) : (i1) ->
+            }) : (i1) -> ()
             // No result
         },{
             %x_A = constant @crate_x_9 : () -> none
-            call_indirect %x_A() : () ->
+            call_indirect %x_A() : () -> ()
             // No result
-        }) : (i1) ->
+        }) : (i1) -> ()
         return
     }
 }

--- a/arc-script/arc-script-test/compile/src/snapshots/mlir@option.arc.snap
+++ b/arc-script/arc-script-test/compile/src/snapshots/mlir@option.arc.snap
@@ -20,9 +20,9 @@ module @toplevel {
             // No result
         },{
             %x_7 = constant @crate_x_6 : () -> none
-            call_indirect %x_7() : () ->
+            call_indirect %x_7() : () -> ()
             // No result
-        }) : (i1) ->
+        }) : (i1) -> ()
         return
     }
 }


### PR DESCRIPTION
Before there was a bug which caused this to generate:

```
foo(...) : (...) ->
```

Now we get:

```
foo(...) : (...) -> ()
```