### PR TITLE
LLVM submodule update

### DIFF
--- a/arc-mlir/src/include/Arc/Arc.td
+++ b/arc-mlir/src/include/Arc/Arc.td
@@ -153,7 +153,7 @@ def MakeVectorOp
   let results = (outs 1DTensorOf<[AnyType]>);
   let hasCanonicalizer = 1;
   let extraClassDeclaration = [{ LogicalResult customVerify(); }];
-  let verifier = [{ return customVerify(); }];
+  let hasVerifier = 1;
 }
 
 def ArcKeepOp : Arc_Op<"keep", []> {
@@ -237,7 +237,7 @@ def MakeStructOp : Arc_Op<"make_struct", [NoSideEffect]> {
   let arguments = (ins Variadic<AnyType>:$values);
   let results = (outs AnyStruct:$result);
   let extraClassDeclaration = [{ LogicalResult customVerify(); }];
-  let verifier = [{ return customVerify(); }];
+  let hasVerifier = 1;
 
   let assemblyFormat = [{
     `(` ($values^ `:` type($values) )? `)` attr-dict `:` type($result)
@@ -255,7 +255,7 @@ def MakeEnumOp : Arc_Op<"make_enum", [NoSideEffect]> {
   let arguments = (ins Variadic<AnyType>:$values, StrAttr:$variant);
   let results = (outs AnyEnum:$result);
   let extraClassDeclaration = [{ LogicalResult customVerify(); }];
-  let verifier = [{ return customVerify(); }];
+  let hasVerifier = 1;
 
   let assemblyFormat =
     "`(` ($values^ `:` type($values))? `)` `as` $variant attr-dict `:` type($result)";
@@ -269,7 +269,7 @@ def MakeTupleOp : Arc_Op<"make_tuple", [NoSideEffect]> {
   let arguments = (ins Variadic<AnyType>:$values);
   let results = (outs AnyTuple);
   let extraClassDeclaration = [{ LogicalResult customVerify(); }];
-  let verifier = [{ return customVerify(); }];
+  let hasVerifier = 1;
 }
 
 def MakeTensorOp : Arc_Op<"make_tensor",
@@ -282,7 +282,7 @@ def MakeTensorOp : Arc_Op<"make_tensor",
   let arguments = (ins Variadic<ArcTensorElementType>:$values);
   let results = (outs StaticShapeTensorOf<[ArcTensorElementType]>);
   let extraClassDeclaration = [{ LogicalResult customVerify(); }];
-  let verifier = [{ return customVerify(); }];
+  let hasVerifier = 1;
 }
 
 def IndexTupleOp : Arc_Op<"index_tuple", [NoSideEffect]> {
@@ -294,7 +294,7 @@ def IndexTupleOp : Arc_Op<"index_tuple", [NoSideEffect]> {
                    Confined<I64Attr, [IntNonNegative]>:$index);
   let results = (outs AnyType);
   let extraClassDeclaration = [{ LogicalResult customVerify(); }];
-  let verifier = [{ return customVerify(); }];
+  let hasVerifier = 1;
   let hasCanonicalizer = 1;
 }
 
@@ -313,7 +313,7 @@ def ArcBlockResultOp :
   }];
   let arguments = (ins Variadic<AnyType>:$result);
   let extraClassDeclaration = [{ LogicalResult customVerify(); }];
-  let verifier = [{ return customVerify(); }];
+  let hasVerifier = 1;
 }
 
 def IfOp : Arc_Op<"if", [SingleBlock]> {
@@ -335,7 +335,7 @@ def IfOp : Arc_Op<"if", [SingleBlock]> {
   let regions = (region SizedRegion<1>:$thenRegion, SizedRegion<1>:$elseRegion);
   let results = (outs Variadic<AnyType>:$result);
   let extraClassDeclaration = [{ LogicalResult customVerify(); }];
-  let verifier = [{ return customVerify(); }];
+  let hasVerifier = 1;
   let hasCanonicalizer = 1;
 }
 
@@ -347,7 +347,7 @@ def LoopBreakOp : Arc_Op<"loop.break", [NoSideEffect, Terminator]> {
 
   let arguments = (ins Variadic<AnyType>:$results);
 
-  let verifier = [{ return ::verify(*this); }];
+  let hasVerifier = 1;
 }
 
 def MakeAppenderOp : Arc_Op<"make_appender", [NoSideEffect, Linear]> {
@@ -381,7 +381,7 @@ def MergeOp : Arc_Op<"merge", [NoSideEffect, Linear]> {
   }];
   let arguments = (ins AnyBuilder:$builder, AnyValue:$value);
   let results = (outs AnyBuilder);
-  let verifier = [{ return customVerify(); }];
+  let hasVerifier = 1;
   let extraClassDeclaration = [{ LogicalResult customVerify(); }];
 }
 
@@ -401,7 +401,7 @@ def ResultOp : Arc_Op<"result", [NoSideEffect]> {
   }];
   let arguments = (ins AnyAppender:$builder);
   let results = (outs AnyType);
