### PR TITLE
Fix the URL for GitHub Pages

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -70,5 +70,5 @@ jobs:
       uses: peaceiris/actions-gh-pages@v3
       with:
         deploy_key: ${{ secrets.ACTIONS_DEPLOY_KEY }}
-        publish_dir: arc-website/target
+        publish_dir: arc-website/target/html
         force_orphan: true

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Arc
 
-[![](https://img.shields.io/badge/docs-online-brightgreen)](https://segeljakt.github.io/arc-website/doc.html)
+[![](https://img.shields.io/badge/docs-online-brightgreen)](https://cda-group.github.io/arc/)
+[![](https://img.shields.io/badge/report-online-brightgreen)](https://cda-group.github.io/arc/Arc-Report.pdf)
 
 Programming language for data stream analysis.
 


### PR DESCRIPTION
Previously it was

https://cda-group.github.io/arc/html

Now it should be

https://cda-group.github.io/arc/