### PR TITLE
LLVM submodule update

### DIFF
--- a/arc-mlir/src/tests/ops/bad-enums.mlir
+++ b/arc-mlir/src/tests/ops/bad-enums.mlir
@@ -4,7 +4,7 @@ module @toplevel {
   func @bad() -> !arc.enum<a : i32, b : f32> {
     %a = constant 4 : i32
     // expected-error@+2 {{'arc.make_enum' op : variant 'c' does not exist in '!arc.enum<a : i32, b : f32>'}}
-    // expected-note@+1 {{see current operation: %0 = "arc.make_enum"(%c4_i32) {variant = "c"} : (i32) -> !arc.enum<a : i32, b : f32>}}
+    // expected-note@+1 {{see current operation:}}
     %r = arc.make_enum (%a : i32) as "c" : !arc.enum<a : i32, b : f32>
     return %r : !arc.enum<a : i32, b : f32>
   }
@@ -16,7 +16,7 @@ module @toplevel {
   func @bad() -> !arc.enum<a : i32, b : f32> {
     %a = constant 3.14 : f32
     // expected-error@+2 {{'arc.make_enum' op : variant 'a' does not have a matching type, expected 'f32' but found 'i32'}}
-    // expected-note@+1 {{see current operation: %0 = "arc.make_enum"(%cst) {variant = "a"} : (f32) -> !arc.enum<a : i32, b : f32>}}
+    // expected-note@+1 {{see current operation:}}
     %r = arc.make_enum (%a : f32) as "a" : !arc.enum<a : i32, b : f32>
     return %r : !arc.enum<a : i32, b : f32>
   }
@@ -27,7 +27,7 @@ module @toplevel {
 module @toplevel {
   func @access0(%e : !arc.enum<a : i32, b : f32>) -> i32 {
     // expected-error@+2 {{'arc.enum_access' op : variant 'b' does not have a matching type, expected 'i32' but found 'f32'}}
-    // expected-note@+1 {{see current operation: %0 = "arc.enum_access"(%arg0) {variant = "b"} : (!arc.enum<a : i32, b : f32>) -> i32}}
+    // expected-note@+1 {{see current operation:}}
     %r = arc.enum_access "b" in (%e : !arc.enum<a : i32, b : f32>) : i32
     return %r : i32
   }
@@ -38,7 +38,7 @@ module @toplevel {
 module @toplevel {
   func @access0(%e : !arc.enum<a : i32, b : f32>) -> i32 {
     // expected-error@+2 {{'arc.enum_access' op : variant 'c' does not exist in '!arc.enum<a : i32, b : f32>'}}
-    // expected-note@+1 {{see current operation: %0 = "arc.enum_access"(%arg0) {variant = "c"} : (!arc.enum<a : i32, b : f32>) -> i32}}
+    // expected-note@+1 {{see current operation:}}
     %r = arc.enum_access "c" in (%e : !arc.enum<a : i32, b : f32>) : i32
     return %r : i32
   }
@@ -49,7 +49,7 @@ module @toplevel {
 module @toplevel {
   func @check2(%e : !arc.enum<a : i32, b : f32>) -> i1 {
     // expected-error@+2 {{'arc.enum_check' op : variant 'c' does not exist in '!arc.enum<a : i32, b : f32>'}}
-    // expected-note@+1 {{see current operation: %0 = "arc.enum_check"(%arg0) {variant = "c"} : (!arc.enum<a : i32, b : f32>) -> i1}}
+    // expected-note@+1 {{see current operation:}}
     %r = arc.enum_check (%e : !arc.enum<a : i32, b : f32>) is "c" : i1
     return %r : i1
   }

--- a/arc-mlir/src/tests/ops/bad-structs.mlir
+++ b/arc-mlir/src/tests/ops/bad-structs.mlir
@@ -17,7 +17,7 @@ module @toplevel {
     %a = constant 4 : i32
     %b = constant 3.14 : f32
     // expected-error@+2 {{'arc.make_struct' op expected 2 fields, but found 1}}
-    // expected-note@+1 {{see current operation: %0 = "arc.make_struct"(%c4_i32) : (i32) -> !arc.struct<a : i32, b : f32>}}
+    // expected-note@+1 {{see current operation:}}
     %r = arc.make_struct(%a : i32) : !arc.struct<a : i32, b : f32>
     return %r : !arc.struct<a : i32, b : f32>
   }
@@ -31,7 +31,7 @@ module @toplevel {
     %b = constant 3.14 : f32
     %c = constant 47.11 : f64
     // expected-error@+2 {{'arc.make_struct' op expected 2 fields, but found 3}}
-    // expected-note@+1 {{see current operation: %0 = "arc.make_struct"(%c4_i32, %cst, %cst_0) : (i32, f32, f64) -> !arc.struct<a : i32, b : f32>}}
+    // expected-note@+1 {{see current operation:}}
     %r = arc.make_struct(%a, %b, %c: i32, f32, f64) : !arc.struct<a : i32, b : f32>
     return %r : !arc.struct<a : i32, b : f32>
   }

--- a/arc-mlir/src/tests/ops/if.mlir
+++ b/arc-mlir/src/tests/ops/if.mlir
@@ -25,7 +25,7 @@ module @toplevel {
     %f = constant 3.14 : f64
 
     // expected-error@+2 {{'arc.block.result' op expects parent op 'arc.if'}}
-    // expected-note@+1 {{see current operation: "arc.block.result"}}
+    // expected-note@+1 {{see current operation:}}
     "arc.block.result"(%f) : (f64) -> ()
     return
   }
@@ -71,7 +71,7 @@ module @toplevel {
     %b = constant 3.14 : f32
     %c = constant 0.693 : f64
     // expected-error@+2 {{'arc.if' op expected 2 regions}}
-    // expected-note@+1 {{see current operation: %0 = "arc.if"}}
+    // expected-note@+1 {{see current operation:}}
     "arc.if"(%a) ({}) : (i1) -> f64
     return
   }
@@ -85,7 +85,7 @@ module @toplevel {
     %b = constant 3.14 : f32
     %c = constant 0.693 : f64
     // expected-error@+2 {{'arc.if' op expected 2 regions}}
-    // expected-note@+1 {{see current operation: %0 = "arc.if"}}
+    // expected-note@+1 {{see current operation:}}
     "arc.if"(%a) ({},{},{}) : (i1) -> f64
     return
   }
@@ -99,7 +99,7 @@ module @toplevel {
     %b = constant 3.14 : f32
     %c = constant 0.693 : f64
     // expected-error@+2 {{'arc.if' op region #0 ('thenRegion') failed to verify constraint: region with 1 blocks}}
-    // expected-note@+1 {{see current operation: %0 = "arc.if"}}
+    // expected-note@+1 {{see current operation:}}
     "arc.if"(%a) ({},{}) : (i1) -> f64
     return
   }
@@ -113,7 +113,7 @@ module @toplevel {
     %b = constant 3.14 : f64
     %c = constant 0.693 : f64
     // expected-error@+2 {{'arc.if' op region #1 ('elseRegion') failed to verify constraint: region with 1 blocks}}
-    // expected-note@+1 {{see current operation: %0 = "arc.if"}}
+    // expected-note@+1 {{see current operation:}}
     "arc.if"(%a) ({
       "arc.block.result"(%b) : (f64) -> ()
     },{}) : (i1) -> f64
@@ -131,7 +131,7 @@ module @toplevel {
 
     // expected-error@+3 {{'arc.if' op expects regions to end with 'arc.block.result', found 'arc.make_tuple'}}
     // expected-note@+2 {{in custom textual format, the absence of terminator implies 'arc.block.result'}}
-    // expected-note@+1 {{see current operation: %0 = "arc.if"}}
+    // expected-note@+1 {{see current operation:}}
     "arc.if"(%a) ( {
       "arc.block.result"(%b) : (f64) -> ()
       %1 = "arc.make_tuple"(%c, %c) : (f64, f64) -> tuple<f64,f64>

--- a/arc-mlir/src/tests/ops/make_appender.mlir
+++ b/arc-mlir/src/tests/ops/make_appender.mlir
@@ -17,7 +17,7 @@ module @toplevel {
     %v = constant 0 : i32
 
     // expected-error@+2 {{'arc.make_appender' op requires zero operands}}
-    // expected-note@+1 {{see current operation: %0 = "arc.make_appender"}}
+    // expected-note@+1 {{see current operation:}}
     %0 = "arc.make_appender"(%v) : (i32) -> !arc.appender<i32>
 
     %r = "arc.result"(%0) : (!arc.appender<i32>) -> tensor<i32>

--- a/arc-mlir/src/tests/ops/make_tuple.mlir
+++ b/arc-mlir/src/tests/ops/make_tuple.mlir
@@ -20,7 +20,7 @@ module @toplevel {
     %a = constant 0 : i1
     %b = constant 1 : i1
     // expected-error@+2 {{'arc.make_tuple' op operand types do not match: expected 'f32' but found 'i1'}}
-    // expected-note@+1 {{see current operation: %0 = "arc.make_tuple"}}
+    // expected-note@+1 {{see current operation:}}
     %1 = "arc.make_tuple"(%a, %b) : (i1, i1) -> tuple<i1,f32>
     return
   }
@@ -45,7 +45,7 @@ module @toplevel {
     %a = constant 0 : i1
     %b = constant 1 : i1
     // expected-error@+2 {{'arc.make_tuple' op result does not match the number of operands: expected 1 but found 2 operands}}
-    // expected-note@+1 {{see current operation: %0 = "arc.make_tuple"}}
+    // expected-note@+1 {{see current operation:}}
     %1 = "arc.make_tuple"(%a, %b) : (i1, i1) -> tuple<i1>
     return
   }
@@ -56,7 +56,7 @@ module @toplevel {
 module @toplevel {
   func @main() {
     // expected-error@+2 {{'arc.make_tuple' op tuple must contain at least one element}}
-    // expected-note@+1 {{see current operation: %0 = "arc.make_tuple"}}
+    // expected-note@+1 {{see current operation:}}
     %1 = "arc.make_tuple"() : () -> tuple<>
     return
   }

--- a/arc-mlir/src/tests/ops/make_vector.mlir
+++ b/arc-mlir/src/tests/ops/make_vector.mlir
@@ -22,7 +22,7 @@ module @toplevel {
     %d = constant 0 : i1
 
     // expected-error@+2 {{'arc.make_vector' op requires the same element type for all operands and results}}
-    // expected-note@+1 {{see current operation: %0 = "arc.make_vector"}}
+    // expected-note@+1 {{see current operation:}}
     %1 = "arc.make_vector"(%b, %b, %c, %d) : (i1, i1, i1, i1) -> tuple<i1,i1,i1,i1>
     return
   }
@@ -37,7 +37,7 @@ module @toplevel {
     %d = constant 0 : i1
 
     // expected-error@+2 {{'arc.make_vector' op requires the same element type for all operands and results}}
-    // expected-note@+1 {{see current operation: %0 = "arc.make_vector"}}
+    // expected-note@+1 {{see current operation:}}
     %1 = "arc.make_vector"(%b, %b, %c, %d) : (i1, i1, i1, i1) -> tensor<f32>
     return
   }
@@ -52,7 +52,7 @@ module @toplevel {
     %d = constant 0 : i1
 
     // expected-error@+2 {{'arc.make_vector' op result #0 must be 1D tensor of any type values, but got 'tensor<4x4xi1>'}}
-    // expected-note@+1 {{see current operation: %0 = "arc.make_vector"}}
+    // expected-note@+1 {{see current operation:}}
     %1 = "arc.make_vector"(%b, %b, %c, %d) : (i1, i1, i1, i1) -> tensor<4x4xi1>
     return
   }
@@ -67,7 +67,7 @@ module @toplevel {
     %d = constant 0 : i1
 
     // expected-error@+2 {{'arc.make_vector' op result must have static shape: expected 'tensor<4xi1>'}}
-    // expected-note@+1 {{see current operation: %0 = "arc.make_vector"}}
+    // expected-note@+1 {{see current operation:}}
     %1 = "arc.make_vector"(%b, %b, %c, %d) : (i1, i1, i1, i1) -> tensor<?xi1>
     return
   }
@@ -82,7 +82,7 @@ module @toplevel {
     %d = constant 0 : i1
 
     // expected-error@+2 {{'arc.make_vector' op result does not match the number of operands: expected 5 but found 4 operands}}
-    // expected-note@+1 {{see current operation: %0 = "arc.make_vector"}}
+    // expected-note@+1 {{see current operation:}}
     %1 = "arc.make_vector"(%b, %b, %c, %d) : (i1, i1, i1, i1) -> tensor<5xi1>
     return
   }

--- a/arc-mlir/src/tests/ops/merge.mlir
+++ b/arc-mlir/src/tests/ops/merge.mlir
@@ -52,7 +52,7 @@ module @toplevel {
     %v2 = constant 5 : i32
 
     // expected-error@+2 {{'arc.make_appender' op failed to verify that result must have exactly one use}}
-    // expected-note@+1 {{see current operation: %0 = "arc.make_appender"}}
+    // expected-note@+1 {{see current operation:}}
     %0 = "arc.make_appender"() : () -> !arc.appender<i32>
 
     %1 = "arc.merge"(%0, %v1) : (!arc.appender<i32>, i32) -> !arc.appender<i32>


### PR DESCRIPTION
Changes needed:

  * Upstream updates change the numbering of the variables used in
    error notes, so just check for any note at the expected line.