### PR TITLE
arc-script: Don't omit `arc.block.results` in MLIR backend

### DIFF
--- a/arc-script/arc-script-core/src/compiler/mlir/display.rs
+++ b/arc-script/arc-script-core/src/compiler/mlir/display.rs
@@ -336,7 +336,7 @@ pretty! {
             }
             mlir::OpKind::Result(v) => {
                 if matches!(fmt.types.resolve(v.t), hir::repr::TypeKind::Scalar(hir::repr::ScalarKind::Unit)) {
-			              write!(w, "// No result")
+			              write!(w, r#""arc.block.result"() : () -> ()"#)
                 } else {
 			              write!(w, r#""arc.block.result"({v}) : ({t}) -> ()"#,
 			                  v = v.pretty(fmt),

--- a/arc-script/arc-script-test/compile/src/snapshots/mlir@enum_pattern.arc.snap
+++ b/arc-script/arc-script-test/compile/src/snapshots/mlir@enum_pattern.arc.snap
@@ -17,11 +17,11 @@ module @toplevel {
         "arc.if"(%x_2) ({
             %x_3 = arc.enum_access "crate_Opt_Some" in (%x_1 : !arc.enum<crate_Opt_Some : si32, crate_Opt_None : none>) :  si32
             // No value
-            // No result
+            "arc.block.result"() : () -> ()
         },{
             %x_7 = constant @crate_x_6 : () -> none
             call_indirect %x_7() : () -> ()
-            // No result
+            "arc.block.result"() : () -> ()
         }) : (i1) -> ()
         return
     }

--- a/arc-script/arc-script-test/compile/src/snapshots/mlir@enum_pattern_nested.arc.snap
+++ b/arc-script/arc-script-test/compile/src/snapshots/mlir@enum_pattern_nested.arc.snap
@@ -21,17 +21,17 @@ module @toplevel {
             "arc.if"(%x_5) ({
                 %x_6 = arc.enum_access "crate_Baz_Some" in (%x_4 : !arc.enum<crate_Baz_Some : si32, crate_Baz_None : none>) :  si32
                 // No value
-                // No result
+                "arc.block.result"() : () -> ()
             },{
                 %x_A = constant @crate_x_9 : () -> none
                 call_indirect %x_A() : () -> ()
-                // No result
+                "arc.block.result"() : () -> ()
             }) : (i1) -> ()
-            // No result
+            "arc.block.result"() : () -> ()
         },{
             %x_A = constant @crate_x_9 : () -> none
             call_indirect %x_A() : () -> ()
-            // No result
+            "arc.block.result"() : () -> ()
         }) : (i1) -> ()
         return
     }

--- a/arc-script/arc-script-test/compile/src/snapshots/mlir@option.arc.snap
+++ b/arc-script/arc-script-test/compile/src/snapshots/mlir@option.arc.snap
@@ -17,11 +17,11 @@ module @toplevel {
         "arc.if"(%x_2) ({
             %x_3 = arc.enum_access "crate_Opt_Some" in (%x_1 : !arc.enum<crate_Opt_Some : si32, crate_Opt_None : none>) :  si32
             // No value
-            // No result
+            "arc.block.result"() : () -> ()
         },{
             %x_7 = constant @crate_x_6 : () -> none
             call_indirect %x_7() : () -> ()
-            // No result
+            "arc.block.result"() : () -> ()
         }) : (i1) -> ()
         return
     }


### PR DESCRIPTION
The blocks in an `arc.if` have to have terminators even if the
`arc.if` does not return a value, so generate an `arc.block.result"()
: () -> ()` in that case.