### PR TITLE
LLVM submodule update

### DIFF
--- a/arc-mlir/src/include/Rust/Rust.td
+++ b/arc-mlir/src/include/Rust/Rust.td
@@ -94,7 +94,8 @@ def RustCallOp : Rust_Op<"call", [CallOpInterface]> {
     }]>,
     OpBuilder<(ins "StringRef":$callee, "TypeRange":$results,
       CArg<"ValueRange", "{}">:$operands), [{
-      build($_builder, $_state, $_builder.getSymbolRefAttr(callee), results,
+      build($_builder, $_state,
+            SymbolRefAttr::get($_state.getContext(), callee), results,
             operands);
     }]>];
 

--- a/arc-mlir/src/lib/Arc/Dialect.cpp
+++ b/arc-mlir/src/lib/Arc/Dialect.cpp
@@ -146,7 +146,7 @@ static ParseResult parseConstantIntOp(OpAsmParser &parser,
 }
 
 static void print(arc::ConstantIntOp constOp, OpAsmPrinter &printer) {
-  printer << arc::ConstantIntOp::getOperationName() << ' ' << constOp.value();
+  printer << ' ' << constOp.value();
 }
 
 static LogicalResult verify(arc::ConstantIntOp constOp) {
@@ -725,8 +725,9 @@ OpFoldResult arc::XOrOp::fold(ArrayRef<Attribute> operands) {
 LogicalResult StateAppenderFoldOp::customVerify() {
   auto InitTy = init().getType();
   auto ResultTy = res().getType();
-  Operation *Callee =
-      ::mlir::SymbolTable::lookupNearestSymbolFrom(this->getOperation(), fun());
+  StringAttr funName = StringAttr::get(this->getContext(), fun());
+  Operation *Callee = ::mlir::SymbolTable::lookupNearestSymbolFrom(
+      this->getOperation(), funName);
   auto StateTy = state().getType().cast<ArconAppenderType>().getType();
 
   FuncOp F = dyn_cast<FuncOp>(Callee);
@@ -883,7 +884,7 @@ static void printArcBinaryOp(Operation *op, OpAsmPrinter &p) {
     return;
   }
 
-  p << op->getName() << ' ' << op->getOperand(0) << ", " << op->getOperand(1);
+  p << ' ' << op->getOperand(0) << ", " << op->getOperand(1);
   p.printOptionalAttrDict(op->getAttrs());
 
   // Now we can output only one type for all operands and the result.
@@ -950,10 +951,9 @@ StringRef ADTType::getTypeName() const { return getImpl()->rustType; }
 Type ADTType::parse(DialectAsmParser &parser) {
   if (parser.parseLess())
     return nullptr;
-  StringRef tmp;
-  if (parser.parseString(&tmp))
+  std::string str;
+  if (parser.parseString(&str))
     return nullptr;
-  std::string str(tmp);
   if (parser.parseGreater())
     return nullptr;
   return ADTType::get(parser.getBuilder().getContext(), str);

--- a/arc-mlir/src/lib/Rust/Dialect.cpp
+++ b/arc-mlir/src/lib/Rust/Dialect.cpp
@@ -322,7 +322,8 @@ void RustCallOp::writeRust(RustPrinterStream &PS) {
   }
 
   StringRef callee = getCallee();
-  Operation *target = SymbolTable::lookupNearestSymbolFrom(*this, getCallee());
+  StringAttr calleeName = StringAttr::get(this->getContext(), getCallee());
+  Operation *target = SymbolTable::lookupNearestSymbolFrom(*this, calleeName);
   if (target && target->hasAttr("arc.rust_name"))
     callee = target->getAttrOfType<StringAttr>("arc.rust_name").getValue();
 


### PR DESCRIPTION
Changes needed to the arc-script implementation:

* Upstream has changed all symbol table look ups to use StringAttrs
  instead of StringRefs, so we have to make the corresponding change.

* AsmParser::parseString() no longer expects a StringRef, so switch to
  a std::string.

* The operation printer now prints out the name of the operation
  before calling the user-defined printer, so remove the name from the
  custom printers.