### PR TITLE
LLVM submodule update

### DIFF
--- a/arc-mlir/src/include/Arc/Arc.td
+++ b/arc-mlir/src/include/Arc/Arc.td
@@ -24,6 +24,7 @@
 #define ARC_OPS
 
 #ifndef OP_BASE
+include "../../mlir/include/mlir/IR/EnumAttr.td"
 include "../../mlir/include/mlir/IR/OpBase.td"
 include "../../mlir/include/mlir/Interfaces/CallInterfaces.td"
 include "../../mlir/include/mlir/Interfaces/InferTypeOpInterface.td"

--- a/arc-mlir/src/include/Arc/Passes.h
+++ b/arc-mlir/src/include/Arc/Passes.h
@@ -39,7 +39,7 @@ std::unique_ptr<OperationPass<ModuleOp>> createLowerToRustPass();
 
 /// Create a pass for converting structured flow-control to branches
 /// between basic blocks.
-std::unique_ptr<OperationPass<FuncOp>> createRemoveSCFPass();
+std::unique_ptr<OperationPass<mlir::func::FuncOp>> createRemoveSCFPass();
 
 /// Create a pass for converting branches
 /// between basic blocks to structured flow-control.

--- a/arc-mlir/src/include/Arc/Passes.td
+++ b/arc-mlir/src/include/Arc/Passes.td
@@ -27,7 +27,7 @@ def LowerToRust : Pass<"arc-to-rust", "ModuleOp"> {
   ];
 }
 
