### PR TITLE
LLVM submodule update

### DIFF
--- a/arc-mlir/src/include/Rust/Rust.td
+++ b/arc-mlir/src/include/Rust/Rust.td
@@ -25,6 +25,7 @@
 
 #ifndef OP_BASE
 include "../../mlir/include/mlir/IR/OpBase.td"
+include "../../mlir/include/mlir/IR/FunctionInterfaces.td"
 include "../../mlir/include/mlir/Interfaces/CallInterfaces.td"
 include "../../mlir/include/mlir/Interfaces/InferTypeOpInterface.td"
 include "../../mlir/include/mlir/Interfaces/SideEffectInterfaces.td"
@@ -190,7 +191,7 @@ def RustCallIndirectOp : Rust_Op<"call_indirect", [
 }
 
 
-def Rust_RustFuncOp : Rust_Op<"func", [FunctionLike, IsolatedFromAbove, Symbol]> {
+def Rust_RustFuncOp : Rust_Op<"func", [FunctionOpInterface, IsolatedFromAbove, Symbol]> {
   let summary = "A function";
 
   let description = [{
@@ -204,14 +205,13 @@ def Rust_RustFuncOp : Rust_Op<"func", [FunctionLike, IsolatedFromAbove, Symbol]>
       return getTypeAttr().getValue().cast<FunctionType>();
     }
 
-    // FunctionLike trait needs access to the functions below.
-    friend class OpTrait::FunctionLike<RustFuncOp>;
+    /// Returns the argument types of this function.
+    ArrayRef<Type> getArgumentTypes() { return getType().getInputs(); }
 
-    /// Hooks for the input/output type enumeration in FunctionLike .
-    unsigned getNumFuncArguments() { return getType().getNumInputs(); }
-    unsigned getNumFuncResults() { return getType().getNumResults(); }
+    /// Returns the result types of this function.
+    ArrayRef<Type> getResultTypes() { return getType().getResults(); }
 
-    /// Hook for FunctionLike verifier.
+    /// Hook for FunctionOpInterface verifier.
     LogicalResult verifyType();
 
     /// Verifies the body of the function.
@@ -222,7 +222,7 @@ def Rust_RustFuncOp : Rust_Op<"func", [FunctionLike, IsolatedFromAbove, Symbol]>
   }];
 }
 
