### PR TITLE
Share Cargo.toml template between compiler driver and test driver

### DIFF
--- a/arc-lang/etc/Cargo.toml.template
+++ b/arc-lang/etc/Cargo.toml.template
@@ -1,0 +1,17 @@
+[package]
+name        = "${CRATE_NAME}"
+version     = "0.0.0"
+authors     = ["The arc-mlir testing gnome"]
+edition     = "2021"
+license     = "MIT"
+description = "Generic MLIR-to-Rust test case"
+
+[dependencies]
+arc-runtime         = { version = "=0.0.0", path = "${ARC_RUNTIME_SOURCE_DIR}", features = ["legacy"] }
+hexf                = { version = "0.2.1" }
+ndarray             = { version = "0.13.0" }
+prost               = { version = "0.7.0" }
+serde               = { version = "1.0.136" }
+
+[profile.dev]
+debug = false

--- a/arc-lang/examples/assign.arc
+++ b/arc-lang/examples/assign.arc
@@ -1,6 +1,6 @@
 # XFAIL: *
-# RUN: arc-lang %s | arc-mlir-rust-test %t - -rustinclude %s.rust-tests
-# RUN: arc-lang %s | arc-mlir-rust-test %t-canon - -rustinclude %s.rust-tests -canonicalize
+# RUN: arc -o %t run %s -- -rustinclude %s.rust-tests
+# RUN: arc -o %t-canon run %s -- -rustinclude %s.rust-tests -canonicalize
 
 def main() {
 # ANCHOR: example

--- a/arc-lang/examples/basic.arc
+++ b/arc-lang/examples/basic.arc
@@ -1,5 +1,5 @@
-# RUN: arc-lang %s | arc-mlir-rust-test %t - -rustinclude %s.rust-tests
-# RUN: arc-lang %s | arc-mlir-rust-test %t-canon - -rustinclude %s.rust-tests -canonicalize
+# RUN: arc -o %t run %s -- -rustinclude %s.rust-tests
+# RUN: arc -o %t-canon run %s -- -rustinclude %s.rust-tests -canonicalize
 
 # ANCHOR: example
 def foo() = bar(1)

--- a/arc-lang/examples/binopref.arc
+++ b/arc-lang/examples/binopref.arc
@@ -1,5 +1,5 @@
-# RUN: arc-lang %s | arc-mlir-rust-test %t - -rustinclude %s.rust-tests
-# RUN: arc-lang %s | arc-mlir-rust-test %t-canon - -rustinclude %s.rust-tests -canonicalize
+# RUN: arc -o %t run %s -- -rustinclude %s.rust-tests
+# RUN: arc -o %t-canon run %s -- -rustinclude %s.rust-tests -canonicalize
 
 # ANCHOR: example
 # Binary operators can be lifted into functions.

--- a/arc-lang/examples/binops.arc
+++ b/arc-lang/examples/binops.arc
@@ -1,5 +1,5 @@
-# RUN: arc-lang %s | arc-mlir-rust-test %t - -rustinclude %s.rust-tests
-# RUN: arc-lang %s | arc-mlir-rust-test %t-canon - -rustinclude %s.rust-tests -canonicalize
+# RUN: arc -o %t run %s -- -rustinclude %s.rust-tests
+# RUN: arc -o %t-canon run %s -- -rustinclude %s.rust-tests -canonicalize
 
 def main() {
 # ANCHOR: example

--- a/arc-lang/examples/blocks.arc
+++ b/arc-lang/examples/blocks.arc
@@ -1,5 +1,5 @@
-# RUN: arc-lang %s | arc-mlir-rust-test %t - -rustinclude %s.rust-tests
-# RUN: arc-lang %s | arc-mlir-rust-test %t-canon - -rustinclude %s.rust-tests -canonicalize
+# RUN: arc -o %t run %s -- -rustinclude %s.rust-tests
+# RUN: arc -o %t-canon run %s -- -rustinclude %s.rust-tests -canonicalize
 
 def main() {
 # ANCHOR: example

--- a/arc-lang/examples/body.arc
+++ b/arc-lang/examples/body.arc
@@ -1,5 +1,5 @@
-# RUN: arc-lang %s | arc-mlir-rust-test %t - -rustinclude %s.rust-tests
-# RUN: arc-lang %s | arc-mlir-rust-test %t-canon - -rustinclude %s.rust-tests -canonicalize
+# RUN: arc -o %t run %s -- -rustinclude %s.rust-tests
+# RUN: arc -o %t-canon run %s -- -rustinclude %s.rust-tests -canonicalize
 
 # ANCHOR: example
 def foo() = 3

--- a/arc-lang/examples/comprehensions.arc
+++ b/arc-lang/examples/comprehensions.arc
@@ -1,6 +1,6 @@
 # XFAIL: *
-# RUN: arc-lang %s | arc-mlir-rust-test %t - -rustinclude %s.rust-tests
-# RUN: arc-lang %s | arc-mlir-rust-test %t-canon - -rustinclude %s.rust-tests -canonicalize
+# RUN: arc -o %t run %s -- -rustinclude %s.rust-tests
+# RUN: arc -o %t-canon run %s -- -rustinclude %s.rust-tests -canonicalize
 
 # ANCHOR: example
 def test(stream) {

--- a/arc-lang/examples/empty.arc
+++ b/arc-lang/examples/empty.arc
@@ -1,4 +1,4 @@
-# RUN: arc-lang %s | arc-mlir-rust-test %t - -rustinclude %s.rust-tests
-# RUN: arc-lang %s | arc-mlir-rust-test %t-canon - -rustinclude %s.rust-tests -canonicalize
+# RUN: arc -o %t run %s -- -rustinclude %s.rust-tests
+# RUN: arc -o %t-canon run %s -- -rustinclude %s.rust-tests -canonicalize
 
 def main() {}

--- a/arc-lang/examples/enum-patterns.arc
+++ b/arc-lang/examples/enum-patterns.arc
@@ -1,6 +1,6 @@
 # XFAIL: *
-# RUN: arc-lang %s | arc-mlir-rust-test %t - -rustinclude %s.rust-tests
-# RUN: arc-lang %s | arc-mlir-rust-test %t-canon - -rustinclude %s.rust-tests -canonicalize
+# RUN: arc -o %t run %s -- -rustinclude %s.rust-tests
+# RUN: arc -o %t-canon run %s -- -rustinclude %s.rust-tests -canonicalize
 
 def main() {
 # ANCHOR: example

--- a/arc-lang/examples/enum.arc
+++ b/arc-lang/examples/enum.arc
@@ -1,5 +1,5 @@
-# RUN: arc-lang %s | arc-mlir-rust-test %t - -rustinclude %s.rust-tests
-# RUN: arc-lang %s | arc-mlir-rust-test %t-canon - -rustinclude %s.rust-tests -canonicalize
+# RUN: arc -o %t run %s -- -rustinclude %s.rust-tests
+# RUN: arc -o %t-canon run %s -- -rustinclude %s.rust-tests -canonicalize
 
 # ANCHOR: example
 enum Foo[T] {

--- a/arc-lang/examples/even-odd.arc
+++ b/arc-lang/examples/even-odd.arc
@@ -1,6 +1,6 @@
 # XFAIL: *
-# RUN: arc-lang %s | arc-mlir-rust-test %t - -rustinclude %s.rust-tests
-# RUN: arc-lang %s | arc-mlir-rust-test %t-canon - -rustinclude %s.rust-tests -canonicalize
+# RUN: arc -o %t run %s -- -rustinclude %s.rust-tests
+# RUN: arc -o %t-canon run %s -- -rustinclude %s.rust-tests -canonicalize
 
 # ANCHOR: example
 # The declaration order of top-level definitions is insignificant. In other words,

--- a/arc-lang/examples/fib-functional.arc
+++ b/arc-lang/examples/fib-functional.arc
@@ -1,6 +1,6 @@
 # XFAIL: *
-# RUN: arc-lang %s | arc-mlir-rust-test %t - -rustinclude %s.rust-tests
-# RUN: arc-lang %s | arc-mlir-rust-test %t-canon - -rustinclude %s.rust-tests -canonicalize
+# RUN: arc -o %t run %s -- -rustinclude %s.rust-tests
+# RUN: arc -o %t-canon run %s -- -rustinclude %s.rust-tests -canonicalize
 
 # ANCHOR: example
 # The following code shows how to define the Fibonacci function functionally.

--- a/arc-lang/examples/fib-imperative.arc
+++ b/arc-lang/examples/fib-imperative.arc
@@ -1,6 +1,6 @@
 # XFAIL: *
-# RUN: arc-lang %s | arc-mlir-rust-test %t - -rustinclude %s.rust-tests
-# RUN: arc-lang %s | arc-mlir-rust-test %t-canon - -rustinclude %s.rust-tests -canonicalize
+# RUN: arc -o %t run %s -- -rustinclude %s.rust-tests
+# RUN: arc -o %t-canon run %s -- -rustinclude %s.rust-tests -canonicalize
 
 # ANCHOR: example
 # The following code shows how to define the Fibonacci function imperatively.

--- a/arc-lang/examples/generic-enum.arc
+++ b/arc-lang/examples/generic-enum.arc
@@ -1,6 +1,6 @@
 # XFAIL: *
-# RUN: arc-lang %s | arc-mlir-rust-test %t - -rustinclude %s.rust-tests
-# RUN: arc-lang %s | arc-mlir-rust-test %t-canon - -rustinclude %s.rust-tests -canonicalize
+# RUN: arc -o %t run %s -- -rustinclude %s.rust-tests
+# RUN: arc -o %t-canon run %s -- -rustinclude %s.rust-tests -canonicalize
 
 # ANCHOR: example
 enum Option[T] {

--- a/arc-lang/examples/generic-function.arc
+++ b/arc-lang/examples/generic-function.arc
@@ -1,5 +1,5 @@
-# RUN: arc-lang %s | arc-mlir-rust-test %t - -rustinclude %s.rust-tests
-# RUN: arc-lang %s | arc-mlir-rust-test %t-canon - -rustinclude %s.rust-tests -canonicalize
+# RUN: arc -o %t run %s -- -rustinclude %s.rust-tests
+# RUN: arc -o %t-canon run %s -- -rustinclude %s.rust-tests -canonicalize
 
 # ANCHOR: example
 def id[A](x: A): A = x

--- a/arc-lang/examples/global.arc
+++ b/arc-lang/examples/global.arc
@@ -1,6 +1,6 @@
 # XFAIL: *
-# RUN: arc-lang %s | arc-mlir-rust-test %t - -rustinclude %s.rust-tests
-# RUN: arc-lang %s | arc-mlir-rust-test %t-canon - -rustinclude %s.rust-tests -canonicalize
+# RUN: arc -o %t run %s -- -rustinclude %s.rust-tests
+# RUN: arc -o %t-canon run %s -- -rustinclude %s.rust-tests -canonicalize
 
 # ANCHOR: example
 val pi = 3.14;

--- a/arc-lang/examples/identity-function.arc
+++ b/arc-lang/examples/identity-function.arc
@@ -1,5 +1,5 @@
-# RUN: arc-lang %s | arc-mlir-rust-test %t - -rustinclude %s.rust-tests
-# RUN: arc-lang %s | arc-mlir-rust-test %t-canon - -rustinclude %s.rust-tests -canonicalize
+# RUN: arc -o %t run %s -- -rustinclude %s.rust-tests
+# RUN: arc -o %t-canon run %s -- -rustinclude %s.rust-tests -canonicalize
 
 # ANCHOR: example
 def id[A](x: A): A = x

--- a/arc-lang/examples/inferred.arc
+++ b/arc-lang/examples/inferred.arc
@@ -1,5 +1,5 @@
-# RUN: arc-lang %s | arc-mlir-rust-test %t - -rustinclude %s.rust-tests
-# RUN: arc-lang %s | arc-mlir-rust-test %t-canon - -rustinclude %s.rust-tests -canonicalize
+# RUN: arc -o %t run %s -- -rustinclude %s.rust-tests
+# RUN: arc -o %t-canon run %s -- -rustinclude %s.rust-tests -canonicalize
 
 # ANCHOR: example
 def id(x) = x

--- a/arc-lang/examples/interpolate.arc
+++ b/arc-lang/examples/interpolate.arc
@@ -1,6 +1,6 @@
 # XFAIL: *
-# RUN: arc-lang %s | arc-mlir-rust-test %t - -rustinclude %s.rust-tests
-# RUN: arc-lang %s | arc-mlir-rust-test %t-canon - -rustinclude %s.rust-tests -canonicalize
+# RUN: arc -o %t run %s -- -rustinclude %s.rust-tests
+# RUN: arc -o %t-canon run %s -- -rustinclude %s.rust-tests -canonicalize
 
 # ANCHOR: example
 # String interpolation is supported using the $ and ${} syntax.

--- a/arc-lang/examples/interpreter.arc
+++ b/arc-lang/examples/interpreter.arc
@@ -1,6 +1,6 @@
 # XFAIL: *
-# RUN: arc-lang %s | arc-mlir-rust-test %t - -rustinclude %s.rust-tests
-# RUN: arc-lang %s | arc-mlir-rust-test %t-canon - -rustinclude %s.rust-tests -canonicalize
+# RUN: arc -o %t run %s -- -rustinclude %s.rust-tests
+# RUN: arc -o %t-canon run %s -- -rustinclude %s.rust-tests -canonicalize
 
 enum Expr {
     Num(i32),

--- a/arc-lang/examples/lambda.arc
+++ b/arc-lang/examples/lambda.arc
@@ -1,6 +1,6 @@
 # XFAIL: *
-# RUN: arc-lang %s | arc-mlir-rust-test %t - -rustinclude %s.rust-tests
-# RUN: arc-lang %s | arc-mlir-rust-test %t-canon - -rustinclude %s.rust-tests -canonicalize
+# RUN: arc -o %t run %s -- -rustinclude %s.rust-tests
+# RUN: arc -o %t-canon run %s -- -rustinclude %s.rust-tests -canonicalize
 
 # ANCHOR: example
 # Lambdas can both capture their environment and be passed around as values.

--- a/arc-lang/examples/modules.arc
+++ b/arc-lang/examples/modules.arc
@@ -1,6 +1,6 @@
 # XFAIL: *
-# RUN: arc-lang %s | arc-mlir-rust-test %t - -rustinclude %s.rust-tests
-# RUN: arc-lang %s | arc-mlir-rust-test %t-canon - -rustinclude %s.rust-tests -canonicalize
+# RUN: arc -o %t run %s -- -rustinclude %s.rust-tests
+# RUN: arc -o %t-canon run %s -- -rustinclude %s.rust-tests -canonicalize
 
 # ANCHOR: example
 mod foo {

--- a/arc-lang/examples/monoid.arc
+++ b/arc-lang/examples/monoid.arc
@@ -1,6 +1,6 @@
 # XFAIL: *
-# RUN: arc-lang %s | arc-mlir-rust-test %t - -rustinclude %s.rust-tests
-# RUN: arc-lang %s | arc-mlir-rust-test %t-canon - -rustinclude %s.rust-tests -canonicalize
+# RUN: arc -o %t run %s -- -rustinclude %s.rust-tests
+# RUN: arc -o %t-canon run %s -- -rustinclude %s.rust-tests -canonicalize
 
 # ANCHOR: example
 class Monoid {

--- a/arc-lang/examples/names.arc
+++ b/arc-lang/examples/names.arc
@@ -1,5 +1,5 @@
-# RUN: arc-lang %s | arc-mlir-rust-test %t - -rustinclude %s.rust-tests
-# RUN: arc-lang %s | arc-mlir-rust-test %t-canon - -rustinclude %s.rust-tests -canonicalize
+# RUN: arc -o %t run %s -- -rustinclude %s.rust-tests
+# RUN: arc -o %t-canon run %s -- -rustinclude %s.rust-tests -canonicalize
 
 # ANCHOR: example
 def this_is_a_name(this_is_also_a_name) {

--- a/arc-lang/examples/open-records.arc
+++ b/arc-lang/examples/open-records.arc
@@ -1,6 +1,6 @@
 # XFAIL: *
-# RUN: arc-lang %s | arc-mlir-rust-test %t - -rustinclude %s.rust-tests
-# RUN: arc-lang %s | arc-mlir-rust-test %t-canon - -rustinclude %s.rust-tests -canonicalize
+# RUN: arc -o %t run %s -- -rustinclude %s.rust-tests
+# RUN: arc -o %t-canon run %s -- -rustinclude %s.rust-tests -canonicalize
 
 def coerce(x: #{}): #{} {
     x

--- a/arc-lang/examples/overload-plus.arc
+++ b/arc-lang/examples/overload-plus.arc
@@ -1,6 +1,6 @@
 # XFAIL: *
-# RUN: arc-lang %s | arc-mlir-rust-test %t - -rustinclude %s.rust-tests
-# RUN: arc-lang %s | arc-mlir-rust-test %t-canon - -rustinclude %s.rust-tests -canonicalize
+# RUN: arc -o %t run %s -- -rustinclude %s.rust-tests
+# RUN: arc -o %t-canon run %s -- -rustinclude %s.rust-tests -canonicalize
 
 # ANCHOR: example
 def test1() = 1 + 2

--- a/arc-lang/examples/params.arc
+++ b/arc-lang/examples/params.arc
@@ -1,5 +1,5 @@
-# RUN: arc-lang %s | arc-mlir-rust-test %t - -rustinclude %s.rust-tests
-# RUN: arc-lang %s | arc-mlir-rust-test %t-canon - -rustinclude %s.rust-tests -canonicalize
+# RUN: arc -o %t run %s -- -rustinclude %s.rust-tests
+# RUN: arc -o %t-canon run %s -- -rustinclude %s.rust-tests -canonicalize
 
 # ANCHOR: example
 def test(typed_param: i32, untyped_param) = typed_param + untyped_param

--- a/arc-lang/examples/paths.arc
+++ b/arc-lang/examples/paths.arc
@@ -1,6 +1,6 @@
 # XFAIL: *
-# RUN: arc-lang %s | arc-mlir-rust-test %t - -rustinclude %s.rust-tests
-# RUN: arc-lang %s | arc-mlir-rust-test %t-canon - -rustinclude %s.rust-tests -canonicalize
+# RUN: arc -o %t run %s -- -rustinclude %s.rust-tests
+# RUN: arc -o %t-canon run %s -- -rustinclude %s.rust-tests -canonicalize
 
 # ANCHOR: example
 mod foo {

--- a/arc-lang/examples/placeholder.arc
+++ b/arc-lang/examples/placeholder.arc
@@ -1,5 +1,5 @@
-# RUN: arc-lang %s | arc-mlir-rust-test %t - -rustinclude %s.rust-tests
-# RUN: arc-lang %s | arc-mlir-rust-test %t-canon - -rustinclude %s.rust-tests -canonicalize
+# RUN: arc -o %t run %s -- -rustinclude %s.rust-tests
+# RUN: arc -o %t-canon run %s -- -rustinclude %s.rust-tests -canonicalize
 
 # ANCHOR: example
 # `(_ + _)` desugars into a lambda function `fun(x0, x1): x0 + x1`

--- a/arc-lang/examples/pre-declaration.arc
+++ b/arc-lang/examples/pre-declaration.arc
@@ -1,6 +1,6 @@
 # XFAIL: *
-# RUN: arc-lang %s | arc-mlir-rust-test %t - -rustinclude %s.rust-tests
-# RUN: arc-lang %s | arc-mlir-rust-test %t-canon - -rustinclude %s.rust-tests -canonicalize
+# RUN: arc -o %t run %s -- -rustinclude %s.rust-tests
+# RUN: arc -o %t-canon run %s -- -rustinclude %s.rust-tests -canonicalize
 
 # ANCHOR: example
 def add(a: i32, b: i32): i32;

--- a/arc-lang/examples/program.arc
+++ b/arc-lang/examples/program.arc
@@ -1,5 +1,5 @@
-# RUN: arc-lang %s | arc-mlir-rust-test %t - -rustinclude %s.rust-tests
-# RUN: arc-lang %s | arc-mlir-rust-test %t-canon - -rustinclude %s.rust-tests -canonicalize
+# RUN: arc -o %t run %s -- -rustinclude %s.rust-tests
+# RUN: arc -o %t-canon run %s -- -rustinclude %s.rust-tests -canonicalize
 
 # ANCHOR: example
 def main() {

--- a/arc-lang/examples/query.arc
+++ b/arc-lang/examples/query.arc
@@ -1,6 +1,6 @@
 # XFAIL: *
-# RUN: arc-lang %s | arc-mlir-rust-test %t - -rustinclude %s.rust-tests
-# RUN: arc-lang %s | arc-mlir-rust-test %t-canon - -rustinclude %s.rust-tests -canonicalize
+# RUN: arc -o %t run %s -- -rustinclude %s.rust-tests
+# RUN: arc -o %t-canon run %s -- -rustinclude %s.rust-tests -canonicalize
 
 # ANCHOR: implicit
 def test0(s) =

--- a/arc-lang/examples/record-patterns.arc
+++ b/arc-lang/examples/record-patterns.arc
@@ -1,6 +1,6 @@
 # XFAIL: *
-# RUN: arc-lang %s | arc-mlir-rust-test %t - -rustinclude %s.rust-tests
-# RUN: arc-lang %s | arc-mlir-rust-test %t-canon - -rustinclude %s.rust-tests -canonicalize
+# RUN: arc -o %t run %s -- -rustinclude %s.rust-tests
+# RUN: arc -o %t-canon run %s -- -rustinclude %s.rust-tests -canonicalize
 
 def main() {
 # ANCHOR: example

--- a/arc-lang/examples/row-polymorphism-shape.arc
+++ b/arc-lang/examples/row-polymorphism-shape.arc
@@ -1,6 +1,6 @@
 # XFAIL: *
-# RUN: arc-lang %s | arc-mlir-rust-test %t - -rustinclude %s.rust-tests
-# RUN: arc-lang %s | arc-mlir-rust-test %t-canon - -rustinclude %s.rust-tests -canonicalize
+# RUN: arc -o %t run %s -- -rustinclude %s.rust-tests
+# RUN: arc -o %t-canon run %s -- -rustinclude %s.rust-tests -canonicalize
 
 # ANCHOR: example
 def area(shape) = shape.x * shape.y

--- a/arc-lang/examples/row-polymorphism.arc
+++ b/arc-lang/examples/row-polymorphism.arc
@@ -1,5 +1,5 @@
-# RUN: arc-lang %s | arc-mlir-rust-test %t - -rustinclude %s.rust-tests
-# RUN: arc-lang %s | arc-mlir-rust-test %t-canon - -rustinclude %s.rust-tests -canonicalize
+# RUN: arc -o %t run %s -- -rustinclude %s.rust-tests
+# RUN: arc -o %t-canon run %s -- -rustinclude %s.rust-tests -canonicalize
 
 def foo[T](x: #{y:i32|T}): i32 = x.y
 

--- a/arc-lang/examples/shapes.arc
+++ b/arc-lang/examples/shapes.arc
@@ -1,6 +1,6 @@
 # XFAIL: *
-# RUN: arc-lang %s | arc-mlir-rust-test %t - -rustinclude %s.rust-tests
-# RUN: arc-lang %s | arc-mlir-rust-test %t-canon - -rustinclude %s.rust-tests -canonicalize
+# RUN: arc -o %t run %s -- -rustinclude %s.rust-tests
+# RUN: arc -o %t-canon run %s -- -rustinclude %s.rust-tests -canonicalize
 
 # ANCHOR: example
 enum Shape[T] {

--- a/arc-lang/examples/task-identity.arc
+++ b/arc-lang/examples/task-identity.arc
@@ -1,6 +1,6 @@
 # XFAIL: *
-# RUN: arc-lang %s | arc-mlir-rust-test %t - -rustinclude %s.rust-tests
-# RUN: arc-lang %s | arc-mlir-rust-test %t-canon - -rustinclude %s.rust-tests -canonicalize
+# RUN: arc -o %t run %s -- -rustinclude %s.rust-tests
+# RUN: arc -o %t-canon run %s -- -rustinclude %s.rust-tests -canonicalize
 
 # ANCHOR: example
 task identity(source): (sink) {

--- a/arc-lang/examples/task-lambda.arc
+++ b/arc-lang/examples/task-lambda.arc
@@ -1,6 +1,6 @@
 # XFAIL: *
-# RUN: arc-lang %s | arc-mlir-rust-test %t - -rustinclude %s.rust-tests
-# RUN: arc-lang %s | arc-mlir-rust-test %t-canon - -rustinclude %s.rust-tests -canonicalize
+# RUN: arc -o %t run %s -- -rustinclude %s.rust-tests
+# RUN: arc -o %t-canon run %s -- -rustinclude %s.rust-tests -canonicalize
 
 # ANCHOR: example
 def test(i) {

--- a/arc-lang/examples/task-merge.arc
+++ b/arc-lang/examples/task-merge.arc
@@ -1,6 +1,6 @@
 # XFAIL: *
-# RUN: arc-lang %s | arc-mlir-rust-test %t - -rustinclude %s.rust-tests
-# RUN: arc-lang %s | arc-mlir-rust-test %t-canon - -rustinclude %s.rust-tests -canonicalize
+# RUN: arc -o %t run %s -- -rustinclude %s.rust-tests
+# RUN: arc -o %t-canon run %s -- -rustinclude %s.rust-tests -canonicalize
 
 extern def read_numbers_stream(): Stream[i32];
 

--- a/arc-lang/examples/task-split.arc
+++ b/arc-lang/examples/task-split.arc
@@ -1,6 +1,6 @@
 # XFAIL: *
-# RUN: arc-lang %s | arc-mlir-rust-test %t - -rustinclude %s.rust-tests
-# RUN: arc-lang %s | arc-mlir-rust-test %t-canon - -rustinclude %s.rust-tests -canonicalize
+# RUN: arc -o %t run %s -- -rustinclude %s.rust-tests
+# RUN: arc -o %t-canon run %s -- -rustinclude %s.rust-tests -canonicalize
 
 extern def read_numbers_stream(): Stream[i32];
 

--- a/arc-lang/examples/task-union.arc
+++ b/arc-lang/examples/task-union.arc
@@ -1,6 +1,6 @@
 # XFAIL: *
-# RUN: arc-lang %s | arc-mlir-rust-test %t - -rustinclude %s.rust-tests
-# RUN: arc-lang %s | arc-mlir-rust-test %t-canon - -rustinclude %s.rust-tests -canonicalize
+# RUN: arc -o %t run %s -- -rustinclude %s.rust-tests
+# RUN: arc -o %t-canon run %s -- -rustinclude %s.rust-tests -canonicalize
 
 task union(s0, s1): (s2) {
     loop {

--- a/arc-lang/examples/tuple-patterns.arc
+++ b/arc-lang/examples/tuple-patterns.arc
@@ -1,6 +1,6 @@
 # XFAIL: *
-# RUN: arc-lang %s | arc-mlir-rust-test %t - -rustinclude %s.rust-tests
-# RUN: arc-lang %s | arc-mlir-rust-test %t-canon - -rustinclude %s.rust-tests -canonicalize
+# RUN: arc -o %t run %s -- -rustinclude %s.rust-tests
+# RUN: arc -o %t-canon run %s -- -rustinclude %s.rust-tests -canonicalize
 
 def main() {
 # ANCHOR: example

--- a/arc-lang/examples/type-alias.arc
+++ b/arc-lang/examples/type-alias.arc
@@ -1,6 +1,6 @@
 # XFAIL: *
-# RUN: arc-lang %s | arc-mlir-rust-test %t - -rustinclude %s.rust-tests
-# RUN: arc-lang %s | arc-mlir-rust-test %t-canon - -rustinclude %s.rust-tests -canonicalize
+# RUN: arc -o %t run %s -- -rustinclude %s.rust-tests
+# RUN: arc -o %t-canon run %s -- -rustinclude %s.rust-tests -canonicalize
 
 extern def sqrt(Num): Num;
 

--- a/arc-lang/examples/type-class.arc
+++ b/arc-lang/examples/type-class.arc
@@ -1,6 +1,6 @@
 # XFAIL: *
-# RUN: arc-lang %s | arc-mlir-rust-test %t - -rustinclude %s.rust-tests
-# RUN: arc-lang %s | arc-mlir-rust-test %t-canon - -rustinclude %s.rust-tests -canonicalize
+# RUN: arc -o %t run %s -- -rustinclude %s.rust-tests
+# RUN: arc -o %t-canon run %s -- -rustinclude %s.rust-tests -canonicalize
 
 # ANCHOR: class
 class Add<T> {

--- a/arc-lang/examples/types.arc
+++ b/arc-lang/examples/types.arc
@@ -1,6 +1,6 @@
 # XFAIL: *
-# RUN: arc-lang %s | arc-mlir-rust-test %t - -rustinclude %s.rust-tests
-# RUN: arc-lang %s | arc-mlir-rust-test %t-canon - -rustinclude %s.rust-tests -canonicalize
+# RUN: arc -o %t run %s -- -rustinclude %s.rust-tests
+# RUN: arc -o %t-canon run %s -- -rustinclude %s.rust-tests -canonicalize
 
 extern def main(
 # ANCHOR: record

--- a/arc-lang/examples/uses.arc
+++ b/arc-lang/examples/uses.arc
@@ -1,6 +1,6 @@
 # XFAIL: *
-# RUN: arc-lang %s | arc-mlir-rust-test %t - -rustinclude %s.rust-tests
-# RUN: arc-lang %s | arc-mlir-rust-test %t-canon - -rustinclude %s.rust-tests -canonicalize
+# RUN: arc -o %t run %s -- -rustinclude %s.rust-tests
+# RUN: arc -o %t-canon run %s -- -rustinclude %s.rust-tests -canonicalize
 
 # ANCHOR: example
 type Person = #{name: str, age: i32}

--- a/arc-lang/examples/values.arc
+++ b/arc-lang/examples/values.arc
@@ -1,6 +1,6 @@
 # XFAIL: *
-# RUN: arc-lang %s | arc-mlir-rust-test %t - -rustinclude %s.rust-tests
-# RUN: arc-lang %s | arc-mlir-rust-test %t-canon - -rustinclude %s.rust-tests -canonicalize
+# RUN: arc -o %t run %s -- -rustinclude %s.rust-tests
+# RUN: arc -o %t-canon run %s -- -rustinclude %s.rust-tests -canonicalize
 
 def main() {
 # ANCHOR: example

--- a/arc-lang/examples/vector-patterns.arc
+++ b/arc-lang/examples/vector-patterns.arc
@@ -1,6 +1,6 @@
 # XFAIL: *
-# RUN: arc-lang %s | arc-mlir-rust-test %t - -rustinclude %s.rust-tests
-# RUN: arc-lang %s | arc-mlir-rust-test %t-canon - -rustinclude %s.rust-tests -canonicalize
+# RUN: arc -o %t run %s -- -rustinclude %s.rust-tests
+# RUN: arc -o %t-canon run %s -- -rustinclude %s.rust-tests -canonicalize
 
 def main() {
 # ANCHOR: example

--- a/arc-mlir/src/CMakeLists.txt
+++ b/arc-mlir/src/CMakeLists.txt
@@ -49,3 +49,8 @@ add_subdirectory(tools)
 add_custom_target(arc-runtime-check DEPENDS check-arc-mlir
   COMMAND cd ${ARC_SCRIPT_SRC_DIR}; ${ARC_CARGO_BIN}/arc-cargo test --package=arc-runtime
 )
+
+install(DIRECTORY ${ARC_LANG_SRC_DIR}/stdlib DESTINATION share/arc/)
+install(DIRECTORY ${ARC_RUNTIME_SRC_DIR} DESTINATION share/arc/)
+install(PROGRAMS ${LLVM_TOOLS_BINARY_DIR}/arc DESTINATION bin)
+install(PROGRAMS ${LLVM_TOOLS_BINARY_DIR}/arc-lang DESTINATION bin)

--- a/arc-mlir/src/tests/lit.cfg.py
+++ b/arc-mlir/src/tests/lit.cfg.py
@@ -70,6 +70,7 @@ tools = [
     'mlir-translate',
     'arc-mlir',
     'arc-lang',
+    'arc',
 ]
 
 llvm_config.add_tool_substitutions(tools, tool_dirs)

--- a/arc-mlir/src/tests/lit.cfg.py
+++ b/arc-mlir/src/tests/lit.cfg.py
@@ -54,12 +54,6 @@ llvm_config.with_environment('PATH', config.llvm_tools_dir, append_path=True)
 
 from pathlib import Path
 
-# /path/to/arc/arc-mlir/src/tests/lit.cfg.py => /path/to/arc/arc-lang/stdlib/
-arc_stdlib_dir = Path(__file__).parents[3] / 'arc-lang' / 'stdlib' 
-
-llvm_config.with_environment('ARC_LANG_STDLIB_PATH', arc_stdlib_dir / 'stdlib.arc')
-llvm_config.with_environment('ARC_MLIR_STDLIB_PATH', arc_stdlib_dir / 'stdlib.mlir')
-
 llvm_config.with_environment('ARC_CARGO', 'arc-cargo')
 
 tool_dirs = [config.mlir_tools_dir, config.llvm_tools_dir,

--- a/arc-mlir/src/tests/lit.cfg.py
+++ b/arc-mlir/src/tests/lit.cfg.py
@@ -60,6 +60,8 @@ arc_stdlib_dir = Path(__file__).parents[3] / 'arc-lang' / 'stdlib'
 llvm_config.with_environment('ARC_LANG_STDLIB_PATH', arc_stdlib_dir / 'stdlib.arc')
 llvm_config.with_environment('ARC_MLIR_STDLIB_PATH', arc_stdlib_dir / 'stdlib.mlir')
 
+llvm_config.with_environment('ARC_CARGO', 'arc-cargo')
+
 tool_dirs = [config.mlir_tools_dir, config.llvm_tools_dir,
              config.arcscript_tools_dir]
 tools = [

--- a/arc-mlir/src/tools/CMakeLists.txt
+++ b/arc-mlir/src/tools/CMakeLists.txt
@@ -1,4 +1,10 @@
 add_subdirectory(arc-mlir)
 
+set(CARGO_TOML_TEMPLATE_FILE "${ARC_LANG_SRC_DIR}/etc/Cargo.toml.template")
+file(READ ${CARGO_TOML_TEMPLATE_FILE} CARGO_TOML_TEMPLATE)
+set_property(DIRECTORY APPEND PROPERTY CMAKE_CONFIGURE_DEPENDS
+  ${CARGO_TOML_TEMPLATE_FILE})
+
 configure_file(arc-cargo.in ${LLVM_TOOLS_BINARY_DIR}/arc-cargo @ONLY)
 configure_file(arc-mlir-rust-test.in ${LLVM_TOOLS_BINARY_DIR}/arc-mlir-rust-test @ONLY)
+configure_file(arc.in ${LLVM_TOOLS_BINARY_DIR}/arc @ONLY)

--- a/arc-mlir/src/tools/arc-mlir-rust-test.in
+++ b/arc-mlir/src/tools/arc-mlir-rust-test.in
@@ -17,7 +17,7 @@ MAIN="${WORK_DIR}/src/main.rs"
 TEST_NAME=$(basename ${WORK_DIR})
 TEST_NAME=${TEST_NAME//.mlir.tmp/}
 TEST_NAME=${TEST_NAME//.arc.tmp/}
-export TEST_NAME=${TEST_NAME//-/_}
+export CRATE_NAME=${TEST_NAME//-/_}
 
 CARGO_DEP_FRAGMENT="${MLIR_FILE%.mlir}.cargo-dep"
 echo "XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX"
@@ -39,24 +39,7 @@ mkdir -p ${WORK_DIR}/src
 
 # Create the Cargo.toml
 envsubst > ${WORK_DIR}/Cargo.toml <<'EOF'
-[package]
-name        = "${TEST_NAME}"
-version     = "0.0.0"
-authors     = ["The arc-mlir testing gnome"]
-edition     = "2021"
-license     = "MIT"
-description = "Generic MLIR-to-Rust test case"
-
-[dependencies]
-arc-runtime         = { version = "=0.0.0", path = "${ARC_RUNTIME_SOURCE_DIR}", features = ["legacy"] }
-hexf                = { version = "0.2.1" }
-ndarray             = { version = "0.13.0" }
-prost               = { version = "0.7.0" }
-serde               = { version = "1.0.136" }
-
-[profile.dev]
-debug = false
-
+@CARGO_TOML_TEMPLATE@
 EOF
 
 # Allow a test to include extra dependencies in the Cargo.toml

--- a/arc-mlir/src/tools/arc.in
+++ b/arc-mlir/src/tools/arc.in
@@ -143,9 +143,9 @@ CARGO_FLAGS+=("--manifest-path=$CRATE_TOML_FILE")
 CARGO_FLAGS+=("--target-dir=$CRATE_TARGET_DIR")
 
 if [ -z "$ARC_LANG" ]; then
-    ARC_LANG="$ROOT/arc-mlir/build/llvm-build/bin/arc-lang"
+    ARC_LANG="$ROOT/arc-lang"
     if [ ! -f "$ARC_LANG" ]; then
-        echo "Could not find arc-lang. Did you run \'$ARC_DIR./build\'?"
+        echo "Could not find arc-lang."
         exit 1
     fi
 fi
@@ -153,9 +153,9 @@ fi
 debug "ARC_LANG: $ARC_LANG"
 
 if [ -z "$ARC_MLIR" ]; then
-    ARC_MLIR="$ROOT/arc-mlir/build/llvm-build/bin/arc-mlir"
+    ARC_MLIR="$ROOT/arc-mlir"
     if [ ! -f "$ARC_LANG" ]; then
-        echo "Could not find arc-mlir. Did you run './build'?"
+        echo "Could not find arc-mlir."
         exit 1
     fi
 fi
@@ -172,19 +172,7 @@ mkdir -p "$CRATE_DIR/src"
 
 # Create the Cargo.toml
 envsubst > "$CRATE_TOML_FILE" <<'EOF'
-[package]
-name    = "$CRATE_NAME"
-version = "0.0.0"
-edition = "2021"
-
-[dependencies]
-arc-runtime = { version = "=0.0.0", path = "$ARC_RUNTIME_DIR" }
-hexf        = { version = "0.2.1" }
-serde       = { version = "1.0.136" }
-
-[profile.dev]
-opt-level = 0
-split-debuginfo = "unpacked"
+@CARGO_TOML_TEMPLATE@
 EOF
 
 [ "$ARC_DEBUG" ] && echo "$CRATE_TOML_FILE: " && cat "$CRATE_TOML_FILE"

--- a/arc-mlir/src/tools/arc.in
+++ b/arc-mlir/src/tools/arc.in
@@ -191,7 +191,7 @@ EOF
 
 echo 'fn main() { toplevel::main() }' >> "$CRATE_MAIN_FILE"
 
-[ "$ARC_DEBUG" ] && echo "$CRATE_MAIL_FILE: " && cat "$CRATE_MAIN_FILE"
+[ "$ARC_DEBUG" ] && echo "$CRATE_MAIN_FILE: " && cat "$CRATE_MAIN_FILE"
 
 debug "CARGO_FLAGS: $CARGO_FLAGS"
 

--- a/arc-mlir/src/tools/arc.in
+++ b/arc-mlir/src/tools/arc.in
@@ -162,11 +162,24 @@ fi
 
 debug "ARC_MLIR: $ARC_MLIR"
 
-if [ -z "$ARC_RUNTIME_DIR" ]; then
-    export ARC_RUNTIME_DIR="$ROOT/arc-runtime/"
+# We could be running from either the installed location or the
+# build tree.
+INSTALLED_SHARED_DIR="$ROOT/../share/arc/"
+if [ -d "${INSTALLED_SHARED_DIR}" ]; then
+    # Looks like we are running from the installed location
+    export ARC_RUNTIME_SOURCE_DIR="${INSTALLED_SHARED_DIR}/arc-runtime"
+    export ARC_LANG_STDLIB_PATH="${INSTALLED_SHARED_DIR}/stdlib/stdlib.arc"
+    export ARC_MLIR_STDLIB_PATH="${INSTALLED_SHARED_DIR}/stdlib/stdlib.mlir"
+else
+    # We are running from the build tree
+    export ARC_RUNTIME_SOURCE_DIR="@ARC_RUNTIME_SRC_DIR@"
+    export ARC_LANG_STDLIB_PATH="@ARC_LANG_SRC_DIR@/stdlib/stdlib.arc"
+    export ARC_MLIR_STDLIB_PATH="@ARC_LANG_SRC_DIR@/stdlib/stdlib.mlir"
 fi
 
-debug "ARC_RUNTIME_DIR: $ARC_RUNTIME_DIR"
+debug "ARC_RUNTIME_SOURCE_DIR: $ARC_RUNTIME_SOURCE_DIR"
+debug "ARC_LANG_STDLIB_PATH: $ARC_LANG_STDLIB_PATH"
+debug "ARC_MLIR_STDLIB_PATH: $ARC_MLIR_STDLIB_PATH"
 
 mkdir -p "$CRATE_DIR/src"
 

--- a/arc-mlir/src/tools/arc.in
+++ b/arc-mlir/src/tools/arc.in
@@ -202,7 +202,7 @@ EOF
 
 "$ARC_MLIR" "$CRATE_MLIR_FILE" "$@" -arc-to-rust -inline-rust -arc-lang-runtime >> "$CRATE_MAIN_FILE"
 
-echo 'fn main() { toplevel::main() }' >> "$CRATE_MAIN_FILE"
+echo 'fn main() { toplevel::main(); }' >> "$CRATE_MAIN_FILE"
 
 [ "$ARC_DEBUG" ] && echo "$CRATE_MAIN_FILE: " && cat "$CRATE_MAIN_FILE"
 

--- a/arc-mlir/src/tools/arc.in
+++ b/arc-mlir/src/tools/arc.in
@@ -195,4 +195,7 @@ echo 'fn main() { toplevel::main() }' >> "$CRATE_MAIN_FILE"
 
 debug "CARGO_FLAGS: $CARGO_FLAGS"
 
-cargo "$CARGO_MODE" "${CARGO_FLAGS[@]}"
+ARC_CARGO="${ARC_CARGO:-cargo}"
+debug "CARGO: $ARC_CARGO"
+
+"$ARC_CARGO" "$CARGO_MODE" "${CARGO_FLAGS[@]}"


### PR DESCRIPTION
Move the `Cargo.toml` template to its own file and let CMake insert it
into arc-mlir-rust-test and arc. Also move the compiler driver from
the top-level directoiry into the bin directory like all other tools.