### PR TITLE
LLVM submodule update

### DIFF
--- a/arc-mlir/src/include/Arc/Arc.td
+++ b/arc-mlir/src/include/Arc/Arc.td
@@ -48,23 +48,23 @@ def Arc_Dialect : Dialect {
 // Arc Operation Classes
 //===----------------------------------------------------------------------===//
 
-class Arc_Op<string mnemonic, list<OpTrait> traits = []>
+class Arc_Op<string mnemonic, list<Trait> traits = []>
     : Op<Arc_Dialect, mnemonic, traits>;
 
 /* The structure for these unary operands is stolen from the standard dialect */
-class Arc_UnaryOp<string mnemonic, list<OpTrait> traits = []>
+class Arc_UnaryOp<string mnemonic, list<Trait> traits = []>
     : Op<Arc_Dialect, mnemonic, !listconcat(traits, [NoSideEffect])> {
   let results = (outs AnyType);
 }
 
 class Arc_UnaryOpSameOperandAndResultType<string mnemonic,
-                                         list<OpTrait> traits = []>
+                                         list<Trait> traits = []>
     : Arc_UnaryOp<mnemonic, !listconcat(traits, [SameOperandsAndResultType])> {
   let parser =
       [{ return impl::parseOneResultSameOperandTypeOp(parser, result); }];
 }
 
-class Arc_FloatUnaryOp<string mnemonic, list<OpTrait> traits = []>
+class Arc_FloatUnaryOp<string mnemonic, list<Trait> traits = []>
     : Arc_UnaryOpSameOperandAndResultType<mnemonic, traits>,
       Arguments<(ins FloatLike:$operand)>;
 
@@ -623,7 +623,7 @@ def StructAccessOp : Arc_Op<"struct_access", [NoSideEffect]> {
 // and results to be of the same type, but does not constrain them to
 // specific types. Individual classes will have `lhs` and `rhs`
 // accessor to operands.  Stolen from standard dialect.
-class ArcArithmeticOp<string mnemonic, list<OpTrait> traits = []> :
+class ArcArithmeticOp<string mnemonic, list<Trait> traits = []> :
     Op<Arc_Dialect, mnemonic,
        !listconcat(traits, [NoSideEffect, SameOperandsAndResultType])> {
 
@@ -646,7 +646,7 @@ class ArcArithmeticOp<string mnemonic, list<OpTrait> traits = []> :
 // the operation is as follows. Stolen from standard dialect.
 //
 //     <op>i %0, %1 : i32
-class ArcIntArithmeticOp<string mnemonic, list<OpTrait> traits = []> :
+class ArcIntArithmeticOp<string mnemonic, list<Trait> traits = []> :
     ArcArithmeticOp<mnemonic, traits>,
     Arguments<(ins ArcIntegerLike:$lhs, ArcIntegerLike:$rhs)>;
 
@@ -727,7 +727,7 @@ def Arc_StateAppenderFoldOp : Arc_Op<"appender_fold",
 // State maps
 
 class Arc_KeyedStateMapOp<string mnemonic,
-                          list<OpTrait> traits = []>
+                          list<Trait> traits = []>
     : Arc_Op<mnemonic, traits> {
   let arguments = (ins ArcStateMap:$state,
                        StreamElementType:$key);

--- a/arc-mlir/src/include/Arc/Opts.td
+++ b/arc-mlir/src/include/Arc/Opts.td
@@ -32,12 +32,9 @@ include "../../mlir/include/mlir/Dialect/Arithmetic/IR/ArithmeticOps.td"
 include "../../include/Arc/Arc.td"
 #endif // ARC_OPS
 
-def AllValuesAreConstants : Constraint<CPred<"AllValuesAreConstant($0)">>;
+def AllValuesAreConstants : Constraint<CPred<"AllValuesAreArithConstant($0)">>;
 def ConstantValuesToDenseAttributes :
     NativeCodeCall<"ConstantValuesToDenseAttributes($0, $1)">;
-def ConstantMakeVectorPattern0 : Pat<(MakeVectorOp:$result $values),
-          (ConstantOp (ConstantValuesToDenseAttributes $result, $values)),
-          [(AllValuesAreConstants $values)]>;
 def ConstantMakeVectorPattern1 : Pat<(MakeVectorOp:$result $values),
           (Arith_ConstantOp (ConstantValuesToDenseAttributes $result, $values)),
           [(AllValuesAreConstants $values)]>;

--- a/arc-mlir/src/include/Rust/Rust.td
+++ b/arc-mlir/src/include/Rust/Rust.td
@@ -55,7 +55,7 @@ def Rust_Dialect : Dialect {
 // Rust Operation Classes
 //===----------------------------------------------------------------------===//
 
-class Rust_Op<string mnemonic, list<OpTrait> traits = []>
+class Rust_Op<string mnemonic, list<Trait> traits = []>
     : Op<Rust_Dialect, mnemonic, traits>;
 
 def AnyRustType : Type<CPred<"$_self.isa<RustType>() || $_self.isa<RustStructType>() || $_self.isa<RustTupleType>() || $_self.isa<RustTensorType>() || $_self.isa<RustEnumType>() || isRustFunctionType($_self) || $_self.isa<RustStreamType>() || $_self.isa<RustSinkStreamType>() || $_self.isa<RustSourceStreamType>()">, "any RustType">;

--- a/arc-mlir/src/lib/Arc/Dialect.cpp
+++ b/arc-mlir/src/lib/Arc/Dialect.cpp
@@ -197,9 +197,10 @@ Operation *ArcDialect::materializeConstant(OpBuilder &builder, Attribute value,
   if (arith::ConstantOp::isBuildableWith(value, type))
     return builder.create<arith::ConstantOp>(loc, type, value);
 
-  if (mlir::ConstantOp::isBuildableWith(value, type))
-
-    return builder.create<ConstantOp>(loc, value, type);
+  if (mlir::ConstantOp::isBuildableWith(value, type)) {
+    return builder.create<ConstantOp>(loc, type,
+                                      value.cast<FlatSymbolRefAttr>());
+  }
 
   return nullptr;
 }

--- a/arc-mlir/src/lib/Arc/Opts.cpp
+++ b/arc-mlir/src/lib/Arc/Opts.cpp
@@ -35,10 +35,10 @@ using namespace arc;
 
 namespace {
 
-bool AllValuesAreConstant(Operation::operand_range &ops) {
+bool AllValuesAreArithConstant(Operation::operand_range &ops) {
   for (const mlir::Value &a : ops) {
     Operation *op = a.getDefiningOp();
-    if (!op || (!isa<arith::ConstantOp>(op) && !isa<ConstantOp>(op)))
+    if (!op || !isa<arith::ConstantOp>(op))
       return false;
   }
   return true;
@@ -51,13 +51,8 @@ ConstantValuesToDenseAttributes(mlir::OpResult result,
   std::vector<Attribute> attribs;
 
   for (const mlir::Value &a : ops) {
-    if (isa<ConstantOp>(a.getDefiningOp())) {
-      ConstantOp def = cast<ConstantOp>(a.getDefiningOp());
-      attribs.push_back(def.getValue());
-    } else {
-      arith::ConstantOp def = cast<arith::ConstantOp>(a.getDefiningOp());
-      attribs.push_back(def.getValue());
-    }
+    arith::ConstantOp def = cast<arith::ConstantOp>(a.getDefiningOp());
+    attribs.push_back(def.getValue());
   }
   return DenseElementsAttr::get(st, llvm::makeArrayRef(attribs));
 }

--- a/arc-mlir/src/lib/Arc/RemoveSCF.cpp
+++ b/arc-mlir/src/lib/Arc/RemoveSCF.cpp
@@ -15,6 +15,7 @@
 #include "Arc/Arc.h"
 #include "Arc/Passes.h"
 #include "mlir/Analysis/Liveness.h"
+#include "mlir/Dialect/ControlFlow/IR/ControlFlowOps.h"
 #include "mlir/Dialect/SCF/SCF.h"
 #include "mlir/IR/BuiltinOps.h"
 #include "mlir/IR/BuiltinTypes.h"
@@ -24,6 +25,7 @@
 #include "mlir/Transforms/DialectConversion.h"
 
 using namespace mlir;
+using namespace mlir::cf;
 using namespace arc;
 
 //===----------------------------------------------------------------------===//

--- a/arc-mlir/src/lib/Arc/ToSCF.cpp
+++ b/arc-mlir/src/lib/Arc/ToSCF.cpp
@@ -15,6 +15,7 @@
 #include "Arc/Passes.h"
 #include "Arc/Types.h"
 #include "mlir/Analysis/Liveness.h"
+#include "mlir/Dialect/ControlFlow/IR/ControlFlowOps.h"
 #include "mlir/Dialect/SCF/SCF.h"
 #include "mlir/IR/BlockAndValueMapping.h"
 #include "mlir/IR/BuiltinOps.h"
@@ -28,6 +29,7 @@
 #include "llvm/Support/ScopedPrinter.h"
 
 using namespace mlir;
+using namespace mlir::cf;
 using namespace arc;
 
 #define DEBUG_TYPE "to-scf"

--- a/arc-mlir/src/tests/arc-to-rust/select.mlir
+++ b/arc-mlir/src/tests/arc-to-rust/select.mlir
@@ -3,7 +3,7 @@
 
 module @arctorustifs  {
   func @test_0(%arg0: i1, %arg1: ui32, %arg2: ui32) -> ui32 {
-    %0 = select %arg0, %arg1, %arg2 : ui32
+    %0 = arith.select %arg0, %arg1, %arg2 : ui32
     return %0 : ui32
   }
 }


### PR DESCRIPTION
Changes needed:

 * The Tablegen OpTrait has been replaced with Trait.

 * The standard control flow instructions such as for example BranchOp
   has been moved to a mlir::cf namespace.

 * std.select has moved to arith.select.

 * Changes to ConstantOp handling makes it necessary to only try to
   constant fold arith::ConstantOp values for arc.make_vector.