### PR TITLE
MLIR Support for Nested ADTs

### DIFF
--- a/arc-mlir/src/include/Arc/Arc.td
+++ b/arc-mlir/src/include/Arc/Arc.td
@@ -97,7 +97,13 @@ def ArcTensorElementType : Type<Or<[
         AnyFloat.predicate]>,
     "arc-tensor-element">;
 
-def ADTType : Type<CPred<"$_self.isa<ADTType>()">, "an ADT type">;
+def ADTType : Type<Or<[
+        CPred<"$_self.isa<ADTType>()">,
+        CPred<"$_self.isa<ADTGenericType>()">]>,
+    "arc-adt">;
+def ADTSimpleType : Type<CPred<"$_self.isa<ADTType>()">, "an ADT type">;
+def ADTGenericType : Type<CPred<"$_self.isa<ADTGenericType>()">, "an ADT template type">;
+
 def AnyBuilder : Type<CPred<"$_self.isa<BuilderType>()">, "any builder">;
 def AnyAppender : Type<CPred<"$_self.isa<AppenderType>()">, "any appender">;
 def AnyEnum : Type<CPred<"$_self.isa<EnumType>()">, "any enum">;

--- a/arc-mlir/src/include/Arc/Types.h
+++ b/arc-mlir/src/include/Arc/Types.h
@@ -56,6 +56,7 @@ struct StreamTypeStorage;
 struct EnumTypeStorage;
 struct StructTypeStorage;
 struct ADTTypeStorage;
+struct ADTGenericTypeStorage;
 
 //===----------------------------------------------------------------------===//
 // Arc Types
@@ -70,6 +71,21 @@ public:
 
   /// Returns the Rust name for this type.
   StringRef getTypeName() const;
