### PR TITLE
build-system: Dump Rust output in arc-mlir-rust-test

### DIFF
--- a/arc-mlir/src/tools/arc-mlir-rust-test.in
+++ b/arc-mlir/src/tools/arc-mlir-rust-test.in
@@ -70,4 +70,7 @@ fn main() {
 }
 EOF
 
+echo 'Rust file:'
+cat "${MAIN}"
+
 exec arc-cargo test -j 1 --manifest-path=${WORK_DIR}/Cargo.toml


### PR DESCRIPTION
To help diagnose failing tests we dump the complete generated
Rust-code.