### PR TITLE
LLVM submodule update

### DIFF
--- a/arc-mlir/src/include/Arc/Arc.h
+++ b/arc-mlir/src/include/Arc/Arc.h
@@ -27,6 +27,7 @@
 #include <mlir/IR/BuiltinOps.h>
 #include <mlir/IR/Dialect.h>
 #include <mlir/IR/Operation.h>
+#include <mlir/Interfaces/InferTypeOpInterface.h>
 #include <mlir/Interfaces/SideEffectInterfaces.h>
 
 #include "Arc/Types.h"

--- a/arc-mlir/src/include/Arc/Arc.td
+++ b/arc-mlir/src/include/Arc/Arc.td
@@ -26,6 +26,7 @@
 #ifndef OP_BASE
 include "../../mlir/include/mlir/IR/OpBase.td"
 include "../../mlir/include/mlir/Interfaces/CallInterfaces.td"
+include "../../mlir/include/mlir/Interfaces/InferTypeOpInterface.td"
 include "../../mlir/include/mlir/Interfaces/SideEffectInterfaces.td"
 #endif // OP_BASE
 

--- a/arc-mlir/src/include/Rust/Rust.td
+++ b/arc-mlir/src/include/Rust/Rust.td
@@ -26,6 +26,7 @@
 #ifndef OP_BASE
 include "../../mlir/include/mlir/IR/OpBase.td"
 include "../../mlir/include/mlir/Interfaces/CallInterfaces.td"
+include "../../mlir/include/mlir/Interfaces/InferTypeOpInterface.td"
 include "../../mlir/include/mlir/Interfaces/SideEffectInterfaces.td"
 include "../../mlir/include/mlir/IR/SymbolInterfaces.td"
 #endif // OP_BASE


### PR DESCRIPTION
Changes needed:

  * The SameOperandsAndResultType trait is now in the
    InferTypeOpInterface.