### PR TITLE
rust-mlir: Fix bug in rust annotation handling

### DIFF
--- a/arc-mlir/src/lib/Rust/Dialect.cpp
+++ b/arc-mlir/src/lib/Rust/Dialect.cpp
@@ -407,7 +407,7 @@ void RustFuncOp::writeRust(RustPrinterStream &PS) {
 
   PS << "// " << (isMethod ? "Method" : "") << "\n";
   if (useArclangRuntime) {
-    if ((*this)->hasAttr("arc.annotation"))
+    if ((*this)->hasAttr("rust.annotation"))
       PS << (*this)->getAttrOfType<StringAttr>("rust.annotation").getValue()
          << "\n";
     else


### PR DESCRIPTION
The "rust.annotation" function attribute did not produce the
annotation to be output. Correct the pretty printer to check for the
correct attribute.