### PR TITLE
LLVM submodule update

### DIFF
--- a/arc-mlir/src/include/Arc/Opts.td
+++ b/arc-mlir/src/include/Arc/Opts.td
@@ -24,7 +24,7 @@
 #define ARC_OPTS
 
 #ifndef STANDARD_OPS
-include "../../mlir/include/mlir/Dialect/StandardOps/IR/Ops.td"
+include "../../mlir/include/mlir/Dialect/Func/IR/FuncOps.td"
 include "../../mlir/include/mlir/Dialect/Arithmetic/IR/ArithmeticOps.td"
 #endif // STANDARD_OPS
 

--- a/arc-mlir/src/include/Arc/Passes.h
+++ b/arc-mlir/src/include/Arc/Passes.h
@@ -20,7 +20,7 @@
 #include <mlir/Dialect/Arithmetic/IR/Arithmetic.h>
 #include <mlir/Dialect/Math/IR/Math.h>
 #include <mlir/Dialect/SCF/SCF.h>
-#include <mlir/Dialect/StandardOps/IR/Ops.h>
+#include <mlir/Dialect/Func/IR/FuncOps.h>
 
 #include "Arc/Arc.h"
 #include "Rust/Rust.h"

--- a/arc-mlir/src/include/Arc/Passes.td
+++ b/arc-mlir/src/include/Arc/Passes.td
@@ -23,7 +23,7 @@ def LowerToRust : Pass<"arc-to-rust", "ModuleOp"> {
   let dependentDialects = [
         "arc::ArcDialect",
         "rust::RustDialect",
-        "StandardOpsDialect"
+        "mlir::func::FuncDialect"
   ];
 }
 
@@ -33,7 +33,7 @@ def RemoveSCF : Pass<"remove-scf", "FuncOp"> {
 
   let dependentDialects = [
         "arc::ArcDialect",
-        "StandardOpsDialect"
+        "mlir::func::FuncDialect"
   ];
 }
 
@@ -43,7 +43,7 @@ def ToSCF : Pass<"to-scf", "ModuleOp"> {
 
   let dependentDialects = [
         "arc::ArcDialect",
-        "StandardOpsDialect"
+        "mlir::func::FuncDialect"
   ];
 }
 
@@ -53,7 +53,7 @@ def ToNonpersistent : Pass<"to-nonpersistent", "ModuleOp"> {
 
   let dependentDialects = [
         "arc::ArcDialect",
-        "StandardOpsDialect"
+        "mlir::func::FuncDialect"
   ];
 }
 

