### PR TITLE
arc-ci: Switch from ACTIONS_DEPLOY_KEY to GITHUB_TOKEN

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ jobs:
         id: release
         uses: actions/create-release@v1
         env:
-          GITHUB_TOKEN: ${{ secrets.ACTIONS_DEPLOY_KEY }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           tag_name: ${{ github.ref_name }}
           release_name: ${{ github.ref_name }}
@@ -69,7 +69,7 @@ jobs:
     - name: Release package
       uses: actions/upload-release-asset@v1.0.1
       env:
-        GITHUB_TOKEN: ${{ secrets.ACTIONS_DEPLOY_KEY }}
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
         upload_url: ${{ needs.prepare.outputs.UPLOAD_URL }}
         asset_path: ${{ env.ASSET }}


### PR DESCRIPTION
Hopefully, this fixes the error in the CI:

https://github.com/cda-group/arc/runs/6155095301?check_suite_focus=true

A fresh GITHUB_TOKEN is automatically generated by GitHub for every CI run:

https://docs.github.com/en/actions/security-guides/automatic-token-authentication