+
+  static Type parse(DialectAsmParser &parser);
+  void print(DialectAsmPrinter &os) const;
+};
+
+class ADTGenericType : public mlir::Type::TypeBase<ADTGenericType, mlir::Type,
+                                                   ADTGenericTypeStorage> {
+public:
+  using Base::Base;
+
+  static ADTGenericType get(mlir::MLIRContext *ctx, StringRef name,
+                            llvm::ArrayRef<mlir::Type> parameterTypes);
+
+  StringRef getTemplateName() const;
+  llvm::ArrayRef<mlir::Type> getParameterTypes() const;
 
   static Type parse(DialectAsmParser &parser);
   void print(DialectAsmPrinter &os) const;

--- a/arc-mlir/src/include/Rust/Rust.td
+++ b/arc-mlir/src/include/Rust/Rust.td
@@ -58,7 +58,7 @@ def Rust_Dialect : Dialect {
 class Rust_Op<string mnemonic, list<Trait> traits = []>
     : Op<Rust_Dialect, mnemonic, traits>;
 
-def AnyRustType : Type<CPred<"$_self.isa<RustType>() || $_self.isa<RustStructType>() || $_self.isa<RustTupleType>() || $_self.isa<RustTensorType>() || $_self.isa<RustEnumType>() || isRustFunctionType($_self) || $_self.isa<RustStreamType>() || $_self.isa<RustSinkStreamType>() || $_self.isa<RustSourceStreamType>()">, "any RustType">;
+def AnyRustType : Type<CPred<"$_self.isa<RustType>() || $_self.isa<RustStructType>() || $_self.isa<RustTupleType>() || $_self.isa<RustTensorType>() || $_self.isa<RustEnumType>() || isRustFunctionType($_self) || $_self.isa<RustStreamType>() || $_self.isa<RustSinkStreamType>() || $_self.isa<RustSourceStreamType>() || $_self.isa<RustGenericADTType>()">, "any RustType">;
 
 def AnyRustStream :
     Type<CPred<"$_self.isa<RustStreamType>()">, "any RustStream">;

--- a/arc-mlir/src/include/Rust/Types.h
+++ b/arc-mlir/src/include/Rust/Types.h
@@ -41,6 +41,7 @@ namespace types {
 
 struct RustTypeStorage;
 struct RustEnumTypeStorage;
+struct RustGenericADTTypeStorage;
 struct RustSinkStreamTypeStorage;
 struct RustSourceStreamTypeStorage;
 struct RustStreamTypeStorage;
@@ -49,6 +50,7 @@ struct RustTupleTypeStorage;
 struct RustTensorTypeStorage;
 
 class RustEnumType;
+class RustGenericADTType;
 
 //===----------------------------------------------------------------------===//
 // Rust Types
@@ -160,6 +162,22 @@ public:
   typedef std::pair<mlir::StringAttr, Type> EnumVariantTy;
   static RustEnumType get(RustDialect *dialect,
                           ArrayRef<EnumVariantTy> variants);
+  void emitNestedTypedefs(rust::RustPrinterStream &ps) const;
+  std::string getSignature() const;
+};
+
+class RustGenericADTType : public Type::TypeBase<RustGenericADTType, Type,
+                                                 RustGenericADTTypeStorage> {
+public:
+  using Base::Base;
+
+  void print(DialectAsmPrinter &os) const;
+  rust::RustPrinterStream &printAsRust(rust::RustPrinterStream &os) const;
+  raw_ostream &printAsRustNamedType(raw_ostream &os) const;
+  std::string getRustType() const;
+
+  static RustGenericADTType get(RustDialect *dialect, StringRef name,
+                                ArrayRef<Type> parameters);
   void emitNestedTypedefs(rust::RustPrinterStream &ps) const;
   std::string getSignature() const;
 };

--- a/arc-mlir/src/tests/arc-to-rust/adt.mlir
+++ b/arc-mlir/src/tests/arc-to-rust/adt.mlir
@@ -16,4 +16,19 @@ func @ok0(%in : !arc.adt<"i32">) -> () {
     %out = arc.adt_constant "4711" : !arc.adt<"i32">
     return %out : !arc.adt<"i32">
   }
+
+  func @ok6(%in : !arc.generic_adt<"crate::arctorustadt::tests::sharable_Foo::Foo", ui32>)
+     -> !arc.generic_adt<"crate::arctorustadt::tests::sharable_Foo::Foo", ui32> {
+     return %in : !arc.generic_adt<"crate::arctorustadt::tests::sharable_Foo::Foo", ui32>
+  }
+
+  func @ok7(%in : !arc.generic_adt<"crate::arctorustadt::tests::sharable_Bar::Bar", ui32, !arc.generic_adt<"crate::arctorustadt::tests::sharable_Foo::Foo", f64>>)
+    -> !arc.generic_adt<"crate::arctorustadt::tests::sharable_Bar::Bar", ui32, !arc.generic_adt<"crate::arctorustadt::tests::sharable_Foo::Foo", f64>> {
+    return %in : !arc.generic_adt<"crate::arctorustadt::tests::sharable_Bar::Bar", ui32, !arc.generic_adt<"crate::arctorustadt::tests::sharable_Foo::Foo", f64>>
+  }
+
+  func @ok8(%in : !arc.generic_adt<"crate::arctorustadt::tests::sharable_Bar::Bar", ui32, !arc.adt<"i32">>)
+    -> !arc.generic_adt<"crate::arctorustadt::tests::sharable_Bar::Bar", ui32, !arc.adt<"i32">> {
+    return %in : !arc.generic_adt<"crate::arctorustadt::tests::sharable_Bar::Bar", ui32, !arc.adt<"i32">>
+  }
 }

--- a/arc-mlir/src/tests/arc-to-rust/adt.mlir.rust-tests
+++ b/arc-mlir/src/tests/arc-to-rust/adt.mlir.rust-tests
@@ -1,6 +1,18 @@
 #[cfg(test)]
 mod tests {
- use crate::arctorustadt::*;
+  use crate::arctorustadt::*;
+
+  #[rewrite]
+  pub struct Foo<A> {
+    pub a: A,
+  }
+
+  #[rewrite]
+  pub struct Bar<A, B> {
+    pub a: A,
+    pub b: B,
+  }
+
   #[rewrite(main)]
   #[test]
   fn test() {


### PR DESCRIPTION
The support for nested ADT types in MLIR requires a runtime without `features = ["legacy"]`, but as that fails many other tests, this patch series and #398 will have to wait until the legacyectomy is done.