### PR TITLE
Annihilate the `unit` type from MLIR codegen

### DIFF
--- a/arc-script/arc-script-core/src/compiler/ast/repr.rs
+++ b/arc-script/arc-script-core/src/compiler/ast/repr.rs
@@ -482,6 +482,7 @@ pub enum ScalarKind {
     U32,
     U64,
     Str,
+    // Eliminated when lowering to HIR
     Unit,
     DateTime,
     Duration,

--- a/arc-script/arc-script-core/src/compiler/info/types/traits.rs
+++ b/arc-script/arc-script-core/src/compiler/info/types/traits.rs
@@ -90,4 +90,7 @@ impl TypeId {
     pub(crate) fn is_bool(self, info: &Info) -> bool {
         matches!(info.types.resolve(self), Scalar(Bool))
     }
+    pub(crate) fn is_unit(self, info: &Info) -> bool {
+        matches!(info.types.resolve(self), Scalar(Unit))
+    }
 }

--- a/arc-script/arc-script-core/src/compiler/mlir/repr.rs
+++ b/arc-script/arc-script-core/src/compiler/mlir/repr.rs
@@ -50,8 +50,14 @@ pub(crate) struct Fun {
 
 #[derive(New, Debug, Copy, Clone)]
 pub(crate) struct Var {
-    pub(crate) name: Name,
+    pub(crate) kind: VarKind,
     pub(crate) t: Type,
+}
+
+#[derive(Debug, Copy, Clone)]
+pub(crate) enum VarKind {
+    Ok(Name),
+    Elided,
 }
 
 #[derive(New, Debug)]
@@ -99,7 +105,7 @@ pub(crate) enum SettingKind {
 
 #[derive(Debug, New)]
 pub(crate) struct Op {
-    pub(crate) var: Option<Var>,
+    pub(crate) var: Var,
     pub(crate) kind: OpKind,
     pub(crate) loc: Loc,
 }
@@ -108,7 +114,7 @@ pub(crate) struct Op {
 pub(crate) enum OpKind {
     Access(Var, Name),
     Array(Vec<Var>),
-    BinOp(Type, Var, BinOp, Var),
+    BinOp(Var, BinOp, Var),
     Break(Var),
     Continue,
     Call(Path, Vec<Var>),
@@ -192,16 +198,16 @@ pub(crate) enum ConstKind {
     U32(u32),
     U64(u64),
     Time(Duration),
-    Unit,
+    Noop,
 }
 
 impl OpKind {
     pub(crate) const fn get_type_specifier(&self, t: Type) -> Type {
         match self {
-            OpKind::BinOp(st, _, op, _) => {
+            OpKind::BinOp(l, op, _) => {
                 use BinOpKind::*;
                 match op.kind {
-                    Equ | Geq | Gt | Leq | Lt | Neq => *st,
+                    Equ | Geq | Gt | Leq | Lt | Neq => l.t,
                     _ => t,
                 }
             }

--- a/arc-script/arc-script-test/compile/src/snapshots/ast@unit_enum.arc.snap
+++ b/arc-script/arc-script-test/compile/src/snapshots/ast@unit_enum.arc.snap
@@ -1,0 +1,16 @@
+---
+source: arc-script-test/compile/src/insta.rs
+expression: s
+input_file: arc-script-test/compile/src/tests/expect_pass/unit_enum.arc
+
+---
+enum Foo { Bar(unit) }
+fun test() {
+    val x = Foo::Bar(unit);
+    if val Foo::Bar(y) = x {
+        y
+    } else {
+        unit
+    }
+}
+

--- a/arc-script/arc-script-test/compile/src/snapshots/ast@unit_fun.arc.snap
+++ b/arc-script/arc-script-test/compile/src/snapshots/ast@unit_fun.arc.snap
@@ -1,0 +1,13 @@
+---
+source: arc-script-test/compile/src/insta.rs
+expression: s
+input_file: arc-script-test/compile/src/tests/expect_pass/unit_fun.arc
+
+---
+fun foo(x: unit): unit {
+    x
+}
+fun bar() {
+    foo(unit)
+}
+

--- a/arc-script/arc-script-test/compile/src/snapshots/hir@unit_enum.arc.snap
+++ b/arc-script/arc-script-test/compile/src/snapshots/hir@unit_enum.arc.snap
@@ -1,0 +1,28 @@
+---
+source: arc-script-test/compile/src/insta.rs
+expression: s
+input_file: arc-script-test/compile/src/tests/expect_pass/unit_enum.arc
+
+---
+enum Foo {
+    Bar
+}
+fun x_5(): unit {
+    val x_4: unit = unit;
+    x_4
+}
+fun test(): unit {
+    val x_0: unit = unit;
+    val x_1: crate::Foo = enwrap[crate::Foo::Bar](x_0);
+    val x_2: bool = is[x_1](x_1);
+    val x_8: unit = if x_2 {
+        val x_3: unit = unwrap[crate::Foo::Bar](x_1);
+        x_3
+    } else {
+        val x_6: fun(): unit = crate::x_5;
+        val x_7: unit = x_6();
+        x_7
+    };
+    x_8
+}
+

--- a/arc-script/arc-script-test/compile/src/snapshots/hir@unit_fun.arc.snap
+++ b/arc-script/arc-script-test/compile/src/snapshots/hir@unit_fun.arc.snap
@@ -1,0 +1,16 @@
+---
+source: arc-script-test/compile/src/insta.rs
+expression: s
+input_file: arc-script-test/compile/src/tests/expect_pass/unit_fun.arc
+
+---
+fun foo(x_0: unit): unit {
+    x_0
+}
+fun bar(): unit {
+    val x_1: fun(unit): unit = crate::foo;
+    val x_2: unit = unit;
+    val x_3: unit = x_1(x_2);
+    x_3
+}
+

--- a/arc-script/arc-script-test/compile/src/snapshots/mlir@binops.arc.snap
+++ b/arc-script/arc-script-test/compile/src/snapshots/mlir@binops.arc.snap
@@ -168,7 +168,7 @@ module @toplevel {
         %x___Z = arc.xor %x_8, %x_8 : ui64
         %x___a = math.powf %x_9, %x_J : f32
         %x___b = math.powf %x_A, %x_K : f64
-        // No value
+        // noop
         return
     }
 }

--- a/arc-script/arc-script-test/compile/src/snapshots/mlir@enum_pattern.arc.snap
+++ b/arc-script/arc-script-test/compile/src/snapshots/mlir@enum_pattern.arc.snap
@@ -6,20 +6,20 @@ input_file: arc-script-test/compile/src/tests/expect_pass/enum_pattern.arc
 ---
 module @toplevel {
     func @crate_x_6() -> () {
-        // No value
+        // noop
         return
     }
 
     func @crate_main() -> () {
         %x_0 = arc.constant 5 : si32
-        %x_1 = arc.make_enum (%x_0 : si32) as "crate_Opt_Some" :  !arc.enum<crate_Opt_Some : si32, crate_Opt_None : none>
-        %x_2 = arc.enum_check (%x_1 : !arc.enum<crate_Opt_Some : si32, crate_Opt_None : none>) is "crate_Opt_Some" :  i1
+        %x_1 = arc.make_enum (%x_0 : si32) as "crate_Opt_Some" : !arc.enum<crate_Opt_Some : si32, crate_Opt_None : none>
+        %x_2 = arc.enum_check (%x_1 : !arc.enum<crate_Opt_Some : si32, crate_Opt_None : none>) is "crate_Opt_Some" : i1
         "arc.if"(%x_2) ({
-            %x_3 = arc.enum_access "crate_Opt_Some" in (%x_1 : !arc.enum<crate_Opt_Some : si32, crate_Opt_None : none>) :  si32
-            // No value
+            %x_3 = arc.enum_access "crate_Opt_Some" in (%x_1 : !arc.enum<crate_Opt_Some : si32, crate_Opt_None : none>) : si32
+            // noop
             "arc.block.result"() : () -> ()
         },{
-            %x_7 = constant @crate_x_6 : () -> none
+            %x_7 = constant @crate_x_6 : () -> ()
             call_indirect %x_7() : () -> ()
             "arc.block.result"() : () -> ()
         }) : (i1) -> ()

--- a/arc-script/arc-script-test/compile/src/snapshots/mlir@enum_pattern_nested.arc.snap
+++ b/arc-script/arc-script-test/compile/src/snapshots/mlir@enum_pattern_nested.arc.snap
@@ -6,30 +6,30 @@ input_file: arc-script-test/compile/src/tests/expect_pass/enum_pattern_nested.ar
 ---
 module @toplevel {
     func @crate_x_9() -> () {
-        // No value
+        // noop
         return
     }
 
     func @crate_main() -> () {
         %x_0 = arc.constant 5 : si32
-        %x_1 = arc.make_enum (%x_0 : si32) as "crate_Baz_Some" :  !arc.enum<crate_Baz_Some : si32, crate_Baz_None : none>
-        %x_2 = arc.make_enum (%x_1 : !arc.enum<crate_Baz_Some : si32, crate_Baz_None : none>) as "crate_Foo_Bar" :  !arc.enum<crate_Foo_Bar : !arc.enum<crate_Baz_Some : si32, crate_Baz_None : none>, crate_Foo_None : none>
-        %x_3 = arc.enum_check (%x_2 : !arc.enum<crate_Foo_Bar : !arc.enum<crate_Baz_Some : si32, crate_Baz_None : none>, crate_Foo_None : none>) is "crate_Foo_Bar" :  i1
+        %x_1 = arc.make_enum (%x_0 : si32) as "crate_Baz_Some" : !arc.enum<crate_Baz_Some : si32, crate_Baz_None : none>
+        %x_2 = arc.make_enum (%x_1 : !arc.enum<crate_Baz_Some : si32, crate_Baz_None : none>) as "crate_Foo_Bar" : !arc.enum<crate_Foo_Bar : !arc.enum<crate_Baz_Some : si32, crate_Baz_None : none>, crate_Foo_None : none>
+        %x_3 = arc.enum_check (%x_2 : !arc.enum<crate_Foo_Bar : !arc.enum<crate_Baz_Some : si32, crate_Baz_None : none>, crate_Foo_None : none>) is "crate_Foo_Bar" : i1
         "arc.if"(%x_3) ({
-            %x_4 = arc.enum_access "crate_Foo_Bar" in (%x_2 : !arc.enum<crate_Foo_Bar : !arc.enum<crate_Baz_Some : si32, crate_Baz_None : none>, crate_Foo_None : none>) :  !arc.enum<crate_Baz_Some : si32, crate_Baz_None : none>
-            %x_5 = arc.enum_check (%x_4 : !arc.enum<crate_Baz_Some : si32, crate_Baz_None : none>) is "crate_Baz_Some" :  i1
+            %x_4 = arc.enum_access "crate_Foo_Bar" in (%x_2 : !arc.enum<crate_Foo_Bar : !arc.enum<crate_Baz_Some : si32, crate_Baz_None : none>, crate_Foo_None : none>) : !arc.enum<crate_Baz_Some : si32, crate_Baz_None : none>
+            %x_5 = arc.enum_check (%x_4 : !arc.enum<crate_Baz_Some : si32, crate_Baz_None : none>) is "crate_Baz_Some" : i1
             "arc.if"(%x_5) ({
-                %x_6 = arc.enum_access "crate_Baz_Some" in (%x_4 : !arc.enum<crate_Baz_Some : si32, crate_Baz_None : none>) :  si32
-                // No value
+                %x_6 = arc.enum_access "crate_Baz_Some" in (%x_4 : !arc.enum<crate_Baz_Some : si32, crate_Baz_None : none>) : si32
+                // noop
                 "arc.block.result"() : () -> ()
             },{
-                %x_A = constant @crate_x_9 : () -> none
+                %x_A = constant @crate_x_9 : () -> ()
                 call_indirect %x_A() : () -> ()
                 "arc.block.result"() : () -> ()
             }) : (i1) -> ()
             "arc.block.result"() : () -> ()
         },{
-            %x_A = constant @crate_x_9 : () -> none
+            %x_A = constant @crate_x_9 : () -> ()
             call_indirect %x_A() : () -> ()
             "arc.block.result"() : () -> ()
         }) : (i1) -> ()

--- a/arc-script/arc-script-test/compile/src/snapshots/mlir@enums.arc.snap
+++ b/arc-script/arc-script-test/compile/src/snapshots/mlir@enums.arc.snap
@@ -8,11 +8,11 @@ module @toplevel {
     func @crate_main() -> () {
         %x_0 = arc.constant 200 : ui32
         %x_1 = constant 2.0 : f32
-        %x_2 = arc.make_enum (%x_0 : ui32) as "crate_Foo_Bar" :  !arc.enum<crate_Foo_Bar : ui32, crate_Foo_Baz : f32>
-        %x_3 = arc.enum_access "crate_Foo_Bar" in (%x_2 : !arc.enum<crate_Foo_Bar : ui32, crate_Foo_Baz : f32>) :  ui32
-        %x_4 = arc.make_enum (%x_1 : f32) as "crate_Foo_Baz" :  !arc.enum<crate_Foo_Bar : ui32, crate_Foo_Baz : f32>
-        %x_5 = arc.enum_check (%x_4 : !arc.enum<crate_Foo_Bar : ui32, crate_Foo_Baz : f32>) is "crate_Foo_Baz" :  i1
-        // No value
+        %x_2 = arc.make_enum (%x_0 : ui32) as "crate_Foo_Bar" : !arc.enum<crate_Foo_Bar : ui32, crate_Foo_Baz : f32>
+        %x_3 = arc.enum_access "crate_Foo_Bar" in (%x_2 : !arc.enum<crate_Foo_Bar : ui32, crate_Foo_Baz : f32>) : ui32
+        %x_4 = arc.make_enum (%x_1 : f32) as "crate_Foo_Baz" : !arc.enum<crate_Foo_Bar : ui32, crate_Foo_Baz : f32>
+        %x_5 = arc.enum_check (%x_4 : !arc.enum<crate_Foo_Bar : ui32, crate_Foo_Baz : f32>) is "crate_Foo_Baz" : i1
+        // noop
         return
     }
 }

--- a/arc-script/arc-script-test/compile/src/snapshots/mlir@ifs.arc.snap
+++ b/arc-script/arc-script-test/compile/src/snapshots/mlir@ifs.arc.snap
@@ -6,7 +6,7 @@ input_file: arc-script-test/compile/src/tests/expect_pass/ifs.arc
 ---
 module @toplevel {
     func @crate_main() -> () {
-        // No value
+        // noop
         return
     }
 

--- a/arc-script/arc-script-test/compile/src/snapshots/mlir@literals.arc.snap
+++ b/arc-script/arc-script-test/compile/src/snapshots/mlir@literals.arc.snap
@@ -28,7 +28,7 @@ module @toplevel {
         %x_J = constant -1.7976931348623157e308 : f64
         %x_K = constant true
         %x_L = constant false
-        // No value
+        // noop
         return
     }
 }

--- a/arc-script/arc-script-test/compile/src/snapshots/mlir@option.arc.snap
+++ b/arc-script/arc-script-test/compile/src/snapshots/mlir@option.arc.snap
@@ -6,20 +6,20 @@ input_file: arc-script-test/compile/src/tests/expect_pass/option.arc
 ---
 module @toplevel {
     func @crate_x_6() -> () {
-        // No value
+        // noop
         return
     }
 
     func @crate_main() -> () {
         %x_0 = arc.constant 3 : si32
-        %x_1 = arc.make_enum (%x_0 : si32) as "crate_Opt_Some" :  !arc.enum<crate_Opt_Some : si32, crate_Opt_None : none>
-        %x_2 = arc.enum_check (%x_1 : !arc.enum<crate_Opt_Some : si32, crate_Opt_None : none>) is "crate_Opt_Some" :  i1
+        %x_1 = arc.make_enum (%x_0 : si32) as "crate_Opt_Some" : !arc.enum<crate_Opt_Some : si32, crate_Opt_None : none>
+        %x_2 = arc.enum_check (%x_1 : !arc.enum<crate_Opt_Some : si32, crate_Opt_None : none>) is "crate_Opt_Some" : i1
         "arc.if"(%x_2) ({
-            %x_3 = arc.enum_access "crate_Opt_Some" in (%x_1 : !arc.enum<crate_Opt_Some : si32, crate_Opt_None : none>) :  si32
-            // No value
+            %x_3 = arc.enum_access "crate_Opt_Some" in (%x_1 : !arc.enum<crate_Opt_Some : si32, crate_Opt_None : none>) : si32
+            // noop
             "arc.block.result"() : () -> ()
         },{
-            %x_7 = constant @crate_x_6 : () -> none
+            %x_7 = constant @crate_x_6 : () -> ()
             call_indirect %x_7() : () -> ()
             "arc.block.result"() : () -> ()
         }) : (i1) -> ()

--- a/arc-script/arc-script-test/compile/src/snapshots/mlir@path.arc.snap
+++ b/arc-script/arc-script-test/compile/src/snapshots/mlir@path.arc.snap
@@ -7,7 +7,7 @@ input_file: arc-script-test/compile/src/tests/expect_pass/path.arc
 module @toplevel {
     func @crate_main() -> () {
         %x_0 = arc.constant 1 : si32
-        // No value
+        // noop
         return
     }
 }

--- a/arc-script/arc-script-test/compile/src/snapshots/mlir@pattern.arc.snap
+++ b/arc-script/arc-script-test/compile/src/snapshots/mlir@pattern.arc.snap
@@ -19,7 +19,7 @@ module @toplevel {
         %x_A = "arc.index_tuple"(%x_6) { index = 1 } : (tuple<tuple<si32, si32>, tuple<si32, si32>>) -> tuple<si32, si32>
         %x_B = "arc.index_tuple"(%x_A) { index = 0 } : (tuple<si32, si32>) -> si32
         %x_C = "arc.index_tuple"(%x_A) { index = 1 } : (tuple<si32, si32>) -> si32
-        // No value
+        // noop
         return
     }
 }

--- a/arc-script/arc-script-test/compile/src/snapshots/mlir@structs.arc.snap
+++ b/arc-script/arc-script-test/compile/src/snapshots/mlir@structs.arc.snap
@@ -20,7 +20,7 @@ module @toplevel {
         %x_7 = arc.constant 2 : si32
         %x_8 = arc.make_struct(%x_6, %x_7 : si32, si32) : !arc.struct<b: si32, c: si32>
         %x_9 = call_indirect %x_2(%x_5, %x_8) : (!arc.struct<b: si32, c: si32>, !arc.struct<b: si32, c: si32>) -> !arc.struct<a: !arc.struct<b: si32, c: si32>, d: !arc.struct<b: si32, c: si32>, xyz: si32>
-        // No value
+        // noop
         return
     }
 }

--- a/arc-script/arc-script-test/compile/src/snapshots/mlir@unit_enum.arc.snap
+++ b/arc-script/arc-script-test/compile/src/snapshots/mlir@unit_enum.arc.snap
@@ -1,0 +1,28 @@
+---
+source: arc-script-test/compile/src/insta.rs
+expression: s
+input_file: arc-script-test/compile/src/tests/expect_pass/unit_enum.arc
+
+---
+module @toplevel {
+    func @crate_x_5() -> () {
+        // noop
+        return
+    }
+
+    func @crate_test() -> () {
+        // noop
+        %x_1 = arc.make_enum () as "crate_Foo_Bar" : !arc.enum<crate_Foo_Bar : none>
+        %x_2 = arc.enum_check (%x_1 : !arc.enum<crate_Foo_Bar : none>) is "crate_Foo_Bar" : i1
+        "arc.if"(%x_2) ({
+            arc.enum_access "crate_Foo_Bar" in (%x_1 : !arc.enum<crate_Foo_Bar : none>) : none
+            "arc.block.result"() : () -> ()
+        },{
+            %x_6 = constant @crate_x_5 : () -> ()
+            call_indirect %x_6() : () -> ()
+            "arc.block.result"() : () -> ()
+        }) : (i1) -> ()
+        return
+    }
+}
+

--- a/arc-script/arc-script-test/compile/src/snapshots/mlir@unit_fun.arc.snap
+++ b/arc-script/arc-script-test/compile/src/snapshots/mlir@unit_fun.arc.snap
@@ -1,0 +1,19 @@
+---
+source: arc-script-test/compile/src/insta.rs
+expression: s
+input_file: arc-script-test/compile/src/tests/expect_pass/unit_fun.arc
+
+---
+module @toplevel {
+    func @crate_foo() -> () {
+        return
+    }
+
+    func @crate_bar() -> () {
+        %x_1 = constant @crate_foo : () -> ()
+        // noop
+        call_indirect %x_1() : () -> ()
+        return
+    }
+}
+

--- a/arc-script/arc-script-test/compile/src/snapshots/rust@unit_enum.arc.snap
+++ b/arc-script/arc-script-test/compile/src/snapshots/rust@unit_enum.arc.snap
@@ -1,0 +1,46 @@
+---
+source: arc-script-test/compile/src/insta.rs
+expression: s
+input_file: arc-script-test/compile/src/tests/expect_pass/unit_enum.arc
+
+---
+#[allow(non_snake_case)]
+#[allow(unused_must_use)]
+#[allow(dead_code)]
+#[allow(unused_variables)]
+#[allow(unused_imports)]
+#[allow(unused_braces)]
+#[allow(irrefutable_let_patterns)]
+#[allow(clippy::redundant_field_names)]
+#[allow(clippy::unused_unit)]
+#[allow(clippy::double_parens)]
+pub mod arc_script_output {
+    use super::*;
+    use arc_script::arcorn;
+    #[arcorn::rewrite]
+    pub enum Foo {
+        Foo_Bar(()),
+    }
+    pub fn x_5() -> () {
+        let x_4: () = ();
+        (x_4.clone())
+    }
+    pub fn test() -> () {
+        let x_0: () = ();
+        let x_1: Foo = arcorn::enwrap!(Foo_Bar, (x_0.clone()));
+        let x_2: bool = arcorn::is!(Foo_Bar, (x_1.clone()));
+        let x_8: () = if (x_2.clone()) {
+            let x_3: () = arcorn::unwrap!(Foo_Bar, (x_1.clone()));
+            (x_3.clone())
+        } else {
+            let x_6: Box<dyn arcorn::ArcornFn() -> ()> =
+                Box::new(x_5) as Box<dyn arcorn::ArcornFn() -> ()>;
+            let x_7: () = (x_6.clone())();
+            (x_7.clone())
+        };
+        (x_8.clone())
+    }
+}
+pub use arc_script_output::*;
+
+

--- a/arc-script/arc-script-test/compile/src/snapshots/rust@unit_fun.arc.snap
+++ b/arc-script/arc-script-test/compile/src/snapshots/rust@unit_fun.arc.snap
@@ -1,0 +1,33 @@
+---
+source: arc-script-test/compile/src/insta.rs
+expression: s
+input_file: arc-script-test/compile/src/tests/expect_pass/unit_fun.arc
+
+---
+#[allow(non_snake_case)]
+#[allow(unused_must_use)]
+#[allow(dead_code)]
+#[allow(unused_variables)]
+#[allow(unused_imports)]
+#[allow(unused_braces)]
+#[allow(irrefutable_let_patterns)]
+#[allow(clippy::redundant_field_names)]
+#[allow(clippy::unused_unit)]
+#[allow(clippy::double_parens)]
+pub mod arc_script_output {
+    use super::*;
+    use arc_script::arcorn;
+    pub fn foo(x_0: ()) -> () {
+        (x_0.clone())
+    }
+    pub fn bar() -> () {
+        let x_1: Box<dyn arcorn::ArcornFn(()) -> ()> =
+            Box::new(foo) as Box<dyn arcorn::ArcornFn(()) -> ()>;
+        let x_2: () = ();
+        let x_3: () = (x_1.clone())((x_2.clone()));
+        (x_3.clone())
+    }
+}
+pub use arc_script_output::*;
+
+

--- a/arc-script/arc-script-test/compile/src/tests/expect_pass/enum_pattern.arc
+++ b/arc-script/arc-script-test/compile/src/tests/expect_pass/enum_pattern.arc
@@ -1,4 +1,3 @@
-# XFAIL: *
 # RUN: arc-script run --output=MLIR %s | arc-mlir
 
 enum Opt {

--- a/arc-script/arc-script-test/compile/src/tests/expect_pass/enum_pattern_nested.arc
+++ b/arc-script/arc-script-test/compile/src/tests/expect_pass/enum_pattern_nested.arc
@@ -1,4 +1,3 @@
-# XFAIL: *
 # RUN: arc-script run --output=MLIR %s | arc-mlir
 
 enum Baz {

--- a/arc-script/arc-script-test/compile/src/tests/expect_pass/option.arc
+++ b/arc-script/arc-script-test/compile/src/tests/expect_pass/option.arc
@@ -1,4 +1,3 @@
-# XFAIL: *
 # RUN: arc-script run --output=MLIR %s | arc-mlir
 
 enum Opt {

--- a/arc-script/arc-script-test/compile/src/tests/expect_pass/unit_enum.arc
+++ b/arc-script/arc-script-test/compile/src/tests/expect_pass/unit_enum.arc
@@ -1,0 +1,14 @@
+# RUN: arc-script run --output=MLIR %s | arc-mlir
+
+enum Foo {
+    Bar(unit)
+}
+
+fun test() {
+    val x = Foo::Bar(unit);
+    if val Foo::Bar(y) = x {
+        y
+    } else {
+        unit
+    }
+}

--- a/arc-script/arc-script-test/compile/src/tests/expect_pass/unit_fun.arc
+++ b/arc-script/arc-script-test/compile/src/tests/expect_pass/unit_fun.arc
@@ -1,0 +1,9 @@
+# RUN: arc-script run --output=MLIR %s | arc-mlir
+
+fun foo(x: unit): unit {
+    x
+}
+
+fun bar() {
+    foo(unit)
+}

--- a/arc-script/arc-script-test/compile/src/tests/mod.rs
+++ b/arc-script/arc-script-test/compile/src/tests/mod.rs
@@ -25,6 +25,7 @@ mod expect_pass {
     test!(t16, "src/tests/expect_pass/structs.rs");
     test!(t17, "src/tests/expect_pass/basic_by.rs");
     test!(t18, "src/tests/expect_pass/sort_fields.rs");
+//     test!(t19, "src/tests/expect_pass/unit_fun.rs");
 }
 
 mod expect_mlir_fail_todo {


### PR DESCRIPTION
MLIR does not like unit types and therefore this commit rewrites all `unit`
types and values into the `void` type (i.e., `()`). If a function takes
parameters which are `unit`, those parameters are also removed.