### PR TITLE
LLVM submodule update

### DIFF
--- a/arc-mlir/src/include/Arc/Arc.td
+++ b/arc-mlir/src/include/Arc/Arc.td
@@ -60,13 +60,14 @@ class Arc_UnaryOp<string mnemonic, list<Trait> traits = []>
 class Arc_UnaryOpSameOperandAndResultType<string mnemonic,
                                          list<Trait> traits = []>
     : Arc_UnaryOp<mnemonic, !listconcat(traits, [SameOperandsAndResultType])> {
-  let parser =
-      [{ return impl::parseOneResultSameOperandTypeOp(parser, result); }];
 }
 
 class Arc_FloatUnaryOp<string mnemonic, list<Trait> traits = []>
     : Arc_UnaryOpSameOperandAndResultType<mnemonic, traits>,
-      Arguments<(ins FloatLike:$operand)>;
+      Arguments<(ins FloatLike:$operand)>,
+      Results<(outs FloatLike:$result)> {
+    let assemblyFormat = "$operand attr-dict `:` type($result)";
+}
 
 //===----------------------------------------------------------------------===//
 // Arc Predicates
@@ -429,9 +430,7 @@ def Arc_ConstantIntOp : Arc_Op<"constant", [ConstantLike, NoSideEffect]> {
   let results = (outs
     AnyArcInteger:$constant
   );
-
-  let parser = [{ return ::parseConstantIntOp(parser, result); }];
-  let printer = [{ return ::print(*this, p); }];
+  let hasCustomAssemblyFormat = 1;
   let verifier = [{ return ::verify(*this); }];
   let hasFolder = 1;
 
@@ -628,14 +627,7 @@ class ArcArithmeticOp<string mnemonic, list<Trait> traits = []> :
        !listconcat(traits, [NoSideEffect, SameOperandsAndResultType])> {
 
   let results = (outs AnyType);
-
-  let parser = [{
-    return impl::parseOneResultSameOperandTypeOp(parser, result);
-  }];
-
-  let printer = [{
-    return printArcBinaryOp(this->getOperation(), p);
-  }];
+  let hasCustomAssemblyFormat = 1;
 }
 
 // Base class for standard arithmetic operations on integers, vectors
@@ -648,7 +640,10 @@ class ArcArithmeticOp<string mnemonic, list<Trait> traits = []> :
 //     <op>i %0, %1 : i32
 class ArcIntArithmeticOp<string mnemonic, list<Trait> traits = []> :
     ArcArithmeticOp<mnemonic, traits>,
-    Arguments<(ins ArcIntegerLike:$lhs, ArcIntegerLike:$rhs)>;
+    Arguments<(ins ArcIntegerLike:$lhs, ArcIntegerLike:$rhs)>,
+   Results<(outs ArcIntegerLike:$result)> {
+   let assemblyFormat = "$lhs `,` $rhs attr-dict `:` type($result)";
+}
 
 def Arc_AddIOp : ArcIntArithmeticOp<"addi", [Commutative]> {
   let summary = "integer addition operation";

--- a/arc-mlir/src/lib/Arc/Dialect.cpp
+++ b/arc-mlir/src/lib/Arc/Dialect.cpp
@@ -147,8 +147,7 @@ OpFoldResult arc::AndOp::fold(ArrayRef<Attribute> operands) {
 //===----------------------------------------------------------------------===//
 // ConstantIntOp
 //===----------------------------------------------------------------------===//
-static ParseResult parseConstantIntOp(OpAsmParser &parser,
-                                      OperationState &state) {
+ParseResult ConstantIntOp::parse(OpAsmParser &parser, OperationState &state) {
   Attribute value;
   if (parser.parseAttribute(value, "value", state.attributes))
     return failure();
@@ -157,8 +156,8 @@ static ParseResult parseConstantIntOp(OpAsmParser &parser,
   return parser.addTypeToList(type, state.types);
 }
 
-static void print(arc::ConstantIntOp constOp, OpAsmPrinter &printer) {
-  printer << ' ' << constOp.value();
+void arc::ConstantIntOp::print(OpAsmPrinter &printer) {
+  printer << ' ' << value();
 }
 
 static LogicalResult verify(arc::ConstantIntOp constOp) {
@@ -928,27 +927,6 @@ static Type getI1SameShape(Type type) {
   Type res = getCheckedI1SameShape(type);
   assert(res && "expected type with valid i1 shape");
   return res;
-}
-
-/// Stolen from the standard dialect.
-static void printArcBinaryOp(Operation *op, OpAsmPrinter &p) {
-  assert(op->getNumOperands() == 2 && "binary op should have two operands");
-  assert(op->getNumResults() == 1 && "binary op should have one result");
-
-  // If not all the operand and result types are the same, just use the
-  // generic assembly form to avoid omitting information in printing.
-  auto resultType = op->getResult(0).getType();
-  if (op->getOperand(0).getType() != resultType ||
-      op->getOperand(1).getType() != resultType) {
-    p.printGenericOp(op);
-    return;
-  }
-
-  p << ' ' << op->getOperand(0) << ", " << op->getOperand(1);
-  p.printOptionalAttrDict(op->getAttrs());
-
-  // Now we can output only one type for all operands and the result.
-  p << " : " << op->getResult(0).getType();
 }
 
 //===----------------------------------------------------------------------===//


### PR DESCRIPTION
Changes needed:

 * Old-style custom parser hooks have been removed upstream. Port the
   trickier syntax to the newer alternatives and switch simple cases to
   use ODS syntax definitions.