### PR TITLE
mlir-rust: Correct Rust output for unit valued enum variants

### DIFF
--- a/arc-mlir/src/tests/arc-to-rust/enums.mlir
+++ b/arc-mlir/src/tests/arc-to-rust/enums.mlir
@@ -56,6 +56,11 @@ module @toplevel {
     return %r : f32
   }
 
+  func @access2(%e : !arc.enum<a : si32, b : f32, no_value : none>) -> none {
+    %r = arc.enum_access "no_value" in (%e : !arc.enum<a : si32, b : f32, no_value : none>) : none
+    return %r : none
+  }
+
   func @check0(%e : !arc.enum<a : si32, b : f32>) -> i1 {
     %r = arc.enum_check (%e : !arc.enum<a : si32, b : f32>) is "a" : i1
     return %r : i1


### PR DESCRIPTION
When the `unit` type is used to declare an enum variant it should be
written as `unit`, but when used as the type of a variable or the
return type of a function it should be `()`.