### PR TITLE
mlir: Verify that enum_access isn't used with none-typed variants

### DIFF
--- a/arc-mlir/src/lib/Arc/Dialect.cpp
+++ b/arc-mlir/src/lib/Arc/Dialect.cpp
@@ -253,11 +253,18 @@ LogicalResult EmitOp::customVerify() {
   return mlir::success();
 }
 
+//===----------------------------------------------------------------------===//
+// Enums
+//===----------------------------------------------------------------------===//
 LogicalResult EnumAccessOp::customVerify() {
   auto ResultTy = result().getType();
   auto SourceTy = value().getType().cast<EnumType>();
   auto VariantTys = SourceTy.getVariants();
   auto WantedVariant = variant();
+
+  if (ResultTy.isa<NoneType>())
+    return emitError(": accessing a ")
+           << ResultTy << "-typed variant does not make sense";
 
   // Check that the given type matches the specified variant.
   for (auto &i : VariantTys)

--- a/arc-mlir/src/tests/arc-to-rust/enums.mlir
+++ b/arc-mlir/src/tests/arc-to-rust/enums.mlir
@@ -56,11 +56,6 @@ module @toplevel {
     return %r : f32
   }
 
-  func @access2(%e : !arc.enum<a : si32, b : f32, no_value : none>) -> none {
-    %r = arc.enum_access "no_value" in (%e : !arc.enum<a : si32, b : f32, no_value : none>) : none
-    return %r : none
-  }
-
   func @check0(%e : !arc.enum<a : si32, b : f32>) -> i1 {
     %r = arc.enum_check (%e : !arc.enum<a : si32, b : f32>) is "a" : i1
     return %r : i1

--- a/arc-mlir/src/tests/ops/bad-enums.mlir
+++ b/arc-mlir/src/tests/ops/bad-enums.mlir
@@ -79,3 +79,12 @@ module @toplevel {
   }
 }
 
+// -----
+module @toplevel {
+   func @access2(%e : !arc.enum<a : si32, b : f32, no_value : none>) -> none {
+    // expected-error@+2 {{accessing a 'none'-typed variant does not make sense}}
+    // expected-note@+1 {{see current operation}}
+    %r = arc.enum_access "no_value" in (%e : !arc.enum<a : si32, b : f32, no_value : none>) : none
+    return %r : none
+  }
+}


### PR DESCRIPTION
Trying to retrieve the value of a none-typed variant does not make
sense, so let the verifier refuse such a constructs.