### PR TITLE
tests: Speed up repeated test runs

### DIFF
--- a/arc-mlir/src/tools/arc-mlir-rust-test.in
+++ b/arc-mlir/src/tools/arc-mlir-rust-test.in
@@ -33,8 +33,6 @@ if [ -f "${CARGO_DEP_FRAGMENT}.cargo-dep" ]; then
 fi
 echo "XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX"
 
-# Clean the work directory
-rm -rf ${WORK_DIR}
 mkdir -p ${WORK_DIR}/src
 
 # Create the Cargo.toml


### PR DESCRIPTION
By not removing the work directory we can speed up repeated tests
runs. The main benefit is due to the preservation of the Cargo target
directory, as Cargo is smart enough to avoid recompiling if the Rust
output from arc-mlir has not changed.