### PR TITLE
mlir-rust: Allow the name used for functions to be overridden

### DIFF
--- a/arc-mlir/src/lib/Arc/LowerToRust.cpp
+++ b/arc-mlir/src/lib/Arc/LowerToRust.cpp
@@ -891,6 +891,10 @@ struct FuncOpLowering : public ConversionPattern {
     mlir::FuncOp func = cast<mlir::FuncOp>(op);
     SmallVector<NamedAttribute, 4> attributes;
 
+    if (func->hasAttr("arc.rust_name"))
+      attributes.push_back(NamedAttribute(Identifier::get("arc.rust_name", ctx),
+                                          func->getAttr("arc.rust_name")));
+
     if (func->hasAttr("arc.task_name"))
       attributes.push_back(NamedAttribute(Identifier::get("arc.task_name", ctx),
                                           func->getAttr("arc.task_name")));

--- a/arc-mlir/src/tests/arc-to-rust/calls.mlir
+++ b/arc-mlir/src/tests/arc-to-rust/calls.mlir
@@ -137,4 +137,22 @@ module @toplevel {
         %x_A = call_indirect %x_9(%input_0) : (!arc.stream<!arc.struct<key: si32, value: si32>>) -> !arc.stream<!arc.struct<key: si32, value: si32>>
         return %x_A : !arc.stream<!arc.struct<key: si32, value: si32>>
     }
+
+  func private @an_external_fun_with_other_name0(si32) -> si32 attributes { "arc.rust_name" = "the_name_on_the_rust_side" }
+
+  func @call_external2(%in : si32) -> si32 {
+    %r = call @an_external_fun_with_other_name0(%in) : (si32) -> si32
+    return %r : si32
+  }
+
+  func private @a_function_called_something_else_in_rust(%in : si32) -> si32
+     attributes { "arc.rust_name" = "defined_in_arc" } {
+    return %in : si32
+  }
+
+  func @call_renamed_local(%in : si32) -> si32 {
+    %r = call @a_function_called_something_else_in_rust(%in) : (si32) -> si32
+    return %r : si32
+  }
+
 }

--- a/arc-mlir/src/tests/arc-to-rust/calls.mlir.rust-tests
+++ b/arc-mlir/src/tests/arc-to-rust/calls.mlir.rust-tests
@@ -19,6 +19,10 @@ pub fn crate_Identity() -> Box<dyn arcorn::ArcornFn(arcorn::Stream<Struct3keyi32
   return Box::new(an_external_fun2);
 }
 
+pub fn the_name_on_the_rust_side(i: i32) -> i32 {
+  return i;
+}
+
 #[cfg(test)]
 mod tests {
   use crate::toplevel::*;
@@ -26,5 +30,8 @@ mod tests {
   fn test() {
   assert_eq!(callee_si32_si32(17), 17);
   assert_eq!(caller1(4711), 4711);
+  assert_eq!(call_external2(13), 13);
+  assert_eq!(call_renamed_local(14), 14);
+  assert_eq!(defined_in_arc(15), 15);
   }
 }


### PR DESCRIPTION
The name used by a function in the generated Rust can be overridden by
setting the attribute `arc.rust_name` on the function.