-  let verifier = [{ return customVerify(); }];
+  let hasVerifier = 1;
   let extraClassDeclaration = [{ LogicalResult customVerify(); }];
 }
 
@@ -431,7 +431,7 @@ def Arc_ConstantIntOp : Arc_Op<"constant", [ConstantLike, NoSideEffect]> {
     AnyArcInteger:$constant
   );
   let hasCustomAssemblyFormat = 1;
-  let verifier = [{ return ::verify(*this); }];
+  let hasVerifier = 1;
   let hasFolder = 1;
 
   let extraClassDeclaration = [{
@@ -482,8 +482,6 @@ def Arc_CmpIOp : Arc_Op<"cmpi",
     }
   }];
 
-  let verifier = [{ return success(); }];
-
   let hasFolder = 1;
 
   let assemblyFormat = "$predicate `,` $lhs `,` $rhs attr-dict `:` type($lhs)";
@@ -500,7 +498,7 @@ def Arc_EmitOp : Arc_Op<"emit", []> {
       ArcStream:$stream
   );
   let results = (outs);
-  let verifier = [{ return customVerify(); }];
+  let hasVerifier = 1;
 
   let extraClassDeclaration = [{ LogicalResult customVerify(); }];
 }
@@ -513,7 +511,7 @@ def Arc_ReceiveOp : Arc_Op<"receive", []> {
 
   let arguments = (ins ArcSourceStream:$source);
   let results = (outs StreamElementType:$value);
-  let verifier = [{ return customVerify(); }];
+  let hasVerifier = 1;
 
   let extraClassDeclaration = [{ LogicalResult customVerify(); }];
 }
@@ -532,7 +530,6 @@ def Arc_SelectOp : Arc_Op<"select", [NoSideEffect, SameOperandsAndResultShape,
                        ArcIntegerLike:$true_value,
                        ArcIntegerLike:$false_value);
   let results = (outs ArcIntegerLike:$result);
