### PR TITLE
mlir: Remove support for the legacy runtime

### DIFF
--- a/arc-mlir/src/tools/arc-mlir-rust-test.in
+++ b/arc-mlir/src/tools/arc-mlir-rust-test.in
@@ -48,7 +48,7 @@ fi
 # Create dummy wrapper .rs-file which includes the generated test-case
 
 echo '#![feature(unboxed_closures)]' > ${MAIN}
-arc-mlir ${MLIR_FILE} "$@" -arc-to-rust -inline-rust -arc-lang-runtime >> ${MAIN}
+arc-mlir ${MLIR_FILE} "$@" -arc-to-rust -inline-rust >> ${MAIN}
 
 cat >> ${MAIN} <<EOF
 fn main() {

--- a/arc-mlir/src/tools/arc.in
+++ b/arc-mlir/src/tools/arc.in
@@ -211,7 +211,7 @@ esac
 
 [ "$ARC_DEBUG" ] && echo "$CRATE_MLIR_FILE: " && cat "$CRATE_MLIR_FILE"
 
-"$ARC_MLIR" "$CRATE_MLIR_FILE" "$@" -arc-to-rust -inline-rust -arc-lang-runtime >> "$CRATE_MAIN_FILE"
+"$ARC_MLIR" "$CRATE_MLIR_FILE" "$@" -arc-to-rust -inline-rust >> "$CRATE_MAIN_FILE"
 
 case $CARGO_MODE in
     test)


### PR DESCRIPTION
Remove all support in the MLIR tools for targeting the legacy runtime