### PR TITLE
Catch and report panic messages

### DIFF
--- a/arc-script/arc-script-api/build/src/build.rs
+++ b/arc-script/arc-script-api/build/src/build.rs
@@ -166,7 +166,7 @@ impl Builder {
 }
 
 fn set_hook(msg: Arc<Mutex<String>>) {
-    std::panic::set_hook(Box::new(move |panic_info| {
+    std::panic::set_hook(Box::new(move |panic_info: &std::panic::PanicInfo<'_>| {
         let location = panic_info
             .location()
             .map(|location| format!(" in '{}' at line {}", location.file(), location.line()))
@@ -175,9 +175,14 @@ fn set_hook(msg: Arc<Mutex<String>>) {
         let payload = panic_info
             .payload()
             .downcast_ref::<&str>()
+            .map(|s| format!(" with payload '{}'", s))
+            .unwrap_or_else(String::new);
+
+        let message = panic_info
+            .message()
             .map(|s| format!("'{}'", s))
             .unwrap_or_else(String::new);
 
-        *msg.lock().unwrap() = format!("{}{}", payload, location);
+        *msg.lock().unwrap() = format!("{}{}{}", message, payload, location);
     }))
 }

--- a/arc-script/arc-script-api/build/src/lib.rs
+++ b/arc-script/arc-script-api/build/src/lib.rs
@@ -1,5 +1,6 @@
 //! Library for compiling arc-scripts inside `build.rs` files.
 
+#![feature(panic_info_message)]
 #![allow(unused)]
 
 mod build;


### PR DESCRIPTION
Catches and reports panic messages in addition to payload and location
whenever a panic occurs in the compiler.