### PR TITLE
mlir: Don't forget to copy string terminator

### DIFF
--- a/arc-mlir/src/lib/Arc/LowerToRust.cpp
+++ b/arc-mlir/src/lib/Arc/LowerToRust.cpp
@@ -176,7 +176,7 @@ private:
     // string.
     for (size_t i = 0; hex[i] && hex[i] != '.'; i++) {
       if (hex[i] == 'p') {
-        memmove(hex + i + 1, hex + i, strlen(hex + i));
+        memmove(hex + i + 1, hex + i, strlen(hex + i) + 1);
         hex[i] = '.';
         break;
       }


### PR DESCRIPTION
We cannot assume that `hex` is initialized to zero, so copy the string
terminator too when moving the exponent.