### PR TITLE
mlir: Support lowering of std.select to Rust

### DIFF
--- a/arc-mlir/src/lib/Arc/LowerToRust.cpp
+++ b/arc-mlir/src/lib/Arc/LowerToRust.cpp
@@ -769,6 +769,29 @@ private:
   RustTypeConverter &TypeConverter;
 };
 
+struct StdSelectOpLowering : public OpConversionPattern<mlir::SelectOp> {
+  StdSelectOpLowering(MLIRContext *ctx, RustTypeConverter &typeConverter)
+      : OpConversionPattern<mlir::SelectOp>(typeConverter, ctx, 1) {}
+
+  LogicalResult
+  matchAndRewrite(mlir::SelectOp o, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const final {
+    // There is no ternary if in Rust, so just sink this to an
+    // ordinary arc if.
+    auto thisIf = rewriter.replaceOpWithNewOp<arc::IfOp>(o, o.getType(),
+                                                         adaptor.condition());
+    Block *thenBB = rewriter.createBlock(&thisIf.thenRegion());
+    rewriter.setInsertionPointToEnd(thenBB);
+    rewriter.create<arc::ArcBlockResultOp>(o.getLoc(), o.true_value());
+
+    Block *elseBB = rewriter.createBlock(&thisIf.elseRegion());
+    rewriter.setInsertionPointToEnd(elseBB);
+    rewriter.create<arc::ArcBlockResultOp>(o.getLoc(), o.false_value());
+
+    return success();
+  };
+};
+
 namespace ArcUnaryFloatOp {
 typedef enum {
   sin = 0,
@@ -1198,6 +1221,7 @@ void ArcToRustLoweringPass::runOnOperation() {
   patterns.insert<EnumCheckOpLowering>(&getContext(), typeConverter);
   patterns.insert<EmitOpLowering>(&getContext(), typeConverter);
   patterns.insert<PanicOpLowering>(&getContext(), typeConverter);
+  patterns.insert<StdSelectOpLowering>(&getContext(), typeConverter);
   patterns.insert<StructAccessOpLowering>(&getContext(), typeConverter);
   patterns.insert<StdCallOpLowering>(&getContext(), typeConverter);
   patterns.insert<StdCallIndirectOpLowering>(&getContext(), typeConverter);

--- a/arc-mlir/src/tests/arc-to-rust/select.mlir
+++ b/arc-mlir/src/tests/arc-to-rust/select.mlir
@@ -1,0 +1,8 @@
+// RUN: arc-mlir-rust-test %t %s -rustinclude %s.rust-tests
+
+module @arctorustifs  {
+  func @test_0(%arg0: i1, %arg1: ui32, %arg2: ui32) -> ui32 {
+    %0 = select %arg0, %arg1, %arg2 : ui32
+    return %0 : ui32
+  }
+}

--- a/arc-mlir/src/tests/arc-to-rust/select.mlir.rust-tests
+++ b/arc-mlir/src/tests/arc-to-rust/select.mlir.rust-tests
@@ -1,0 +1,9 @@
+#[cfg(test)]
+mod tests {
+  use crate::arctorustifs::*;
+  #[test]
+  fn test() {
+    assert_eq!(test_0(true, 3, 4), 3);
+    assert_eq!(test_0(false, 3, 4), 4);
+  }
+}


### PR DESCRIPTION
std.select-operations are sometimes introduced by canonicalization, so
we need to support them. As Rust does not have a ternary if, we simply
lower the select to an if.