### PR TITLE
arc-ci: Switch to newer release action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,32 +6,14 @@ on:
       - "v[0-9]+.[0-9]+.[0-9]+"
 
 jobs:
-
-  prepare:
-    runs-on: ubuntu-latest
-    outputs:
-      UPLOAD_URL: ${{ steps.release.outputs.upload_url }}
-    steps:
-      - name: Create GitHub release
-        id: release
-        uses: actions/create-release@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          tag_name: ${{ github.ref_name }}
-          release_name: ${{ github.ref_name }}
-
   release:
-    needs: ['prepare']
+    name: Release for ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        build:
-          - linux
-        # - macos
         include:
           - build: linux
-            os: ubuntu-18.04
+            os: ubuntu-latest
             target: x86_64-unknown-linux-musl
         # - build: macos
         #   os: macos-latest
@@ -71,8 +53,6 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
-        upload_url: ${{ needs.prepare.outputs.UPLOAD_URL }}
-        asset_path: ${{ env.ASSET }}
-        asset_name: ${{ env.ASSET }}
-        asset_content_type: application/octet-stream
-
+        repo_token: ${{ secrets.GITHUB_TOKEN }}
+        file: ${{ env.ASSET }}
+        tag: ${{ github.ref }}


### PR DESCRIPTION
Switch to https://github.com/svenstaro/upload-release-action

Previously we used the archived repos:

* https://github.com/actions/create-release
* https://github.com/actions/upload-release-asset