-def Rust_RustExtFuncOp : Rust_Op<"extfunc", [FunctionLike, IsolatedFromAbove, Symbol]> {
+def Rust_RustExtFuncOp : Rust_Op<"extfunc", [FunctionOpInterface, IsolatedFromAbove, Symbol]> {
   let summary = "An external function";
 
   let description = [{
@@ -236,14 +236,13 @@ def Rust_RustExtFuncOp : Rust_Op<"extfunc", [FunctionLike, IsolatedFromAbove, Sy
       return getTypeAttr().getValue().cast<FunctionType>();
     }
 
-    // FunctionLike trait needs access to the functions below.
-    friend class OpTrait::FunctionLike<RustExtFuncOp>;
+    /// Returns the argument types of this function.
+    ArrayRef<Type> getArgumentTypes() { return getType().getInputs(); }
 
-    /// Hooks for the input/output type enumeration in FunctionLike .
-    unsigned getNumFuncArguments() { return getType().getNumInputs(); }
-    unsigned getNumFuncResults() { return getType().getNumResults(); }
+    /// Returns the result types of this function.
+    ArrayRef<Type> getResultTypes() { return getType().getResults(); }
 
-    /// Hook for FunctionLike verifier.
+    /// Hook for FunctionOpInterface verifier.
     LogicalResult verifyType();
 
     // Write this function as Rust code to os

--- a/arc-mlir/src/lib/Arc/RemoveSCF.cpp
+++ b/arc-mlir/src/lib/Arc/RemoveSCF.cpp
@@ -75,8 +75,9 @@ LogicalResult IfLowering::matchAndRewrite(arc::IfOp ifOp,
   if (ifOp.getNumResults() == 0) {
     continueBlock = remainingOpsBlock;
   } else {
-    continueBlock =
-        rewriter.createBlock(remainingOpsBlock, ifOp.getResultTypes());
+    continueBlock = rewriter.createBlock(
+        remainingOpsBlock, ifOp.getResultTypes(),
+        SmallVector<Location>(ifOp.getResultTypes().size(), loc));
     rewriter.create<BranchOp>(loc, remainingOpsBlock);
   }
 
@@ -154,7 +155,9 @@ LogicalResult WhileLowering::matchAndRewrite(scf::WhileOp whileOp,
 
   if (whileOp.getNumResults() != 0) {
     Block *t = continuation;
-    continuation = rewriter.createBlock(t, whileOp.getResultTypes());
+    auto resultTypes = whileOp.getResultTypes();
+    continuation = rewriter.createBlock(
+        t, resultTypes, SmallVector<Location>(resultTypes.size(), loc));
     rewriter.create<BranchOp>(loc, t);
   }
 

--- a/arc-mlir/src/lib/Arc/ToSCF.cpp
+++ b/arc-mlir/src/lib/Arc/ToSCF.cpp
@@ -182,8 +182,9 @@ private:
 
     // Create a new basic block to hold the loop
     auto &entryBB = f->getRegion(0).front();
-    Block *newEntryBB =
-        rewriter.createBlock(&entryBB, entryBB.getArgumentTypes());
+    Block *newEntryBB = rewriter.createBlock(
+        &entryBB, entryBB.getArgumentTypes(),
+        SmallVector<Location>(entryBB.getArgumentTypes().size(), f->getLoc()));
     rewriter.setInsertionPointToEnd(newEntryBB);
 
     // Create the type for the state, it consists of the variants for
@@ -207,9 +208,12 @@ private:
     scf::WhileOp loop =
         rewriter.create<scf::WhileOp>(f->getLoc(), loopVarTypes, loopOps);
     Block *beforeBB = rewriter.createBlock(&loop.getBefore());
-    beforeBB->addArguments(loopVarTypes);
+
+    auto tmp = SmallVector<Location>(loopVarTypes.size(), f->getLoc());
+    beforeBB->addArguments(loopVarTypes, tmp);
     Block *afterBB = rewriter.createBlock(&loop.getAfter());
-    afterBB->addArguments(loopVarTypes);
+    afterBB->addArguments(
+        loopVarTypes, SmallVector<Location>(loopVarTypes.size(), f->getLoc()));
 
     // Fill in the before block
     rewriter.setInsertionPointToEnd(beforeBB);

--- a/arc-mlir/src/lib/Rust/Dialect.cpp
+++ b/arc-mlir/src/lib/Rust/Dialect.cpp
@@ -459,7 +459,7 @@ void RustFuncOp::writeRust(RustPrinterStream &PS) {
     }
   }
   PS << ") ";
-  if (getNumFuncResults()) { // The return type
+  if (getType().getNumResults()) { // The return type
     PS << "-> " << getType().getResult(0) << " ";
   }
 

--- a/arc-mlir/src/tools/arc-mlir/CMakeLists.txt
+++ b/arc-mlir/src/tools/arc-mlir/CMakeLists.txt
@@ -4,7 +4,7 @@ get_property(conversion_libs GLOBAL PROPERTY MLIR_CONVERSION_LIBS)
 set(LIBS
   ${dialect_libs}
   ${conversion_libs}
-  MLIRLoopAnalysis
+  MLIRAffineAnalysis
   MLIRAffineTransformsTestPasses
   MLIRAnalysis
   MLIRDialect


### PR DESCRIPTION
Changes needed:

  * The trait FunctionLike has been replace by the interface
    FunctionOpInterface, adapt RustFuncOp and RustExtFuncOp
    accordingly.

  * Locations are now required for all block arguments, all code
    locations where we create new blocks have to provide a Location.