-  let verifier = ?;
 
   let extraClassDeclaration = [{
       Value getCondition() { return condition(); }
@@ -558,7 +555,7 @@ def Arc_SendOp : Arc_Op<"send", []> {
       ArcSinkStream:$sink
   );
   let results = (outs);
-  let verifier = [{ return customVerify(); }];
+  let hasVerifier = 1;
 
   let extraClassDeclaration = [{ LogicalResult customVerify(); }];
 }
@@ -576,7 +573,7 @@ def EnumAccessOp : Arc_Op<"enum_access", [NoSideEffect]> {
   let arguments = (ins AnyEnum:$value, StrAttr:$variant);
   let results = (outs AnyType:$result);
   let extraClassDeclaration = [{ LogicalResult customVerify(); }];
-  let verifier = [{ return customVerify(); }];
+  let hasVerifier = 1;
   let hasCanonicalizer = 1;
   let assemblyFormat =
     "$variant `in` `(` $value `:` type($value) `)` attr-dict `:` type($result)";
@@ -595,7 +592,7 @@ def EnumCheckOp : Arc_Op<"enum_check", [NoSideEffect]> {
   let arguments = (ins AnyEnum:$value, StrAttr:$variant);
   let results = (outs BoolLike:$result);
   let extraClassDeclaration = [{ LogicalResult customVerify(); }];
-  let verifier = [{ return customVerify(); }];
+  let hasVerifier = 1;
   let hasCanonicalizer = 1;
   let assemblyFormat =
     "`(` $value `:` type($value) `)` `is` $variant attr-dict `:` type($result)";
@@ -614,7 +611,7 @@ def StructAccessOp : Arc_Op<"struct_access", [NoSideEffect]> {
   let arguments = (ins AnyStruct:$value, StrAttr : $field);
   let results = (outs AnyType);
   let extraClassDeclaration = [{ LogicalResult customVerify(); }];
-  let verifier = [{ return customVerify(); }];
+  let hasVerifier = 1;
   let hasCanonicalizer = 1;
 }
 
@@ -699,7 +696,7 @@ def Arc_StateAppenderPushOp : Arc_Op<"appender_push", []> {
   let arguments = (ins ArcStateAppender:$state, StreamElementType:$value);
   let results = (outs);
   let extraClassDeclaration = [{ LogicalResult customVerify(); }];
-  let verifier = [{ return customVerify(); }];
+  let hasVerifier = 1;
 }
 
 def Arc_StateAppenderFoldOp : Arc_Op<"appender_fold",
@@ -712,7 +709,7 @@ def Arc_StateAppenderFoldOp : Arc_Op<"appender_fold",
                        FlatSymbolRefAttr:$fun);
   let results = (outs StreamElementType:$res);
   let extraClassDeclaration = [{ LogicalResult customVerify(); }];
-  let verifier = [{ return customVerify(); }];
+  let hasVerifier = 1;
   let builders = [
     OpBuilder<(ins "Value":$state, "Value":$init, "StringRef":$callee)>
   ];
@@ -727,7 +724,7 @@ class Arc_KeyedStateMapOp<string mnemonic,
   let arguments = (ins ArcStateMap:$state,
                        StreamElementType:$key);
   let extraClassDeclaration = [{ LogicalResult customVerify(); }];
-  let verifier = [{ return customVerify(); }];
+  let hasVerifier = 1;
 }
 
 def Arc_StateMapContainsOp : Arc_KeyedStateMapOp<"map_contains", []> {
@@ -756,7 +753,7 @@ def Arc_StateMapInsertOp : Arc_Op<"map_insert", []> {
                        StreamElementType:$value);
   let results = (outs);
   let extraClassDeclaration = [{ LogicalResult customVerify(); }];
-  let verifier = [{ return customVerify(); }];
+  let hasVerifier = 1;
 }
 
 def Arc_StateMapRemoveOp : Arc_KeyedStateMapOp<"map_remove", []> {
@@ -777,7 +774,7 @@ def Arc_StateValueWriteOp : Arc_Op<"value_write", []> {
   let arguments = (ins ArcStateValue:$state, StreamElementType:$value);
   let results = (outs);
   let extraClassDeclaration = [{ LogicalResult customVerify(); }];
-  let verifier = [{ return customVerify(); }];
+  let hasVerifier = 1;
 }
 
 def Arc_StateValueReadOp : Arc_Op<"value_read", []> {
@@ -788,7 +785,7 @@ def Arc_StateValueReadOp : Arc_Op<"value_read", []> {
   let arguments = (ins ArcStateValue:$state);
   let results = (outs StreamElementType);
   let extraClassDeclaration = [{ LogicalResult customVerify(); }];
-  let verifier = [{ return customVerify(); }];
+  let hasVerifier = 1;
 }
 
 def PanicOp : Arc_Op<"panic", []> {
@@ -821,7 +818,7 @@ def ArcReturnOp : Arc_Op<"return", [Terminator]> {
 
   let arguments = (ins Optional<AnyType>:$operands);
 
-  let verifier = [{ return ::verify(*this); }];
+  let hasVerifier = 1;
 }
 
 

--- a/arc-mlir/src/include/Arc/Opts.td
+++ b/arc-mlir/src/include/Arc/Opts.td
@@ -26,6 +26,7 @@
 #ifndef STANDARD_OPS
 include "../../mlir/include/mlir/Dialect/Func/IR/FuncOps.td"
 include "../../mlir/include/mlir/Dialect/Arithmetic/IR/ArithmeticOps.td"
+include "../../mlir/include/mlir/IR/PatternBase.td"
 #endif // STANDARD_OPS
 
 #ifndef ARC_OPS

--- a/arc-mlir/src/include/Rust/Rust.h
+++ b/arc-mlir/src/include/Rust/Rust.h
@@ -28,7 +28,9 @@
 #include <mlir/IR/Builders.h>
 #include <mlir/IR/BuiltinOps.h>
 #include <mlir/IR/Dialect.h>
+#include <mlir/IR/FunctionInterfaces.h>
 #include <mlir/IR/Operation.h>
+#include <mlir/Interfaces/CallInterfaces.h>
 #include <mlir/Interfaces/ControlFlowInterfaces.h>
 #include <mlir/Interfaces/SideEffectInterfaces.h>
 

--- a/arc-mlir/src/include/Rust/Rust.td
+++ b/arc-mlir/src/include/Rust/Rust.td
@@ -186,12 +186,11 @@ def RustCallIndirectOp : Rust_Op<"call_indirect", [
     // Write this op as Rust code to os
     void writeRust(RustPrinterStream &os);
   }];
-
-  let verifier = ?;
 }
 
 
-def Rust_RustFuncOp : Rust_Op<"func", [FunctionOpInterface, IsolatedFromAbove, Symbol]> {
+def Rust_RustFuncOp : Rust_Op<"func",
+  [FunctionOpInterface, IsolatedFromAbove, Symbol]> {
   let summary = "A function";
 
   let description = [{
@@ -199,17 +198,23 @@ def Rust_RustFuncOp : Rust_Op<"func", [FunctionOpInterface, IsolatedFromAbove, S
 
   let regions = (region AnyRegion:$body);
 
+  let arguments = (ins SymbolNameAttr:$sym_name,
+                       TypeAttrOf<FunctionType>:$function_type,
+                       OptionalAttr<StrAttr>:$sym_visibility);
   let extraClassDeclaration = [{
-    /// Returns the type of the function this Op defines.
-    FunctionType getType() {
-      return getTypeAttr().getValue().cast<FunctionType>();
+    FunctionType getFunctionType() {
+      return getFunctionTypeAttr().getValue().cast<FunctionType>();
     }
 
     /// Returns the argument types of this function.
-    ArrayRef<Type> getArgumentTypes() { return getType().getInputs(); }
+    ArrayRef<Type> getArgumentTypes() {
+      return getFunctionType().cast<FunctionType>().getInputs();
+    }
 
     /// Returns the result types of this function.
-    ArrayRef<Type> getResultTypes() { return getType().getResults(); }
+    ArrayRef<Type> getResultTypes() {
+      return getFunctionType().cast<FunctionType>().getResults();
+    }
 
     /// Hook for FunctionOpInterface verifier.
     LogicalResult verifyType();
@@ -222,25 +227,32 @@ def Rust_RustFuncOp : Rust_Op<"func", [FunctionOpInterface, IsolatedFromAbove, S
   }];
 }
 
-def Rust_RustExtFuncOp : Rust_Op<"extfunc", [FunctionOpInterface, IsolatedFromAbove, Symbol]> {
+def Rust_RustExtFuncOp : Rust_Op<"extfunc",
+  [FunctionOpInterface, IsolatedFromAbove, Symbol]> {
   let summary = "An external function";
 
   let description = [{
   }];
 
   let regions = (region AnyRegion:$empty_body);
+  let arguments = (ins SymbolNameAttr:$sym_name,
+                       TypeAttrOf<FunctionType>:$function_type,
+                       OptionalAttr<StrAttr>:$sym_visibility);
 
   let extraClassDeclaration = [{
-    /// Returns the type of the function this Op defines.
-    FunctionType getType() {
-      return getTypeAttr().getValue().cast<FunctionType>();
-    }
+     FunctionType getFunctionType() {
+       return getFunctionTypeAttr().getValue().cast<FunctionType>();
+     }
 
     /// Returns the argument types of this function.
-    ArrayRef<Type> getArgumentTypes() { return getType().getInputs(); }
+    ArrayRef<Type> getArgumentTypes() {
+      return getFunctionType().cast<FunctionType>().getInputs();
+    }
 
     /// Returns the result types of this function.
-    ArrayRef<Type> getResultTypes() { return getType().getResults(); }
+    ArrayRef<Type> getResultTypes() {
+      return getFunctionType().cast<FunctionType>().getResults();
+    }
 
     /// Hook for FunctionOpInterface verifier.
     LogicalResult verifyType();
@@ -321,7 +333,7 @@ def Rust_RustLoopBreakOp : Rust_Op<"loop.break",
     void writeRust(RustPrinterStream &os);
   }];
 
-  let verifier = [{ return ::verify(*this); }];
+  let hasVerifier = 1;
 }
 
 def Rust_RustReturnOp : Rust_Op<"return", [Terminator]> {
@@ -334,7 +346,7 @@ def Rust_RustReturnOp : Rust_Op<"return", [Terminator]> {
 
   let arguments = (ins Optional<AnyRustType>:$operands);
 
-  let verifier = [{ return ::verify(*this); }];
+  let hasVerifier = 1;
 
   let extraClassDeclaration = [{
     // Write this function as Rust code to os
@@ -570,7 +582,7 @@ def Rust_RustIfOp
     // Write this operation as Rust code to the stream
     void writeRust(RustPrinterStream &);
   }];
-  let verifier = [{ return ::verify(*this); }];
+  let hasVerifier = 1;
 }
 
 def Rust_RustMakeEnumOp

--- a/arc-mlir/src/lib/Arc/LowerToRust.cpp
+++ b/arc-mlir/src/lib/Arc/LowerToRust.cpp
@@ -308,14 +308,14 @@ private:
         SymbolTable::lookupNearestSymbolFrom(op->getParentOp(), attr);
 
     if (rust::RustFuncOp o = dyn_cast<rust::RustFuncOp>(refOp)) {
-      Type ty = o.getType();
+      Type ty = o.getFunctionType();
       Type rustTy = TypeConverter.convertType(ty);
 
       rewriter.replaceOpWithNewOp<rust::RustConstantOp>(op, rustTy,
                                                         o.getName());
       return success();
     } else if (rust::RustExtFuncOp o = dyn_cast<rust::RustExtFuncOp>(refOp)) {
-      Type ty = o.getType();
+      Type ty = o.getFunctionType();
       Type rustTy = TypeConverter.convertType(ty);
 
       rewriter.replaceOpWithNewOp<rust::RustConstantOp>(op, rustTy,
@@ -1116,10 +1116,10 @@ struct FuncOpLowering : public OpConversionPattern<mlir::FuncOp> {
 
     TypeConverter::SignatureConversion sigConv(func.getNumArguments());
     mlir::FunctionType funcType =
-        TypeConverter.convertFunctionSignature(func.getType(), sigConv);
+        TypeConverter.convertFunctionSignature(func.getFunctionType(), sigConv);
 
     attributes.push_back(
-        NamedAttribute(StringAttr::get(ctx, "type"), TypeAttr::get(funcType)));
+        NamedAttribute(StringAttr::get(ctx, "function_type"), TypeAttr::get(funcType)));
     attributes.push_back(NamedAttribute(StringAttr::get(ctx, "sym_name"),
                                         StringAttr::get(ctx, func.getName())));
 

--- a/arc-mlir/src/lib/Arc/ToSCF.cpp
+++ b/arc-mlir/src/lib/Arc/ToSCF.cpp
@@ -176,8 +176,9 @@ private:
     // Create a variant to hold the result
     StringAttr returnValueVariantName =
         StringAttr::get(getContext(), "ReturnValue");
-    Type funReturnTy = f.getType().getNumResults() ? f.getType().getResult(0)
-                                                   : rewriter.getNoneType();
+    FunctionType funTy = f.getFunctionType();
+    Type funReturnTy =
+        funTy.getNumResults() ? funTy.getResult(0) : rewriter.getNoneType();
     types::EnumType::VariantTy returnValueVariant{returnValueVariantName,
                                                   funReturnTy};
     enumVariants.push_back(returnValueVariant);
@@ -332,7 +333,7 @@ private:
 
     // Return the result
     rewriter.setInsertionPointAfter(loop);
-    if (f.getType().getNumResults()) {
+    if (f.getFunctionType().getNumResults()) {
       Value r = rewriter.create<arc::EnumAccessOp>(
           f.getLoc(), funReturnTy, loop.getResult(0), returnValueVariantName);
       rewriter.create<func::ReturnOp>(f.getLoc(), r);

--- a/arc-mlir/src/tests/rust/crate.mlir
+++ b/arc-mlir/src/tests/rust/crate.mlir
@@ -5,26 +5,29 @@
 module @"name-of-the-crate-0" {
 "rust.func"() ( {
 
-}) {sym_name = "the-function-name-0", type = () -> () } : () -> ()
+}) {sym_name = "the-function-name-0",
+    function_type = () -> () } : () -> ()
 
 "rust.func"() ( {
  ^bb0(%arg0: !rust<"f32">):
  "rust.return"(%arg0) : (!rust<"f32">) -> ()
 
-}) {sym_name = "the-function-name-1", type = (!rust<"f32">) -> !rust<"f32"> } : () -> ()
+}) {sym_name = "the-function-name-1",
+    function_type = (!rust<"f32">) -> !rust<"f32"> } : () -> ()
 
 "rust.func"() ( {
  ^bb0(%arg0: !rust<"f64">):
  "rust.return"(%arg0) : (!rust<"f64">) -> ()
 
-}) {sym_name = "the-function-name-2", type = (!rust<"f64">) -> !rust<"f64"> } : () -> ()
+}) {sym_name = "the-function-name-2",
+    function_type = (!rust<"f64">) -> !rust<"f64"> } : () -> ()
 }
 
 // -----
 
 module @"name-of-the-crate-1" {
 
-// expected-error@+2 {{'rust.func' op requires a type attribute 'type'}}
+// expected-error@+2 {{'rust.func' op requires attribute 'function_type'}}
 // expected-note@+1 {{see current operation: "rust.func"() (}}
 "rust.func"() ( {
  ^bb0(%arg0: !rust<"f32">):
@@ -41,7 +44,8 @@ module @"name-of-the-crate-2" {
 "rust.func"() ( {
  ^bb0(%arg0: !rust<"f32">, %arg1: !rust<"f32">):
  "rust.return"(%arg0) : (!rust<"f32">) -> ()
-}) {sym_name = "the-function-name-1", type = (!rust<"f32">) -> !rust<"f32"> } : () -> ()
+}) {sym_name = "the-function-name-1",
+    function_type = (!rust<"f32">) -> !rust<"f32"> } : () -> ()
 }
 
 // -----
@@ -52,7 +56,8 @@ module @"name-of-the-crate-3" {
 "rust.func"() ( {
  ^bb0(%arg0: !rust<"f32">):
  "rust.return"(%arg0) : (!rust<"f32">) -> ()
-}) {sym_name = "the-function-name-1", type = (!rust<"f64">) -> !rust<"f32"> } : () -> ()
+}) {sym_name = "the-function-name-1",
+    function_type = (!rust<"f64">) -> !rust<"f32"> } : () -> ()
 }
 
 // -----
@@ -63,6 +68,7 @@ module @"name-of-the-crate-3" {
 // expected-error@+2 {{'rust.return' op result type does not match the type of the function: expected '!rust.f64' but found '!rust.f32'}}
 // expected-note@+1 {{see current operation: "rust.return"}}
  "rust.return"(%arg0) : (!rust<"f32">) -> ()
-}) {sym_name = "the-function-name-1", type = (!rust<"f32">) -> !rust<"f64"> } : () -> ()
+}) {sym_name = "the-function-name-1",
+    function_type = (!rust<"f32">) -> !rust<"f64"> } : () -> ()
 }
 

--- a/arc-mlir/src/tests/rust/loop.mlir
+++ b/arc-mlir/src/tests/rust/loop.mlir
@@ -18,7 +18,7 @@ module @"loop_crate" {
     "rust.return"(%0#1) : (!rust<"u64">) -> ()
 }) {
     sym_name = "a_while_loop",
-    type = (!rust<"u64">, !rust<"u64">, !rust<"u64">) -> !rust<"u64">
+    function_type = (!rust<"u64">, !rust<"u64">, !rust<"u64">) -> !rust<"u64">
    } : () -> ()
 
 "rust.func"() ( {
@@ -46,7 +46,7 @@ module @"loop_crate" {
     "rust.return"(%0#1) : (!rust<"u64">) -> ()
 }) {
     sym_name = "a_while_loop_with_a_break_in_before",
-    type = (!rust<"u64">, !rust<"u64">, !rust<"u64">) -> !rust<"u64">
+    function_type = (!rust<"u64">, !rust<"u64">, !rust<"u64">) -> !rust<"u64">
    } : () -> ()
 
 "rust.func"() ( {
@@ -74,7 +74,7 @@ module @"loop_crate" {
     "rust.return"(%0#1) : (!rust<"u64">) -> ()
 }) {
     sym_name = "a_while_loop_with_a_break_in_after",
-    type = (!rust<"u64">, !rust<"u64">, !rust<"u64">) -> !rust<"u64">
+    function_type = (!rust<"u64">, !rust<"u64">, !rust<"u64">) -> !rust<"u64">
    } : () -> ()
 }
 

--- a/arc-mlir/src/tests/rust/rust-output.mlir
+++ b/arc-mlir/src/tests/rust/rust-output.mlir
@@ -6,20 +6,23 @@ module @"this_is_the_name_of_the_crate" {
  ^bb0(%arg0: !rust<"f32">):
  "rust.return"(%arg0) : (!rust<"f32">) -> ()
 
-}) {sym_name = "this_is_the_name_of_the_second_function", type = (!rust<"f32">) -> !rust<"f32"> } : () -> ()
+}) {sym_name = "this_is_the_name_of_the_second_function",
+    function_type = (!rust<"f32">) -> !rust<"f32"> } : () -> ()
 
 "rust.func"() ( {
  ^bb0(%arg0: !rust<"f64">):
  "rust.return"(%arg0) : (!rust<"f64">) -> ()
 
-}) {sym_name = "this_is_the_name_of_the_third_function", type = (!rust<"f64">) -> !rust<"f64"> } : () -> ()
+}) {sym_name = "this_is_the_name_of_the_third_function",
+    function_type = (!rust<"f64">) -> !rust<"f64"> } : () -> ()
 
 "rust.func"() ( {
  ^bb0:
  %r = "rust.constant"() {value="3.14"} : () -> (!rust<"f64">)
  "rust.return"(%r) : (!rust<"f64">) -> ()
 
-}) {sym_name = "this_is_the_name_of_the_fourth_function", type = () -> !rust<"f64"> } : () -> ()
+}) {sym_name = "this_is_the_name_of_the_fourth_function",
+    function_type = () -> !rust<"f64"> } : () -> ()
 
 "rust.func"() ( {
  ^bb0:
@@ -27,7 +30,8 @@ module @"this_is_the_name_of_the_crate" {
  %x = "rust.unaryop"(%r) {op="-"} : (!rust<"f64">) -> (!rust<"f64">)
  "rust.return"(%x) : (!rust<"f64">) -> ()
 
-}) {sym_name = "this_is_the_name_of_the_fifth_function", type = () -> !rust<"f64"> } : () -> ()
+}) {sym_name = "this_is_the_name_of_the_fifth_function",
+    function_type = () -> !rust<"f64"> } : () -> ()
 
 "rust.func"() ( {
  ^bb0(%arg0: !rust<"f64">):
@@ -36,7 +40,8 @@ module @"this_is_the_name_of_the_crate" {
  %y = "rust.binaryop"(%arg0, %x) {op="+"} : (!rust<"f64">, !rust<"f64">) -> (!rust<"f64">)
  "rust.return"(%y) : (!rust<"f64">) -> ()
 
-}) {sym_name = "this_is_the_name_of_the_sixth_function", type = (!rust<"f64">) -> !rust<"f64"> } : () -> ()
+}) {sym_name = "this_is_the_name_of_the_sixth_function",
+    function_type = (!rust<"f64">) -> !rust<"f64"> } : () -> ()
 
 "rust.func"() ( {
  ^bb0(%arg0: !rust<"bool">, %arg1: !rust<"f64">):
@@ -50,14 +55,16 @@ module @"this_is_the_name_of_the_crate" {
        }) : (!rust<"bool">) -> !rust<"f64">
  "rust.return"(%all) : (!rust<"f64">) -> ()
 
-}) {sym_name = "this_is_the_name_of_the_seventh_function", type = (!rust<"bool">, !rust<"f64">) -> !rust<"f64"> } : () -> ()
+}) {sym_name = "this_is_the_name_of_the_seventh_function",
+    function_type = (!rust<"bool">, !rust<"f64">) -> !rust<"f64"> } : () -> ()
 
 "rust.func"() ( {
  ^bb0(%a: !rust<"f64">, %b: !rust<"f64">):
  %x = "rust.compop"(%a, %b) {op="<"} : (!rust<"f64">, !rust<"f64">) -> (!rust<"bool">)
  "rust.return"(%x) : (!rust<"bool">) -> ()
 
-}) {sym_name = "this_is_the_name_of_the_eigth_function", type = (!rust<"f64">, !rust<"f64">) -> !rust<"bool"> } : () -> ()
+}) {sym_name = "this_is_the_name_of_the_eigth_function",
+    function_type = (!rust<"f64">, !rust<"f64">) -> !rust<"bool"> } : () -> ()
 
 "rust.func"() ( {
  ^bb0:
@@ -65,7 +72,8 @@ module @"this_is_the_name_of_the_crate" {
  %r = "rust.method_call"(%a) {method="sin"} : (!rust<"f64">) -> (!rust<"f64">)
  "rust.return"(%r) : (!rust<"f64">) -> ()
 
-}) {sym_name = "testing_a_method_call", type = () -> !rust<"f64"> } : () -> ()
+}) {sym_name = "testing_a_method_call",
+    function_type = () -> !rust<"f64"> } : () -> ()
 
 "rust.func"() ( {
  ^bb0:
@@ -74,7 +82,8 @@ module @"this_is_the_name_of_the_crate" {
  %r = "rust.method_call"(%a, %b) {method="log"} : (!rust<"f64">, !rust<"f64">) -> (!rust<"f64">)
  "rust.return"(%r) : (!rust<"f64">) -> ()
 
-}) {sym_name = "testing_a_method_call_with_args", type = () -> !rust<"f64"> } : () -> ()
+}) {sym_name = "testing_a_method_call_with_args",
+    function_type = () -> !rust<"f64"> } : () -> ()
 
 "rust.func"() ( {
  ^bb0:
@@ -83,7 +92,8 @@ module @"this_is_the_name_of_the_crate" {
  %r = "rust.method_call"(%a, %b) {method="log"} : (!rust<"f64">, !rust<"f64">) -> (!rust<"f64">)
  "rust.return"() : () -> ()
 
-}) {sym_name = "no_returned_value", type = () -> () } : () -> ()
+}) {sym_name = "no_returned_value",
+    function_type = () -> () } : () -> ()
 
 "rust.func"() ( {
  ^bb0(%arg0: !rust<"bool">, %arg1: !rust<"f64">):
@@ -97,7 +107,8 @@ module @"this_is_the_name_of_the_crate" {
    }) : (!rust<"bool">) -> ()
  "rust.return"() : () -> ()
 
-}) {sym_name = "if_without_value", type = (!rust<"bool">, !rust<"f64">) -> () } : () -> ()
+}) {sym_name = "if_without_value",
+    function_type = (!rust<"bool">, !rust<"f64">) -> () } : () -> ()
 
 
 }


### PR DESCRIPTION
Changes needed:

 * There is no longer a way to define a custom verifer in tablegen
   using `verifier`. Instead a verifier has to use the default
   signature, and its existance is indicated by `hasVerifier`.

 * Upstream has split out AttrDef/TypeDef and pattern constructs from
   OpBase.td, so we have to include `mlir/IR/PatternBase.td` when
   defining rewrite patterns using Tablegen.

 * Adapt to upstream refactoring and moving function anc call
   interfaces to their own headers.

 * The attribute used for the type of a function has been renamed to
   `function_type` from `type` for operators using the function
   interface. So we have to do the corresponding rename for the Rust
   dialect and update the lowering of Arc to Rust.