-def RemoveSCF : Pass<"remove-scf", "FuncOp"> {
+def RemoveSCF : Pass<"remove-scf", "mlir::func::FuncOp"> {
   let summary = "Convert structured flow-control to branches between basic blocks";
   let constructor = "arc::createRemoveSCFPass()";
 

--- a/arc-mlir/src/lib/Arc/Dialect.cpp
+++ b/arc-mlir/src/lib/Arc/Dialect.cpp
@@ -634,7 +634,8 @@ OpFoldResult arc::OrOp::fold(ArrayRef<Attribute> operands) {
 //===----------------------------------------------------------------------===//
 LogicalResult ReceiveOp::verify() {
   // Check that we're located inside a task
-  FuncOp function = getOperation()->getParentOfType<FuncOp>();
+  mlir::func::FuncOp function =
+      getOperation()->getParentOfType<mlir::func::FuncOp>();
   if (!function->hasAttr("arc.is_task")) {
     emitOpError("can only be used inside a task");
     return mlir::failure();
@@ -681,7 +682,7 @@ OpFoldResult RemIOp::fold(ArrayRef<Attribute> operands) {
 // ArcReturnOp
 //===----------------------------------------------------------------------===//
 LogicalResult ArcReturnOp::verify() {
-  FuncOp function = (*this)->getParentOfType<FuncOp>();
+  mlir::func::FuncOp function = (*this)->getParentOfType<mlir::func::FuncOp>();
   if (!function)
     return emitOpError("expects parent op builtin.func");
 
@@ -731,7 +732,8 @@ OpFoldResult arc::SelectOp::fold(ArrayRef<Attribute> operands) {
 //===----------------------------------------------------------------------===//
 LogicalResult SendOp::verify() {
   // Check that we're located inside a task
-  FuncOp function = getOperation()->getParentOfType<FuncOp>();
+  mlir::func::FuncOp function =
+      getOperation()->getParentOfType<mlir::func::FuncOp>();
   if (!function->hasAttr("arc.is_task")) {
     emitOpError("can only be used inside a task");
     return mlir::failure();
@@ -794,7 +796,7 @@ LogicalResult StateAppenderFoldOp::verify() {
       this->getOperation(), funName);
   auto StateTy = state().getType().cast<ArconAppenderType>().getType();
 
-  FuncOp F = dyn_cast<FuncOp>(Callee);
+  mlir::func::FuncOp F = dyn_cast<mlir::func::FuncOp>(Callee);
   FunctionType FT = F.getFunctionType().dyn_cast<FunctionType>();
 
   if (!F)

--- a/arc-mlir/src/lib/Arc/LowerToRust.cpp
+++ b/arc-mlir/src/lib/Arc/LowerToRust.cpp
@@ -1103,14 +1103,14 @@ RustTypeConverter::convertFunctionSignature(Type ty, SignatureConversion &SC) {
   return funcType;
 }
 
-struct FuncOpLowering : public OpConversionPattern<mlir::FuncOp> {
+struct FuncOpLowering : public OpConversionPattern<mlir::func::FuncOp> {
 
   FuncOpLowering(MLIRContext *ctx, RustTypeConverter &typeConverter)
-      : OpConversionPattern<mlir::FuncOp>(typeConverter, ctx, 1),
+      : OpConversionPattern<mlir::func::FuncOp>(typeConverter, ctx, 1),
         TypeConverter(typeConverter) {}
 
   LogicalResult
-  matchAndRewrite(mlir::FuncOp func, OpAdaptor adaptor,
+  matchAndRewrite(mlir::func::FuncOp func, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const final {
     MLIRContext *ctx = func.getContext();
     SmallVector<NamedAttribute, 4> attributes;
@@ -1185,7 +1185,7 @@ private:
   LogicalResult buildLocalFun(ConversionPatternRewriter &rewriter,
                               ArrayRef<Value> &operands,
                               SmallVector<NamedAttribute, 4> &attributes,
-                              mlir::FuncOp &func, Operation *op,
+                              mlir::func::FuncOp &func, Operation *op,
                               TypeConverter::SignatureConversion &sigConv,
                               MLIRContext *ctx) const {
 
@@ -1206,7 +1206,7 @@ private:
   LogicalResult buildExternalFun(ConversionPatternRewriter &rewriter,
                                  ArrayRef<Value> &operands,
                                  SmallVector<NamedAttribute, 4> &attributes,
-                                 mlir::FuncOp &func, Operation *op,
+                                 mlir::func::FuncOp &func, Operation *op,
                                  TypeConverter::SignatureConversion &sigConv,
                                  MLIRContext *ctx) const {
     auto newOp = rewriter.create<rust::RustExtFuncOp>(

--- a/arc-mlir/src/lib/Arc/RemoveSCF.cpp
+++ b/arc-mlir/src/lib/Arc/RemoveSCF.cpp
@@ -209,7 +209,7 @@ LogicalResult WhileLowering::matchAndRewrite(scf::WhileOp whileOp,
 }
 
 void RemoveSCF::runOnOperation() {
-  mlir::FuncOp f = getOperation();
+  mlir::func::FuncOp f = getOperation();
 
   // In order to match arc.loop.breaks to their enclosing scf.while we
   // add an unique attribute to each scf.while. We then tag all
@@ -245,6 +245,6 @@ void RemoveSCF::runOnOperation() {
     signalPassFailure();
 }
 
-std::unique_ptr<OperationPass<FuncOp>> arc::createRemoveSCFPass() {
+std::unique_ptr<OperationPass<mlir::func::FuncOp>> arc::createRemoveSCFPass() {
   return std::make_unique<RemoveSCF>();
 }

--- a/arc-mlir/src/lib/Arc/ToNonpersistent.cpp
+++ b/arc-mlir/src/lib/Arc/ToNonpersistent.cpp
@@ -32,7 +32,7 @@ struct ToNonpersistent : public ToNonpersistentBase<ToNonpersistent> {
 } // end anonymous namespace.
 
 void ToNonpersistent::runOnOperation() {
-  getOperation().walk([&](FuncOp f) {
+  getOperation().walk([&](mlir::func::FuncOp f) {
     if (f->hasAttr("arc.is_task")) {
       f->setAttr("arc.is_toplevel_task_function", UnitAttr::get(&getContext()));
       f->setAttr("arc.use_nonpersistent", UnitAttr::get(&getContext()));

--- a/arc-mlir/src/lib/Arc/ToSCF.cpp
+++ b/arc-mlir/src/lib/Arc/ToSCF.cpp
@@ -50,10 +50,10 @@ struct ToSCF : public ToSCFBase<ToSCF> {
 
 } // end anonymous namespace.
 
-struct FunPattern : public OpRewritePattern<mlir::FuncOp> {
-  using OpRewritePattern<mlir::FuncOp>::OpRewritePattern;
+struct FunPattern : public OpRewritePattern<mlir::func::FuncOp> {
+  using OpRewritePattern<mlir::func::FuncOp>::OpRewritePattern;
 
-  LogicalResult matchAndRewrite(mlir::FuncOp fun,
+  LogicalResult matchAndRewrite(mlir::func::FuncOp fun,
                                 PatternRewriter &rewriter) const override {
     bool foundBr = false;
     fun->walk<WalkOrder::PreOrder>([&](BranchOp br) { foundBr = true; });
@@ -107,7 +107,8 @@ private:
     rewriter.create<arc::ArcBlockResultOp>(loc, destState);
   }
 
-  LogicalResult transformFun(mlir::FuncOp f, PatternRewriter &rewriter) const {
+  LogicalResult transformFun(mlir::func::FuncOp f,
+                             PatternRewriter &rewriter) const {
     LLVM_DEBUG({
       llvm::dbgs() << "=== Function ===\n";
       auto &block = f->getRegion(0).front();


### PR DESCRIPTION
Changes needed:

 * Upstream has moved mlir::FuncOp to mlir::func::FuncOp, change
   our code accordingly.

 * Upstream moved enum attribute definitions from OpBase.td to
   EnumAttr.td, include EnumAttr.td where we use them.