### PR TITLE
arc-mlir: Fix name of arc.receive stream parameter

### DIFF
--- a/arc-mlir/src/include/Arc/Arc.td
+++ b/arc-mlir/src/include/Arc/Arc.td
@@ -512,9 +512,7 @@ def Arc_ReceiveOp : Arc_Op<"receive", []> {
     Receive a value from a stream. Must be located inside a task.
   }];
 
-  let arguments = (ins
-      ArcSourceStream:$sink
-  );
+  let arguments = (ins ArcSourceStream:$source);
   let results = (outs StreamElementType:$value);
   let verifier = [{ return customVerify(); }];
 

--- a/arc-mlir/src/lib/Arc/Dialect.cpp
+++ b/arc-mlir/src/lib/Arc/Dialect.cpp
@@ -636,7 +636,7 @@ LogicalResult ReceiveOp::customVerify() {
   }
   // Check that the stream's element type matches what we receive
   auto ElemTy = value().getType();
-  SourceStreamType StreamTy = sink().getType().cast<SourceStreamType>();
+  SourceStreamType StreamTy = source().getType().cast<SourceStreamType>();
   if (ElemTy != StreamTy.getType())
     return emitOpError("Can't receive a value of type ")
            << ElemTy << " from a " << StreamTy << " stream";


### PR DESCRIPTION
The stream parameter to the receive operation should be named a
'source' and not 'sink'.