### PR TITLE
rust-mlir: Construct function references using function!()

### DIFF
--- a/arc-mlir/src/include/Rust/RustPrinterStream.h
+++ b/arc-mlir/src/include/Rust/RustPrinterStream.h
@@ -174,7 +174,8 @@ public:
               << " = Box::new(" << str.getValue() << ") as ";
           printAsRust(Body, fType) << ";\n";
         } else {
-          printAsRust(Body, fType) << " = " << str.getValue() << ";\n";
+          printAsRust(Body, fType)
+              << " = function!(" << str.getValue() << ");\n";
         }
       } else
         id = found->second;


### PR DESCRIPTION
Using the new runtime library, function references must be created
using `function!()`.