### PR TITLE
build-system: End CI runs with a report on cache usage

### DIFF
--- a/.github/continuous-integration.sh
+++ b/.github/continuous-integration.sh
@@ -37,6 +37,8 @@ fi
 function check-ccache {
     echo "Ccache statistics:"
     ccache -s
+    echo "Cccache statistics:"
+    sccache --show-stats
 }
 
 function run-mlir-build {

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -86,6 +86,9 @@ jobs:
       env:
         A2M_BUILD: ${{ format('{0}/build', runner.temp) }}
 
+    - name: "Ccache/Sccache statistics"
+      run: ./.github/continuous-integration.sh check-ccache
+
 #    - name: "Run arc-script test: fmt -- -v --check"
 #      run: ./.github/continuous-integration.sh cargo fmt -- -v --check
 #      env:


### PR DESCRIPTION
Dump Sccache and Ccache statistics at the end of the CI run.