### PR TITLE
mlir: Fix crash in verification of `arc.block.result`

### DIFF
--- a/arc-mlir/src/lib/Arc/Dialect.cpp
+++ b/arc-mlir/src/lib/Arc/Dialect.cpp
@@ -434,6 +434,14 @@ LogicalResult ArcBlockResultOp::customVerify() {
     return mlir::success();
   }
 
+  if (Parent->getNumResults() != Op->getNumOperands()) {
+    emitOpError(
+        "the number of values returned does not match parent: expected ")
+        << Parent->getNumResults() << " but found " << Op->getNumOperands()
+        << " values";
+    return mlir::failure();
+  }
+
   if (Op->getOperand(0).getType() != Parent->getResult(0).getType()) {
     emitOpError("result type does not match the type of the parent: expected ")
         << Parent->getResult(0).getType() << " but found "

--- a/arc-mlir/src/tests/ops/if.mlir
+++ b/arc-mlir/src/tests/ops/if.mlir
@@ -230,3 +230,20 @@ module @toplevel {
     return
   }
 }
+
+// -----
+
+module @toplevel {
+  func @main() {
+    %a = constant 0 : i1
+    %b = arc.constant 66 : ui64
+    "arc.if"(%a) ( {
+      "arc.block.result"(%b) : (ui64) -> ()
+    },  {
+      // expected-error@+2 {{'arc.block.result' op the number of values returned does not match parent: expected 1 but found 0 values}}
+      // expected-note@+1 {{see current operation}}
+      "arc.block.result"() : () -> ()
+    }) : (i1) -> ui64
+    return
+  }
+}


### PR DESCRIPTION
If the number of results of the parent `arc.if` did not match the
number of operands to `arc.block.result` the verifier would crash with
a segfault during type verification. The fix is to check that the
number of results match before trying to verify the types.