### PR TITLE
arc-mlir: Move generated pass definitions to header

### DIFF
--- a/arc-mlir/src/include/Arc/Passes.h
+++ b/arc-mlir/src/include/Arc/Passes.h
@@ -14,13 +14,23 @@
 #ifndef ARC_PASSES_H
 #define ARC_PASSES_H
 
+#include <memory>
 #include <mlir/Pass/Pass.h>
 
-#include <memory>
+#include <mlir/Dialect/Arithmetic/IR/Arithmetic.h>
+#include <mlir/Dialect/Math/IR/Math.h>
+#include <mlir/Dialect/SCF/SCF.h>
+#include <mlir/Dialect/StandardOps/IR/Ops.h>
+
+#include "Arc/Arc.h"
+#include "Rust/Rust.h"
 
 using namespace mlir;
 
 namespace arc {
+
+#define GEN_PASS_CLASSES
+#include "Arc/Passes.h.inc"
 
 void registerArcPasses();
 

--- a/arc-mlir/src/lib/Arc/LowerToRust.cpp
+++ b/arc-mlir/src/lib/Arc/LowerToRust.cpp
@@ -11,26 +11,15 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include "Arc/Arc.h"
 #include "Arc/Passes.h"
-#include "Rust/Rust.h"
 #include "mlir/IR/BuiltinTypes.h"
 #include "mlir/IR/MLIRContext.h"
 #include "mlir/Support/LLVM.h"
 #include "mlir/Support/LogicalResult.h"
-#include <mlir/Dialect/Arithmetic/IR/Arithmetic.h>
-#include <mlir/Dialect/Math/IR/Math.h>
-#include <mlir/Dialect/SCF/SCF.h>
-#include <mlir/Dialect/StandardOps/IR/Ops.h>
 #include <mlir/Transforms/DialectConversion.h>
 
 using namespace mlir;
 using namespace arc;
-
-namespace arc {
-#define GEN_PASS_CLASSES
-#include "Arc/Passes.h.inc"
-} // namespace arc
 
 //===----------------------------------------------------------------------===//
 // ArcToRustLoweringPass


### PR DESCRIPTION
With the planned addition of additional passes for the Arc dialect we
don't want to have to remember the boilerplate inclusion, so move it
to a shared header.