### PR TITLE
LLVM submodule update

### DIFF
--- a/arc-mlir/src/lib/Arc/LowerToRust.cpp
+++ b/arc-mlir/src/lib/Arc/LowerToRust.cpp
@@ -168,8 +168,8 @@ struct StdCallOpLowering : public OpConversionPattern<CallOp> {
     SmallVector<Type, 4> resultTypes;
     for (auto r : o.getResultTypes())
       resultTypes.push_back(TypeConverter.convertType(r));
-    rewriter.replaceOpWithNewOp<rust::RustCallOp>(o, o.getCallee(), resultTypes,
-                                                  o.getOperands());
+    rewriter.replaceOpWithNewOp<rust::RustCallOp>(
+        o, adaptor.getCallee(), resultTypes, adaptor.getOperands());
     return success();
   };
 

--- a/arc-mlir/src/tests/ops/index_tuple.mlir
+++ b/arc-mlir/src/tests/ops/index_tuple.mlir
@@ -37,7 +37,8 @@ module @toplevel {
     %b = arith.constant true
     %tuple = "arc.make_tuple"(%a, %b) : (i1, i1) -> tuple<i1,i1>
 
-    // expected-error@+1 {{'arc.index_tuple' op attribute 'index' failed to satisfy constraint: 64-bit signless integer attribute whose value is non-negative}}
+    // expected-error@+2 {{'arc.index_tuple' op attribute 'index' failed to satisfy constraint: 64-bit signless integer attribute whose value is non-negative}}
+    // expected-note@+1 {{see current operation:}}
     %elem = "arc.index_tuple"(%tuple) { index = -5 } : (tuple<i1,i1>) -> i1
     return
   }
@@ -51,7 +52,8 @@ module @toplevel {
     %b = arith.constant true
     %tuple = "arc.make_tuple"(%a, %b) : (i1, i1) -> tuple<i1,i1>
 
-    // expected-error@+1 {{'arc.index_tuple' op requires attribute 'index'}}
+    // expected-error@+2 {{'arc.index_tuple' op requires attribute 'index'}}
+    // expected-note@+1 {{see current operation:}}
     %elem = "arc.index_tuple"(%tuple) : (tuple<i1,i1>) -> i1
     return
   }


### PR DESCRIPTION
Changes needed:

 * Update arc.index_tuple tests to deal with new notices.

 * Use adaptor operands when lowering CallOp to Rust. This is further
   fallout from upstream's refactoring of the lowering framework.