--- a/arc-mlir/src/lib/Arc/CMakeLists.txt
+++ b/arc-mlir/src/lib/Arc/CMakeLists.txt
@@ -15,6 +15,6 @@ add_mlir_dialect_library(ArcDialect
 target_link_libraries(ArcDialect
   PUBLIC
   MLIRIR
-  MLIRStandard
+  MLIRFunc
   LLVMSupport
   )

--- a/arc-mlir/src/lib/Arc/Dialect.cpp
+++ b/arc-mlir/src/lib/Arc/Dialect.cpp
@@ -25,8 +25,8 @@
 #include <llvm/Support/raw_ostream.h>
 #include <mlir/Dialect/Arithmetic/IR/Arithmetic.h>
 #include <mlir/Dialect/CommonFolders.h>
+#include <mlir/Dialect/Func/IR/FuncOps.h>
 #include <mlir/Dialect/SCF/SCF.h>
-#include <mlir/Dialect/StandardOps/IR/Ops.h>
 #include <mlir/IR/Builders.h>
 #include <mlir/IR/BuiltinTypes.h>
 #include <mlir/IR/DialectImplementation.h>
@@ -196,9 +196,9 @@ Operation *ArcDialect::materializeConstant(OpBuilder &builder, Attribute value,
   if (arith::ConstantOp::isBuildableWith(value, type))
     return builder.create<arith::ConstantOp>(loc, type, value);
 
-  if (mlir::ConstantOp::isBuildableWith(value, type)) {
-    return builder.create<ConstantOp>(loc, type,
-                                      value.cast<FlatSymbolRefAttr>());
+  if (func::ConstantOp::isBuildableWith(value, type)) {
+    return builder.create<func::ConstantOp>(loc, type,
+                                            value.cast<FlatSymbolRefAttr>());
   }
 
   return nullptr;

--- a/arc-mlir/src/lib/Arc/LowerToRust.cpp
+++ b/arc-mlir/src/lib/Arc/LowerToRust.cpp
@@ -71,13 +71,13 @@ struct ArcReturnOpLowering : public OpConversionPattern<ArcReturnOp> {
   };
 };
 
-struct ReturnOpLowering : public OpConversionPattern<mlir::ReturnOp> {
+struct ReturnOpLowering : public OpConversionPattern<func::ReturnOp> {
 
   ReturnOpLowering(MLIRContext *ctx, RustTypeConverter &typeConverter)
-      : OpConversionPattern<mlir::ReturnOp>(typeConverter, ctx, 1) {}
+      : OpConversionPattern<func::ReturnOp>(typeConverter, ctx, 1) {}
 
   LogicalResult
-  matchAndRewrite(mlir::ReturnOp op, OpAdaptor adaptor,
+  matchAndRewrite(func::ReturnOp op, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const final {
     rewriter.replaceOpWithNewOp<rust::RustReturnOp>(
         op, llvm::None,
@@ -149,13 +149,13 @@ struct SCFLoopYieldOpLowering : public OpConversionPattern<scf::YieldOp> {
   };
 };
 
-struct StdCallOpLowering : public OpConversionPattern<CallOp> {
+struct StdCallOpLowering : public OpConversionPattern<func::CallOp> {
   StdCallOpLowering(MLIRContext *ctx, RustTypeConverter &typeConverter)
-      : OpConversionPattern<CallOp>(typeConverter, ctx, 1),
+      : OpConversionPattern<func::CallOp>(typeConverter, ctx, 1),
         TypeConverter(typeConverter) {}
 
   LogicalResult
-  matchAndRewrite(CallOp o, OpAdaptor adaptor,
+  matchAndRewrite(func::CallOp o, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const final {
     SmallVector<Type, 4> resultTypes;
     for (auto r : o.getResultTypes())
@@ -169,13 +169,14 @@ private:
   RustTypeConverter &TypeConverter;
 };
 
-struct StdCallIndirectOpLowering : public OpConversionPattern<CallIndirectOp> {
+struct StdCallIndirectOpLowering
+    : public OpConversionPattern<func::CallIndirectOp> {
   StdCallIndirectOpLowering(MLIRContext *ctx, RustTypeConverter &typeConverter)
-      : OpConversionPattern<CallIndirectOp>(typeConverter, ctx, 1),
+      : OpConversionPattern<func::CallIndirectOp>(typeConverter, ctx, 1),
         TypeConverter(typeConverter) {}
 
   LogicalResult
-  matchAndRewrite(CallIndirectOp o, OpAdaptor adaptor,
+  matchAndRewrite(func::CallIndirectOp o, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const final {
     SmallVector<Type, 4> resultTypes;
     for (auto r : o.getResultTypes())
@@ -275,14 +276,14 @@ private:
   }
 };
 
-struct StdConstantOpLowering : public OpConversionPattern<mlir::ConstantOp> {
+struct StdConstantOpLowering : public OpConversionPattern<func::ConstantOp> {
 
   StdConstantOpLowering(MLIRContext *ctx, RustTypeConverter &typeConverter)
-      : OpConversionPattern<mlir::ConstantOp>(typeConverter, ctx, 1),
+      : OpConversionPattern<func::ConstantOp>(typeConverter, ctx, 1),
         TypeConverter(typeConverter) {}
 
   LogicalResult
-  matchAndRewrite(mlir::ConstantOp cOp, OpAdaptor adaptor,
+  matchAndRewrite(func::ConstantOp cOp, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const final {
     Attribute attr = cOp.getValueAttr();
     if (attr.isa<SymbolRefAttr>())
@@ -300,7 +301,7 @@ private:
     return success();
   }
 
-  LogicalResult convertSymbolRef(mlir::ConstantOp op,
+  LogicalResult convertSymbolRef(func::ConstantOp op,
                                  ConversionPatternRewriter &rewriter) const {
     SymbolRefAttr attr = op.getValueAttr().cast<SymbolRefAttr>();
     Operation *refOp =

--- a/arc-mlir/src/lib/Arc/Opts.cpp
+++ b/arc-mlir/src/lib/Arc/Opts.cpp
@@ -24,7 +24,7 @@
 #include "Arc/Arc.h"
 #include <llvm/Support/raw_ostream.h>
 #include <mlir/Dialect/Arithmetic/IR/Arithmetic.h>
-#include <mlir/Dialect/StandardOps/IR/Ops.h>
+#include <mlir/Dialect/Func/IR/FuncOps.h>
 #include <mlir/IR/BlockAndValueMapping.h>
 #include <mlir/IR/Matchers.h>
 #include <mlir/IR/PatternMatch.h>

--- a/arc-mlir/src/lib/Arc/RemoveSCF.cpp
+++ b/arc-mlir/src/lib/Arc/RemoveSCF.cpp
@@ -93,9 +93,9 @@ LogicalResult IfLowering::matchAndRewrite(arc::IfOp ifOp,
   if (isa<arc::LoopBreakOp>(thenTerminator)) {
     // Leave it in, the while lowering will remove it
   } else if (isa<arc::ArcReturnOp>(thenTerminator) ||
-             isa<ReturnOp>(thenTerminator)) {
-    rewriter.create<ReturnOp>(loc, thenTerminator->getResultTypes(),
-                              thenTerminatorOperands);
+             isa<func::ReturnOp>(thenTerminator)) {
+    rewriter.create<func::ReturnOp>(loc, thenTerminator->getResultTypes(),
+                                    thenTerminatorOperands);
     rewriter.eraseOp(thenTerminator);
   } else {
     rewriter.create<BranchOp>(loc, continueBlock, thenTerminatorOperands);
@@ -117,9 +117,9 @@ LogicalResult IfLowering::matchAndRewrite(arc::IfOp ifOp,
       // Leave it in, the while lowering will remove it
     }
     if (isa<arc::ArcReturnOp>(elseTerminator) ||
-        isa<ReturnOp>(elseTerminator)) {
-      rewriter.create<ReturnOp>(loc, elseTerminator->getResultTypes(),
-                                elseTerminatorOperands);
+        isa<func::ReturnOp>(elseTerminator)) {
+      rewriter.create<func::ReturnOp>(loc, elseTerminator->getResultTypes(),
+                                      elseTerminatorOperands);
       rewriter.eraseOp(elseTerminator);
     } else {
       rewriter.create<BranchOp>(loc, continueBlock, elseTerminatorOperands);
@@ -139,7 +139,7 @@ LogicalResult IfLowering::matchAndRewrite(arc::IfOp ifOp,
 LogicalResult
 ArcReturnLowering::matchAndRewrite(ArcReturnOp op,
                                    PatternRewriter &rewriter) const {
-  rewriter.replaceOpWithNewOp<ReturnOp>(op, op.operands());
+  rewriter.replaceOpWithNewOp<func::ReturnOp>(op, op.operands());
   return success();
 }
 

--- a/arc-mlir/src/lib/Arc/ToSCF.cpp
+++ b/arc-mlir/src/lib/Arc/ToSCF.cpp
@@ -315,7 +315,7 @@ private:
           buildBranchTo(br.getFalseDest(), br.getFalseDestOperands(),
                         block2variantStruct, block2variantName,
                         block2live2Field, stateTy, map, f->getLoc(), rewriter);
-        } else if (ReturnOp r = dyn_cast<ReturnOp>(op)) {
+        } else if (func::ReturnOp r = dyn_cast<func::ReturnOp>(op)) {
           SmallVector<Value, 1> values;
 
           if (r.getNumOperands())
@@ -335,9 +335,9 @@ private:
     if (f.getType().getNumResults()) {
       Value r = rewriter.create<arc::EnumAccessOp>(
           f.getLoc(), funReturnTy, loop.getResult(0), returnValueVariantName);
-      rewriter.create<ReturnOp>(f.getLoc(), r);
+      rewriter.create<func::ReturnOp>(f.getLoc(), r);
     } else
-      rewriter.create<ReturnOp>(f.getLoc());
+      rewriter.create<func::ReturnOp>(f.getLoc());
 
     // Remove all basic blocks from the original function, only
     // leaving the new entry block.

--- a/arc-mlir/src/lib/Rust/CMakeLists.txt
+++ b/arc-mlir/src/lib/Rust/CMakeLists.txt
@@ -12,6 +12,6 @@ add_mlir_dialect_library(RustDialect
 target_link_libraries(RustDialect
   PUBLIC
   MLIRIR
-  MLIRStandard
+  MLIRFunc
   LLVMSupport
 )

--- a/arc-mlir/src/tests/types/bad-structs.mlir
+++ b/arc-mlir/src/tests/types/bad-structs.mlir
@@ -32,7 +32,7 @@ module @toplevel {
 module @toplevel {
   func @fail4(%in : !arc.struct<foo : i32, bar : f32>) -> !arc.struct<foo : i32, baz : f32> {
   // expected-error@+2 {{type of return operand 0 ('!arc.struct<foo : i32, bar : f32>') doesn't match function result type ('!arc.struct<foo : i32, baz : f32>')}}
-  // expected-note@+1 {{see current operation: "std.return"(%arg0) : (!arc.struct<foo : i32, bar : f32>) -> ()}}
+  // expected-note@+1 {{see current operation: "func.return"(%arg0) : (!arc.struct<foo : i32, bar : f32>) -> ()}}
     return %in : !arc.struct<foo : i32, bar : f32>
   }
 }

--- a/arc-mlir/src/tools/arc-mlir/Main.cpp
+++ b/arc-mlir/src/tools/arc-mlir/Main.cpp
@@ -82,7 +82,7 @@ int main(int argc, char **argv) {
   mlir::registerAllPasses();
 
   mlir::DialectRegistry registry;
-  registry.insert<mlir::StandardOpsDialect>();
+  registry.insert<func::FuncDialect>();
   registry.insert<arith::ArithmeticDialect>();
   registry.insert<math::MathDialect>();
   registry.insert<scf::SCFDialect>();


### PR DESCRIPTION
Changes needed:

 * Upstream has renamed the Standard dialect to the Func dialect,
   adapt to the new name in arc-mlir and arc-rust tools and libraries.