### PR TITLE
 LLVM submodule update

### DIFF
--- a/arc-lang/src/pretty_mlir.ml
+++ b/arc-lang/src/pretty_mlir.ml
@@ -19,14 +19,14 @@ and pr_item (x, i) ctx =
   | Mlir.IAssign _ ->
       todo ()
   | Mlir.IExternFunc (x_rust, ps, t) ->
-      pr "func private @";
+      pr "func.func private @";
       pr_path x ctx;
       pr_params ps ctx;
       pr " -> ";
       pr_type t ctx;
       pr " attributes { rust.declare, rust.annotation=\"#[rewrite(unmangled = \\\"%s\\\")]\"}" x_rust
   | Mlir.IFunc (ps, t, b) ->
-      pr "func @";
+      pr "func.func @";
       pr_path x ctx;
       pr_params ps ctx;
       begin match t with
@@ -40,7 +40,7 @@ and pr_item (x, i) ctx =
       pr " } ";
       pr_block b ctx;
   | Mlir.ITask (ps0, ps1, b) ->
-      pr "func @";
+      pr "func.func @";
       pr_path x ctx;
       pr_params ps0 ctx;
       pr_params ps1 ctx;

--- a/arc-lang/stdlib/stdlib.mlir
+++ b/arc-lang/stdlib/stdlib.mlir
@@ -1,771 +1,771 @@
 // Integer arithmetics
 
-func @add_u8(%a : ui8, %b : ui8) -> ui8 attributes {rust.declare} {
+func.func @add_u8(%a : ui8, %b : ui8) -> ui8 attributes {rust.declare} {
   %c = arc.addi %a, %b : ui8
   return %c : ui8
 }
 
-func @sub_u8(%a : ui8, %b : ui8) -> ui8 attributes {rust.declare} {
+func.func @sub_u8(%a : ui8, %b : ui8) -> ui8 attributes {rust.declare} {
   %c = arc.subi %a, %b : ui8
   return %c : ui8
 }
 
-func @mul_u8(%a : ui8, %b : ui8) -> ui8 attributes {rust.declare} {
+func.func @mul_u8(%a : ui8, %b : ui8) -> ui8 attributes {rust.declare} {
   %c = arc.muli %a, %b : ui8
   return %c : ui8
 }
 
-func @div_u8(%a : ui8, %b : ui8) -> ui8 attributes {rust.declare} {
+func.func @div_u8(%a : ui8, %b : ui8) -> ui8 attributes {rust.declare} {
   %c = arc.divi %a, %b : ui8
   return %c : ui8
 }
 
-func @rem_u8(%a : ui8, %b : ui8) -> ui8 attributes {rust.declare} {
+func.func @rem_u8(%a : ui8, %b : ui8) -> ui8 attributes {rust.declare} {
   %c = arc.remi %a, %b : ui8
   return %c : ui8
 }
 
-func @add_u16(%a : ui16, %b : ui16) -> ui16 attributes {rust.declare} {
+func.func @add_u16(%a : ui16, %b : ui16) -> ui16 attributes {rust.declare} {
   %c = arc.addi %a, %b : ui16
   return %c : ui16
 }
 
-func @sub_u16(%a : ui16, %b : ui16) -> ui16 attributes {rust.declare} {
+func.func @sub_u16(%a : ui16, %b : ui16) -> ui16 attributes {rust.declare} {
   %c = arc.subi %a, %b : ui16
   return %c : ui16
 }
 
-func @mul_u16(%a : ui16, %b : ui16) -> ui16 attributes {rust.declare} {
+func.func @mul_u16(%a : ui16, %b : ui16) -> ui16 attributes {rust.declare} {
   %c = arc.muli %a, %b : ui16
   return %c : ui16
 }
 
-func @div_u16(%a : ui16, %b : ui16) -> ui16 attributes {rust.declare} {
+func.func @div_u16(%a : ui16, %b : ui16) -> ui16 attributes {rust.declare} {
   %c = arc.divi %a, %b : ui16
   return %c : ui16
 }
 
-func @rem_u16(%a : ui16, %b : ui16) -> ui16 attributes {rust.declare} {
+func.func @rem_u16(%a : ui16, %b : ui16) -> ui16 attributes {rust.declare} {
   %c = arc.remi %a, %b : ui16
   return %c : ui16
 }
 
-func @add_u32(%a : ui32, %b : ui32) -> ui32 attributes {rust.declare} {
+func.func @add_u32(%a : ui32, %b : ui32) -> ui32 attributes {rust.declare} {
   %c = arc.addi %a, %b : ui32
   return %c : ui32
 }
 
-func @sub_u32(%a : ui32, %b : ui32) -> ui32 attributes {rust.declare} {
+func.func @sub_u32(%a : ui32, %b : ui32) -> ui32 attributes {rust.declare} {
   %c = arc.subi %a, %b : ui32
   return %c : ui32
 }
 
-func @mul_u32(%a : ui32, %b : ui32) -> ui32 attributes {rust.declare} {
+func.func @mul_u32(%a : ui32, %b : ui32) -> ui32 attributes {rust.declare} {
   %c = arc.muli %a, %b : ui32
   return %c : ui32
 }
 
-func @div_u32(%a : ui32, %b : ui32) -> ui32 attributes {rust.declare} {
+func.func @div_u32(%a : ui32, %b : ui32) -> ui32 attributes {rust.declare} {
   %c = arc.divi %a, %b : ui32
   return %c : ui32
 }
 
-func @rem_u32(%a : ui32, %b : ui32) -> ui32 attributes {rust.declare} {
+func.func @rem_u32(%a : ui32, %b : ui32) -> ui32 attributes {rust.declare} {
   %c = arc.remi %a, %b : ui32
   return %c : ui32
 }
 
-func @add_u64(%a : ui64, %b : ui64) -> ui64 attributes {rust.declare} {
+func.func @add_u64(%a : ui64, %b : ui64) -> ui64 attributes {rust.declare} {
   %c = arc.addi %a, %b : ui64
   return %c : ui64
 }
 
-func @sub_u64(%a : ui64, %b : ui64) -> ui64 attributes {rust.declare} {
+func.func @sub_u64(%a : ui64, %b : ui64) -> ui64 attributes {rust.declare} {
   %c = arc.subi %a, %b : ui64
   return %c : ui64
 }
 
-func @mul_u64(%a : ui64, %b : ui64) -> ui64 attributes {rust.declare} {
+func.func @mul_u64(%a : ui64, %b : ui64) -> ui64 attributes {rust.declare} {
   %c = arc.muli %a, %b : ui64
   return %c : ui64
 }
 
-func @div_u64(%a : ui64, %b : ui64) -> ui64 attributes {rust.declare} {
+func.func @div_u64(%a : ui64, %b : ui64) -> ui64 attributes {rust.declare} {
   %c = arc.divi %a, %b : ui64
   return %c : ui64
 }
 
-func @rem_u64(%a : ui64, %b : ui64) -> ui64 attributes {rust.declare} {
+func.func @rem_u64(%a : ui64, %b : ui64) -> ui64 attributes {rust.declare} {
   %c = arc.remi %a, %b : ui64
   return %c : ui64
 }
 
-func @add_i8(%a : si8, %b : si8) -> si8 attributes {rust.declare} {
+func.func @add_i8(%a : si8, %b : si8) -> si8 attributes {rust.declare} {
   %c = arc.addi %a, %b : si8
   return %c : si8
 }
 
-func @sub_i8(%a : si8, %b : si8) -> si8 attributes {rust.declare} {
+func.func @sub_i8(%a : si8, %b : si8) -> si8 attributes {rust.declare} {
   %c = arc.subi %a, %b : si8
   return %c : si8
 }
 
-func @mul_i8(%a : si8, %b : si8) -> si8 attributes {rust.declare} {
+func.func @mul_i8(%a : si8, %b : si8) -> si8 attributes {rust.declare} {
   %c = arc.muli %a, %b : si8
   return %c : si8
 }
 
-func @div_i8(%a : si8, %b : si8) -> si8 attributes {rust.declare} {
+func.func @div_i8(%a : si8, %b : si8) -> si8 attributes {rust.declare} {
   %c = arc.divi %a, %b : si8
   return %c : si8
 }
 
-func @rem_i8(%a : si8, %b : si8) -> si8 attributes {rust.declare} {
+func.func @rem_i8(%a : si8, %b : si8) -> si8 attributes {rust.declare} {
   %c = arc.remi %a, %b : si8
   return %c : si8
 }
 
-func @add_i16(%a : si16, %b : si16) -> si16 attributes {rust.declare} {
+func.func @add_i16(%a : si16, %b : si16) -> si16 attributes {rust.declare} {
   %c = arc.addi %a, %b : si16
   return %c : si16
 }
 
-func @sub_i16(%a : si16, %b : si16) -> si16 attributes {rust.declare} {
+func.func @sub_i16(%a : si16, %b : si16) -> si16 attributes {rust.declare} {
   %c = arc.subi %a, %b : si16
   return %c : si16
 }
 
-func @mul_i16(%a : si16, %b : si16) -> si16 attributes {rust.declare} {
+func.func @mul_i16(%a : si16, %b : si16) -> si16 attributes {rust.declare} {
   %c = arc.muli %a, %b : si16
   return %c : si16
 }
 
-func @div_i16(%a : si16, %b : si16) -> si16 attributes {rust.declare} {
+func.func @div_i16(%a : si16, %b : si16) -> si16 attributes {rust.declare} {
   %c = arc.divi %a, %b : si16
   return %c : si16
 }
 
-func @rem_i16(%a : si16, %b : si16) -> si16 attributes {rust.declare} {
+func.func @rem_i16(%a : si16, %b : si16) -> si16 attributes {rust.declare} {
   %c = arc.remi %a, %b : si16
   return %c : si16
 }
 
-func @add_i32(%a : si32, %b : si32) -> si32 attributes {rust.declare} {
+func.func @add_i32(%a : si32, %b : si32) -> si32 attributes {rust.declare} {
   %c = arc.addi %a, %b : si32
   return %c : si32
 }
 
-func @sub_i32(%a : si32, %b : si32) -> si32 attributes {rust.declare} {
+func.func @sub_i32(%a : si32, %b : si32) -> si32 attributes {rust.declare} {
   %c = arc.subi %a, %b : si32
   return %c : si32
 }
 
-func @mul_i32(%a : si32, %b : si32) -> si32 attributes {rust.declare} {
+func.func @mul_i32(%a : si32, %b : si32) -> si32 attributes {rust.declare} {
   %c = arc.muli %a, %b : si32
   return %c : si32
 }
 
-func @div_i32(%a : si32, %b : si32) -> si32 attributes {rust.declare} {
+func.func @div_i32(%a : si32, %b : si32) -> si32 attributes {rust.declare} {
   %c = arc.divi %a, %b : si32
   return %c : si32
 }
 
-func @rem_i32(%a : si32, %b : si32) -> si32 attributes {rust.declare} {
+func.func @rem_i32(%a : si32, %b : si32) -> si32 attributes {rust.declare} {
   %c = arc.remi %a, %b : si32
   return %c : si32
 }
 
-func @add_i64(%a : si64, %b : si64) -> si64 attributes {rust.declare} {
+func.func @add_i64(%a : si64, %b : si64) -> si64 attributes {rust.declare} {
   %c = arc.addi %a, %b : si64
   return %c : si64
 }
 
-func @sub_i64(%a : si64, %b : si64) -> si64 attributes {rust.declare} {
+func.func @sub_i64(%a : si64, %b : si64) -> si64 attributes {rust.declare} {
   %c = arc.subi %a, %b : si64
   return %c : si64
 }
 
-func @mul_i64(%a : si64, %b : si64) -> si64 attributes {rust.declare} {
+func.func @mul_i64(%a : si64, %b : si64) -> si64 attributes {rust.declare} {
   %c = arc.muli %a, %b : si64
   return %c : si64
 }
 
-func @div_i64(%a : si64, %b : si64) -> si64 attributes {rust.declare} {
+func.func @div_i64(%a : si64, %b : si64) -> si64 attributes {rust.declare} {
   %c = arc.divi %a, %b : si64
   return %c : si64
 }
 
-func @rem_i64(%a : si64, %b : si64) -> si64 attributes {rust.declare} {
+func.func @rem_i64(%a : si64, %b : si64) -> si64 attributes {rust.declare} {
   %c = arc.remi %a, %b : si64
   return %c : si64
 }
 
 // Float arithmetics
 
-func @rem_f32(%a : f32, %b : f32) -> f32 attributes {rust.declare} {
+func.func @rem_f32(%a : f32, %b : f32) -> f32 attributes {rust.declare} {
   %c = arith.remf %a, %b : f32
   return %c : f32
 }
 
-func @add_f32(%a: f32, %b: f32) -> f32 attributes {rust.declare} {
+func.func @add_f32(%a: f32, %b: f32) -> f32 attributes {rust.declare} {
   %c = arith.addf %a, %b : f32
   return %c : f32
 }
 
-func @sub_f32(%a: f32, %b: f32) -> f32 attributes {rust.declare} {
+func.func @sub_f32(%a: f32, %b: f32) -> f32 attributes {rust.declare} {
   %c = arith.subf %a, %b : f32
   return %c : f32
 }
 
-func @mul_f32(%a: f32, %b: f32) -> f32 attributes {rust.declare} {
+func.func @mul_f32(%a: f32, %b: f32) -> f32 attributes {rust.declare} {
   %c = arith.mulf %a, %b : f32
   return %c : f32
 }
 
-func @div_f32(%a: f32, %b: f32) -> f32 attributes {rust.declare} {
+func.func @div_f32(%a: f32, %b: f32) -> f32 attributes {rust.declare} {
   %c = arith.divf %a, %b : f32
   return %c : f32
 }
 
-func @pow_f32(%a: f32, %b: f32) -> f32 attributes {rust.declare} {
+func.func @pow_f32(%a: f32, %b: f32) -> f32 attributes {rust.declare} {
   %c = math.powf %a, %b : f32
   return %c : f32
 }
 
-func @rem_f64(%a : f64, %b : f64) -> f64 attributes {rust.declare} {
+func.func @rem_f64(%a : f64, %b : f64) -> f64 attributes {rust.declare} {
   %c = arith.remf %a, %b : f64
   return %c : f64
 }
 
-func @add_f64(%a: f64, %b: f64) -> f64 attributes {rust.declare} {
+func.func @add_f64(%a: f64, %b: f64) -> f64 attributes {rust.declare} {
   %c = arith.addf %a, %b : f64
   return %c : f64
 }
 
-func @sub_f64(%a: f64, %b: f64) -> f64 attributes {rust.declare} {
+func.func @sub_f64(%a: f64, %b: f64) -> f64 attributes {rust.declare} {
   %c = arith.subf %a, %b : f64
   return %c : f64
 }
 
-func @mul_f64(%a: f64, %b: f64) -> f64 attributes {rust.declare} {
+func.func @mul_f64(%a: f64, %b: f64) -> f64 attributes {rust.declare} {
   %c = arith.mulf %a, %b : f64
   return %c : f64
 }
 
-func @div_f64(%a: f64, %b: f64) -> f64 attributes {rust.declare} {
+func.func @div_f64(%a: f64, %b: f64) -> f64 attributes {rust.declare} {
   %c = arith.divf %a, %b : f64
   return %c : f64
 }
 
-func @pow_f64(%a : f64, %b : f64) -> f64 attributes {rust.declare} {
+func.func @pow_f64(%a : f64, %b : f64) -> f64 attributes {rust.declare} {
   %c = math.powf %a, %b : f64
   return %c : f64
 }
 
 // Logical operations
 
-func @eq_i1(%a : i1, %b : i1) -> i1 attributes {rust.declare} {
+func.func @eq_i1(%a : i1, %b : i1) -> i1 attributes {rust.declare} {
   %r = arith.cmpi "eq", %a, %b : i1
   return %r : i1
 }
 
-func @and_i1(%arg0: i1, %arg1: i1) -> i1 attributes {rust.declare} {
+func.func @and_i1(%arg0: i1, %arg1: i1) -> i1 attributes {rust.declare} {
   %0 = arith.andi %arg0, %arg1 : i1
   return %0 : i1
 }
 
-func @or_i1(%arg0: i1, %arg1: i1) -> i1 attributes {rust.declare} {
+func.func @or_i1(%arg0: i1, %arg1: i1) -> i1 attributes {rust.declare} {
   %0 = arith.ori %arg0, %arg1 : i1
   return %0 : i1
 }
 
-func @xor_i1(%arg0: i1, %arg1: i1) -> i1 attributes {rust.declare} {
+func.func @xor_i1(%arg0: i1, %arg1: i1) -> i1 attributes {rust.declare} {
   %0 = arith.xori %arg0, %arg1 : i1
   return %0 : i1
 }
 
-func @and_i8(%arg0: i8, %arg1: i8) -> i8 attributes {rust.declare} {
+func.func @and_i8(%arg0: i8, %arg1: i8) -> i8 attributes {rust.declare} {
   %0 = arith.andi %arg0, %arg1 : i8
   return %0 : i8
 }
 
-func @or_i8(%arg0: i8, %arg1: i8) -> i8 attributes {rust.declare} {
+func.func @or_i8(%arg0: i8, %arg1: i8) -> i8 attributes {rust.declare} {
   %0 = arith.ori %arg0, %arg1 : i8
   return %0 : i8
 }
 
-func @xor_i8(%arg0: i8, %arg1: i8) -> i8 attributes {rust.declare} {
+func.func @xor_i8(%arg0: i8, %arg1: i8) -> i8 attributes {rust.declare} {
   %0 = arith.xori %arg0, %arg1 : i8
   return %0 : i8
 }
 
-func @and_i16(%arg0: i16, %arg1: i16) -> i16 attributes {rust.declare} {
+func.func @and_i16(%arg0: i16, %arg1: i16) -> i16 attributes {rust.declare} {
   %0 = arith.andi %arg0, %arg1 : i16
   return %0 : i16
 }
 
-func @or_i16(%arg0: i16, %arg1: i16) -> i16 attributes {rust.declare} {
+func.func @or_i16(%arg0: i16, %arg1: i16) -> i16 attributes {rust.declare} {
   %0 = arith.ori %arg0, %arg1 : i16
   return %0 : i16
 }
 
-func @xor_i16(%arg0: i16, %arg1: i16) -> i16 attributes {rust.declare} {
+func.func @xor_i16(%arg0: i16, %arg1: i16) -> i16 attributes {rust.declare} {
   %0 = arith.xori %arg0, %arg1 : i16
   return %0 : i16
 }
 
-func @and_i32(%arg0: i32, %arg1: i32) -> i32 attributes {rust.declare} {
+func.func @and_i32(%arg0: i32, %arg1: i32) -> i32 attributes {rust.declare} {
   %0 = arith.andi %arg0, %arg1 : i32
   return %0 : i32
 }
 
-func @or_i32(%arg0: i32, %arg1: i32) -> i32 attributes {rust.declare} {
+func.func @or_i32(%arg0: i32, %arg1: i32) -> i32 attributes {rust.declare} {
   %0 = arith.ori %arg0, %arg1 : i32
   return %0 : i32
 }
 
-func @xor_i32(%arg0: i32, %arg1: i32) -> i32 attributes {rust.declare} {
+func.func @xor_i32(%arg0: i32, %arg1: i32) -> i32 attributes {rust.declare} {
   %0 = arith.xori %arg0, %arg1 : i32
   return %0 : i32
 }
 
-func @and_i64(%arg0: i64, %arg1: i64) -> i64 attributes {rust.declare} {
+func.func @and_i64(%arg0: i64, %arg1: i64) -> i64 attributes {rust.declare} {
   %0 = arith.andi %arg0, %arg1 : i64
   return %0 : i64
 }
 
-func @or_i64(%arg0: i64, %arg1: i64) -> i64 attributes {rust.declare} {
+func.func @or_i64(%arg0: i64, %arg1: i64) -> i64 attributes {rust.declare} {
   %0 = arith.ori %arg0, %arg1 : i64
   return %0 : i64
 }
 
-func @xor_i64(%arg0: i64, %arg1: i64) -> i64 attributes {rust.declare} {
+func.func @xor_i64(%arg0: i64, %arg1: i64) -> i64 attributes {rust.declare} {
   %0 = arith.xori %arg0, %arg1 : i64
   return %0 : i64
 }
 
 // Comparison
 
-func @eq_u8(%a : ui8, %b : ui8) -> i1 attributes {rust.declare} {
+func.func @eq_u8(%a : ui8, %b : ui8) -> i1 attributes {rust.declare} {
   %r = arc.cmpi "eq", %a, %b : ui8
   return %r : i1
 }
 
-func @ne_u8(%a : ui8, %b : ui8) -> i1 attributes {rust.declare} {
+func.func @ne_u8(%a : ui8, %b : ui8) -> i1 attributes {rust.declare} {
   %r = arc.cmpi "ne", %a, %b : ui8
   return %r : i1
 }
 
-func @lt_u8(%a : ui8, %b : ui8) -> i1 attributes {rust.declare} {
+func.func @lt_u8(%a : ui8, %b : ui8) -> i1 attributes {rust.declare} {
   %r = arc.cmpi "lt", %a, %b : ui8
   return %r : i1
 }
 
-func @le_u8(%a : ui8, %b : ui8) -> i1 attributes {rust.declare} {
+func.func @le_u8(%a : ui8, %b : ui8) -> i1 attributes {rust.declare} {
   %r = arc.cmpi "le", %a, %b : ui8
   return %r : i1
 }
 
-func @gt_u8(%a : ui8, %b : ui8) -> i1 attributes {rust.declare} {
+func.func @gt_u8(%a : ui8, %b : ui8) -> i1 attributes {rust.declare} {
   %r = arc.cmpi "gt", %a, %b : ui8
   return %r : i1
 }
 
-func @ge_u8(%a : ui8, %b : ui8) -> i1 attributes {rust.declare} {
+func.func @ge_u8(%a : ui8, %b : ui8) -> i1 attributes {rust.declare} {
   %r = arc.cmpi "ge", %a, %b : ui8
   return %r : i1
 }
 
-func @eq_u16(%a : ui16, %b : ui16) -> i1 attributes {rust.declare} {
+func.func @eq_u16(%a : ui16, %b : ui16) -> i1 attributes {rust.declare} {
   %r = arc.cmpi "eq", %a, %b : ui16
   return %r : i1
 }
 
-func @ne_u16(%a : ui16, %b : ui16) -> i1 attributes {rust.declare} {
+func.func @ne_u16(%a : ui16, %b : ui16) -> i1 attributes {rust.declare} {
   %r = arc.cmpi "ne", %a, %b : ui16
   return %r : i1
 }
 
-func @lt_u16(%a : ui16, %b : ui16) -> i1 attributes {rust.declare} {
+func.func @lt_u16(%a : ui16, %b : ui16) -> i1 attributes {rust.declare} {
   %r = arc.cmpi "lt", %a, %b : ui16
   return %r : i1
 }
 
-func @le_u16(%a : ui16, %b : ui16) -> i1 attributes {rust.declare} {
+func.func @le_u16(%a : ui16, %b : ui16) -> i1 attributes {rust.declare} {
   %r = arc.cmpi "le", %a, %b : ui16
   return %r : i1
 }
 
-func @gt_u16(%a : ui16, %b : ui16) -> i1 attributes {rust.declare} {
+func.func @gt_u16(%a : ui16, %b : ui16) -> i1 attributes {rust.declare} {
   %r = arc.cmpi "gt", %a, %b : ui16
   return %r : i1
 }
 
-func @ge_u16(%a : ui16, %b : ui16) -> i1 attributes {rust.declare} {
+func.func @ge_u16(%a : ui16, %b : ui16) -> i1 attributes {rust.declare} {
   %r = arc.cmpi "ge", %a, %b : ui16
   return %r : i1
 }
 
-func @eq_u32(%a : ui32, %b : ui32) -> i1 attributes {rust.declare} {
+func.func @eq_u32(%a : ui32, %b : ui32) -> i1 attributes {rust.declare} {
   %r = arc.cmpi "eq", %a, %b : ui32
   return %r : i1
 }
 
-func @ne_u32(%a : ui32, %b : ui32) -> i1 attributes {rust.declare} {
+func.func @ne_u32(%a : ui32, %b : ui32) -> i1 attributes {rust.declare} {
   %r = arc.cmpi "ne", %a, %b : ui32
   return %r : i1
 }
 
-func @lt_u32(%a : ui32, %b : ui32) -> i1 attributes {rust.declare} {
+func.func @lt_u32(%a : ui32, %b : ui32) -> i1 attributes {rust.declare} {
   %r = arc.cmpi "lt", %a, %b : ui32
   return %r : i1
 }
 
-func @le_u32(%a : ui32, %b : ui32) -> i1 attributes {rust.declare} {
+func.func @le_u32(%a : ui32, %b : ui32) -> i1 attributes {rust.declare} {
   %r = arc.cmpi "le", %a, %b : ui32
   return %r : i1
 }
 
-func @gt_u32(%a : ui32, %b : ui32) -> i1 attributes {rust.declare} {
+func.func @gt_u32(%a : ui32, %b : ui32) -> i1 attributes {rust.declare} {
   %r = arc.cmpi "gt", %a, %b : ui32
   return %r : i1
 }
 
-func @ge_u32(%a : ui32, %b : ui32) -> i1 attributes {rust.declare} {
+func.func @ge_u32(%a : ui32, %b : ui32) -> i1 attributes {rust.declare} {
   %r = arc.cmpi "ge", %a, %b : ui32
   return %r : i1
 }
 
-func @eq_u64(%a : ui64, %b : ui64) -> i1 attributes {rust.declare} {
+func.func @eq_u64(%a : ui64, %b : ui64) -> i1 attributes {rust.declare} {
   %r = arc.cmpi "eq", %a, %b : ui64
   return %r : i1
 }
 
-func @ne_u64(%a : ui64, %b : ui64) -> i1 attributes {rust.declare} {
+func.func @ne_u64(%a : ui64, %b : ui64) -> i1 attributes {rust.declare} {
   %r = arc.cmpi "ne", %a, %b : ui64
   return %r : i1
 }
 
-func @lt_u64(%a : ui64, %b : ui64) -> i1 attributes {rust.declare} {
+func.func @lt_u64(%a : ui64, %b : ui64) -> i1 attributes {rust.declare} {
   %r = arc.cmpi "lt", %a, %b : ui64
   return %r : i1
 }
 
-func @le_u64(%a : ui64, %b : ui64) -> i1 attributes {rust.declare} {
+func.func @le_u64(%a : ui64, %b : ui64) -> i1 attributes {rust.declare} {
   %r = arc.cmpi "le", %a, %b : ui64
   return %r : i1
 }
 
-func @gt_u64(%a : ui64, %b : ui64) -> i1 attributes {rust.declare} {
+func.func @gt_u64(%a : ui64, %b : ui64) -> i1 attributes {rust.declare} {
   %r = arc.cmpi "gt", %a, %b : ui64
   return %r : i1
 }
 
-func @ge_u64(%a : ui64, %b : ui64) -> i1 attributes {rust.declare} {
+func.func @ge_u64(%a : ui64, %b : ui64) -> i1 attributes {rust.declare} {
   %r = arc.cmpi "ge", %a, %b : ui64
   return %r : i1
 }
 
-func @eq_i8(%a : si8, %b : si8) -> i1 attributes {rust.declare} {
+func.func @eq_i8(%a : si8, %b : si8) -> i1 attributes {rust.declare} {
   %r = arc.cmpi "eq", %a, %b : si8
   return %r : i1
 }
 
-func @ne_i8(%a : si8, %b : si8) -> i1 attributes {rust.declare} {
+func.func @ne_i8(%a : si8, %b : si8) -> i1 attributes {rust.declare} {
   %r = arc.cmpi "ne", %a, %b : si8
   return %r : i1
 }
 
-func @lt_i8(%a : si8, %b : si8) -> i1 attributes {rust.declare} {
+func.func @lt_i8(%a : si8, %b : si8) -> i1 attributes {rust.declare} {
   %r = arc.cmpi "lt", %a, %b : si8
   return %r : i1
 }
 
-func @le_i8(%a : si8, %b : si8) -> i1 attributes {rust.declare} {
+func.func @le_i8(%a : si8, %b : si8) -> i1 attributes {rust.declare} {
   %r = arc.cmpi "le", %a, %b : si8
   return %r : i1
 }
 
-func @gt_i8(%a : si8, %b : si8) -> i1 attributes {rust.declare} {
+func.func @gt_i8(%a : si8, %b : si8) -> i1 attributes {rust.declare} {
   %r = arc.cmpi "gt", %a, %b : si8
   return %r : i1
 }
 
-func @ge_i8(%a : si8, %b : si8) -> i1 attributes {rust.declare} {
+func.func @ge_i8(%a : si8, %b : si8) -> i1 attributes {rust.declare} {
   %r = arc.cmpi "ge", %a, %b : si8
   return %r : i1
 }
 
-func @eq_i16(%a : si16, %b : si16) -> i1 attributes {rust.declare} {
+func.func @eq_i16(%a : si16, %b : si16) -> i1 attributes {rust.declare} {
   %r = arc.cmpi "eq", %a, %b : si16
   return %r : i1
 }
 
-func @ne_i16(%a : si16, %b : si16) -> i1 attributes {rust.declare} {
+func.func @ne_i16(%a : si16, %b : si16) -> i1 attributes {rust.declare} {
   %r = arc.cmpi "ne", %a, %b : si16
   return %r : i1
 }
 
-func @lt_i16(%a : si16, %b : si16) -> i1 attributes {rust.declare} {
+func.func @lt_i16(%a : si16, %b : si16) -> i1 attributes {rust.declare} {
   %r = arc.cmpi "lt", %a, %b : si16
   return %r : i1
 }
 
-func @le_i16(%a : si16, %b : si16) -> i1 attributes {rust.declare} {
+func.func @le_i16(%a : si16, %b : si16) -> i1 attributes {rust.declare} {
   %r = arc.cmpi "le", %a, %b : si16
   return %r : i1
 }
 
-func @gt_i16(%a : si16, %b : si16) -> i1 attributes {rust.declare} {
+func.func @gt_i16(%a : si16, %b : si16) -> i1 attributes {rust.declare} {
   %r = arc.cmpi "gt", %a, %b : si16
   return %r : i1
 }
 
-func @ge_i16(%a : si16, %b : si16) -> i1 attributes {rust.declare} {
+func.func @ge_i16(%a : si16, %b : si16) -> i1 attributes {rust.declare} {
   %r = arc.cmpi "ge", %a, %b : si16
   return %r : i1
 }
 
-func @eq_i32(%a : si32, %b : si32) -> i1 attributes {rust.declare} {
+func.func @eq_i32(%a : si32, %b : si32) -> i1 attributes {rust.declare} {
   %r = arc.cmpi "eq", %a, %b : si32
   return %r : i1
 }
 
-func @ne_i32(%a : si32, %b : si32) -> i1 attributes {rust.declare} {
+func.func @ne_i32(%a : si32, %b : si32) -> i1 attributes {rust.declare} {
   %r = arc.cmpi "ne", %a, %b : si32
   return %r : i1
 }
 
-func @lt_i32(%a : si32, %b : si32) -> i1 attributes {rust.declare} {
+func.func @lt_i32(%a : si32, %b : si32) -> i1 attributes {rust.declare} {
   %r = arc.cmpi "lt", %a, %b : si32
   return %r : i1
 }
 
-func @le_i32(%a : si32, %b : si32) -> i1 attributes {rust.declare} {
+func.func @le_i32(%a : si32, %b : si32) -> i1 attributes {rust.declare} {
   %r = arc.cmpi "le", %a, %b : si32
   return %r : i1
 }
 
-func @gt_i32(%a : si32, %b : si32) -> i1 attributes {rust.declare} {
+func.func @gt_i32(%a : si32, %b : si32) -> i1 attributes {rust.declare} {
   %r = arc.cmpi "gt", %a, %b : si32
   return %r : i1
 }
 
-func @ge_i32(%a : si32, %b : si32) -> i1 attributes {rust.declare} {
+func.func @ge_i32(%a : si32, %b : si32) -> i1 attributes {rust.declare} {
   %r = arc.cmpi "ge", %a, %b : si32
   return %r : i1
 }
 
-func @eq_i64(%a : si64, %b : si64) -> i1 attributes {rust.declare} {
+func.func @eq_i64(%a : si64, %b : si64) -> i1 attributes {rust.declare} {
   %r = arc.cmpi "eq", %a, %b : si64
   return %r : i1
 }
 
-func @ne_i64(%a : si64, %b : si64) -> i1 attributes {rust.declare} {
+func.func @ne_i64(%a : si64, %b : si64) -> i1 attributes {rust.declare} {
   %r = arc.cmpi "ne", %a, %b : si64
   return %r : i1
 }
 
-func @lt_i64(%a : si64, %b : si64) -> i1 attributes {rust.declare} {
+func.func @lt_i64(%a : si64, %b : si64) -> i1 attributes {rust.declare} {
   %r = arc.cmpi "lt", %a, %b : si64
   return %r : i1
 }
 
-func @le_i64(%a : si64, %b : si64) -> i1 attributes {rust.declare} {
+func.func @le_i64(%a : si64, %b : si64) -> i1 attributes {rust.declare} {
   %r = arc.cmpi "le", %a, %b : si64
   return %r : i1
 }
 
-func @gt_i64(%a : si64, %b : si64) -> i1 attributes {rust.declare} {
+func.func @gt_i64(%a : si64, %b : si64) -> i1 attributes {rust.declare} {
   %r = arc.cmpi "gt", %a, %b : si64
   return %r : i1
 }
 
-func @ge_i64(%a : si64, %b : si64) -> i1 attributes {rust.declare} {
+func.func @ge_i64(%a : si64, %b : si64) -> i1 attributes {rust.declare} {
   %r = arc.cmpi "ge", %a, %b : si64
   return %r : i1
 }
 
 // ---------------------------------------
 
-func @eq_f32(%a : f32, %b : f32) -> i1 attributes {rust.declare} {
+func.func @eq_f32(%a : f32, %b : f32) -> i1 attributes {rust.declare} {
   %r = arith.cmpf "oeq", %a, %b : f32
   return %r : i1
 }
 
-func @ne_f32(%a : f32, %b : f32) -> i1 attributes {rust.declare} {
+func.func @ne_f32(%a : f32, %b : f32) -> i1 attributes {rust.declare} {
   %r = arith.cmpf "one", %a, %b : f32
   return %r : i1
 }
 
-func @lt_f32(%a : f32, %b : f32) -> i1 attributes {rust.declare} {
+func.func @lt_f32(%a : f32, %b : f32) -> i1 attributes {rust.declare} {
   %r = arith.cmpf "olt", %a, %b : f32
   return %r : i1
 }
 
-func @le_f32(%a : f32, %b : f32) -> i1 attributes {rust.declare} {
+func.func @le_f32(%a : f32, %b : f32) -> i1 attributes {rust.declare} {
   %r = arith.cmpf "ole", %a, %b : f32
   return %r : i1
 }
 
-func @gt_f32(%a : f32, %b : f32) -> i1 attributes {rust.declare} {
+func.func @gt_f32(%a : f32, %b : f32) -> i1 attributes {rust.declare} {
   %r = arith.cmpf "ogt", %a, %b : f32
   return %r : i1
 }
 
-func @ge_f32(%a : f32, %b : f32) -> i1 attributes {rust.declare} {
+func.func @ge_f32(%a : f32, %b : f32) -> i1 attributes {rust.declare} {
   %r = arith.cmpf "oge", %a, %b : f32
   return %r : i1
 }
 
-func @eq_f64(%a : f64, %b : f64) -> i1 attributes {rust.declare} {
+func.func @eq_f64(%a : f64, %b : f64) -> i1 attributes {rust.declare} {
   %r = arith.cmpf "oeq", %a, %b : f64
   return %r : i1
 }
 
-func @ne_f64(%a : f64, %b : f64) -> i1 attributes {rust.declare} {
+func.func @ne_f64(%a : f64, %b : f64) -> i1 attributes {rust.declare} {
   %r = arith.cmpf "one", %a, %b : f64
   return %r : i1
 }
 
-func @lt_f64(%a : f64, %b : f64) -> i1 attributes {rust.declare} {
+func.func @lt_f64(%a : f64, %b : f64) -> i1 attributes {rust.declare} {
   %r = arith.cmpf "olt", %a, %b : f64
   return %r : i1
 }
 
-func @le_f64(%a : f64, %b : f64) -> i1 attributes {rust.declare} {
+func.func @le_f64(%a : f64, %b : f64) -> i1 attributes {rust.declare} {
   %r = arith.cmpf "ole", %a, %b : f64
   return %r : i1
 }
 
-func @gt_f64(%a : f64, %b : f64) -> i1 attributes {rust.declare} {
+func.func @gt_f64(%a : f64, %b : f64) -> i1 attributes {rust.declare} {
   %r = arith.cmpf "ogt", %a, %b : f64
   return %r : i1
 }
 
-func @ge_f64(%a : f64, %b : f64) -> i1 attributes {rust.declare} {
+func.func @ge_f64(%a : f64, %b : f64) -> i1 attributes {rust.declare} {
   %r = arith.cmpf "oge", %a, %b : f64
   return %r : i1
 }
 
 // Unary ops
 
-func @acos_f32(%a : f32) -> f32 attributes {rust.declare} {
+func.func @acos_f32(%a : f32) -> f32 attributes {rust.declare} {
   %r = arc.acos %a : f32
   return %r : f32
 }
 
-func @asin_f32(%a : f32) -> f32 attributes {rust.declare} {
+func.func @asin_f32(%a : f32) -> f32 attributes {rust.declare} {
   %r = arc.asin %a : f32
   return %r : f32
 }
 
-func @atan_f32(%a : f32) -> f32 attributes {rust.declare} {
+func.func @atan_f32(%a : f32) -> f32 attributes {rust.declare} {
   %r = math.atan %a : f32
   return %r : f32
 }
 
-func @cos_f32(%a : f32) -> f32 attributes {rust.declare} {
+func.func @cos_f32(%a : f32) -> f32 attributes {rust.declare} {
   %r = math.cos %a : f32
   return %r : f32
 }
 
-func @cosh_f32(%a : f32) -> f32 attributes {rust.declare} {
+func.func @cosh_f32(%a : f32) -> f32 attributes {rust.declare} {
   %r = arc.cosh %a : f32
   return %r : f32
 }
 
-func @exp_f32(%a : f32) -> f32 attributes {rust.declare} {
+func.func @exp_f32(%a : f32) -> f32 attributes {rust.declare} {
   %r = math.exp %a : f32
   return %r : f32
 }
 
-func @log_f32(%a : f32) -> f32 attributes {rust.declare} {
+func.func @log_f32(%a : f32) -> f32 attributes {rust.declare} {
   %r = math.log %a : f32
   return %r : f32
 }
 
-func @sin_f32(%a : f32) -> f32 attributes {rust.declare} {
+func.func @sin_f32(%a : f32) -> f32 attributes {rust.declare} {
   %r = math.sin %a : f32
   return %r : f32
 }
 
-func @sinh_f32(%a : f32) -> f32 attributes {rust.declare} {
+func.func @sinh_f32(%a : f32) -> f32 attributes {rust.declare} {
   %r = arc.sinh %a : f32
   return %r : f32
 }
 
-func @sqrt_f32(%a : f32) -> f32 attributes {rust.declare} {
+func.func @sqrt_f32(%a : f32) -> f32 attributes {rust.declare} {
   %r = math.sqrt %a : f32
   return %r : f32
 }
 
-func @tan_f32(%a : f32) -> f32 attributes {rust.declare} {
+func.func @tan_f32(%a : f32) -> f32 attributes {rust.declare} {
   %r = arc.tan %a : f32
   return %r : f32
 }
 
-func @tanh_f32(%a : f32) -> f32 attributes {rust.declare} {
+func.func @tanh_f32(%a : f32) -> f32 attributes {rust.declare} {
   %r = math.tanh %a : f32
   return %r : f32
 }
 
-func @acos_f64(%a : f64) -> f64 attributes {rust.declare} {
+func.func @acos_f64(%a : f64) -> f64 attributes {rust.declare} {
   %r = arc.acos %a : f64
   return %r : f64
 }
 
-func @asin_f64(%a : f64) -> f64 attributes {rust.declare} {
+func.func @asin_f64(%a : f64) -> f64 attributes {rust.declare} {
   %r = arc.asin %a : f64
   return %r : f64
 }
 
-func @atan_f64(%a : f64) -> f64 attributes {rust.declare} {
+func.func @atan_f64(%a : f64) -> f64 attributes {rust.declare} {
   %r = math.atan %a : f64
   return %r : f64
 }
 
-func @cos_f64(%a : f64) -> f64 attributes {rust.declare} {
+func.func @cos_f64(%a : f64) -> f64 attributes {rust.declare} {
   %r = math.cos %a : f64
   return %r : f64
 }
 
-func @cosh_f64(%a : f64) -> f64 attributes {rust.declare} {
+func.func @cosh_f64(%a : f64) -> f64 attributes {rust.declare} {
   %r = arc.cosh %a : f64
   return %r : f64
 }
 
-func @exp_f64(%a : f64) -> f64 attributes {rust.declare} {
+func.func @exp_f64(%a : f64) -> f64 attributes {rust.declare} {
   %r = math.exp %a : f64
   return %r : f64
 }
 
-func @log_f64(%a : f64) -> f64 attributes {rust.declare} {
+func.func @log_f64(%a : f64) -> f64 attributes {rust.declare} {
   %r = math.log %a : f64
   return %r : f64
 }
 
-func @sin_f64(%a : f64) -> f64 attributes {rust.declare} {
+func.func @sin_f64(%a : f64) -> f64 attributes {rust.declare} {
   %r = math.sin %a : f64
   return %r : f64
 }
 
-func @sinh_f64(%a : f64) -> f64 attributes {rust.declare} {
+func.func @sinh_f64(%a : f64) -> f64 attributes {rust.declare} {
   %r = arc.sinh %a : f64
   return %r : f64
 }
 
-func @sqrt_f64(%a : f64) -> f64 attributes {rust.declare} {
+func.func @sqrt_f64(%a : f64) -> f64 attributes {rust.declare} {
   %r = math.sqrt %a : f64
   return %r : f64
 }
 
-func @tan_f64(%a : f64) -> f64 attributes {rust.declare} {
+func.func @tan_f64(%a : f64) -> f64 attributes {rust.declare} {
   %r = arc.tan %a : f64
   return %r : f64
 }
 
-func @tanh_f64(%a : f64) -> f64 attributes {rust.declare} {
+func.func @tanh_f64(%a : f64) -> f64 attributes {rust.declare} {
   %r = math.tanh %a : f64
   return %r : f64
 }

--- a/arc-mlir/src/tests/arc-to-rust/adt.mlir
+++ b/arc-mlir/src/tests/arc-to-rust/adt.mlir
@@ -4,30 +4,30 @@
 
 module @arctorustadt {
 
-func @ok0(%in : !arc.adt<"i32">) -> () {
+  func.func @ok0(%in : !arc.adt<"i32">) -> () {
     return
   }
 
-  func @ok2(%in : !arc.adt<"i32">) -> !arc.adt<"i32"> {
+  func.func @ok2(%in : !arc.adt<"i32">) -> !arc.adt<"i32"> {
     return %in : !arc.adt<"i32">
   }
 
-  func @ok4() -> !arc.adt<"i32"> {
+  func.func @ok4() -> !arc.adt<"i32"> {
     %out = arc.adt_constant "4711" : !arc.adt<"i32">
     return %out : !arc.adt<"i32">
   }
 
-  func @ok6(%in : !arc.generic_adt<"crate::arctorustadt::tests::sharable_Foo::Foo", ui32>)
+  func.func @ok6(%in : !arc.generic_adt<"crate::arctorustadt::tests::sharable_Foo::Foo", ui32>)
      -> !arc.generic_adt<"crate::arctorustadt::tests::sharable_Foo::Foo", ui32> {
      return %in : !arc.generic_adt<"crate::arctorustadt::tests::sharable_Foo::Foo", ui32>
   }
 
-  func @ok7(%in : !arc.generic_adt<"crate::arctorustadt::tests::sharable_Bar::Bar", ui32, !arc.generic_adt<"crate::arctorustadt::tests::sharable_Foo::Foo", f64>>)
+  func.func @ok7(%in : !arc.generic_adt<"crate::arctorustadt::tests::sharable_Bar::Bar", ui32, !arc.generic_adt<"crate::arctorustadt::tests::sharable_Foo::Foo", f64>>)
     -> !arc.generic_adt<"crate::arctorustadt::tests::sharable_Bar::Bar", ui32, !arc.generic_adt<"crate::arctorustadt::tests::sharable_Foo::Foo", f64>> {
     return %in : !arc.generic_adt<"crate::arctorustadt::tests::sharable_Bar::Bar", ui32, !arc.generic_adt<"crate::arctorustadt::tests::sharable_Foo::Foo", f64>>
   }
 
-  func @ok8(%in : !arc.generic_adt<"crate::arctorustadt::tests::sharable_Bar::Bar", ui32, !arc.adt<"i32">>)
+  func.func @ok8(%in : !arc.generic_adt<"crate::arctorustadt::tests::sharable_Bar::Bar", ui32, !arc.adt<"i32">>)
     -> !arc.generic_adt<"crate::arctorustadt::tests::sharable_Bar::Bar", ui32, !arc.adt<"i32">> {
     return %in : !arc.generic_adt<"crate::arctorustadt::tests::sharable_Bar::Bar", ui32, !arc.adt<"i32">>
   }

--- a/arc-mlir/src/tests/arc-to-rust/arc-cmpf.mlir
+++ b/arc-mlir/src/tests/arc-to-rust/arc-cmpf.mlir
@@ -2,62 +2,62 @@
 // RUN: arc-mlir-rust-test %t-roundtrip-scf %s -rustinclude %s.rust-tests -canonicalize -remove-scf -canonicalize -to-scf -canonicalize
 
 module @arctorustarcarccmpf {
-func @oeq_f32(%a : f32, %b : f32) -> i1 {
+func.func @oeq_f32(%a : f32, %b : f32) -> i1 {
   %r = arith.cmpf "oeq", %a, %b : f32
   return %r : i1
 }
 
-func @one_f32(%a : f32, %b : f32) -> i1 {
+func.func @one_f32(%a : f32, %b : f32) -> i1 {
   %r = arith.cmpf "one", %a, %b : f32
   return %r : i1
 }
 
-func @olt_f32(%a : f32, %b : f32) -> i1 {
+func.func @olt_f32(%a : f32, %b : f32) -> i1 {
   %r = arith.cmpf "olt", %a, %b : f32
   return %r : i1
 }
 
-func @ole_f32(%a : f32, %b : f32) -> i1 {
+func.func @ole_f32(%a : f32, %b : f32) -> i1 {
   %r = arith.cmpf "ole", %a, %b : f32
   return %r : i1
 }
 
-func @ogt_f32(%a : f32, %b : f32) -> i1 {
+func.func @ogt_f32(%a : f32, %b : f32) -> i1 {
   %r = arith.cmpf "ogt", %a, %b : f32
   return %r : i1
 }
 
-func @oge_f32(%a : f32, %b : f32) -> i1 {
+func.func @oge_f32(%a : f32, %b : f32) -> i1 {
   %r = arith.cmpf "oge", %a, %b : f32
   return %r : i1
 }
 
-func @oeq_f64(%a : f64, %b : f64) -> i1 {
+func.func @oeq_f64(%a : f64, %b : f64) -> i1 {
   %r = arith.cmpf "oeq", %a, %b : f64
   return %r : i1
 }
 
-func @one_f64(%a : f64, %b : f64) -> i1 {
+func.func @one_f64(%a : f64, %b : f64) -> i1 {
   %r = arith.cmpf "one", %a, %b : f64
   return %r : i1
 }
 
-func @olt_f64(%a : f64, %b : f64) -> i1 {
+func.func @olt_f64(%a : f64, %b : f64) -> i1 {
   %r = arith.cmpf "olt", %a, %b : f64
   return %r : i1
 }
 
-func @ole_f64(%a : f64, %b : f64) -> i1 {
+func.func @ole_f64(%a : f64, %b : f64) -> i1 {
   %r = arith.cmpf "ole", %a, %b : f64
   return %r : i1
 }
 
-func @ogt_f64(%a : f64, %b : f64) -> i1 {
+func.func @ogt_f64(%a : f64, %b : f64) -> i1 {
   %r = arith.cmpf "ogt", %a, %b : f64
   return %r : i1
 }
 
-func @oge_f64(%a : f64, %b : f64) -> i1 {
+func.func @oge_f64(%a : f64, %b : f64) -> i1 {
   %r = arith.cmpf "oge", %a, %b : f64
   return %r : i1
 }

--- a/arc-mlir/src/tests/arc-to-rust/arc-cmpi.mlir
+++ b/arc-mlir/src/tests/arc-to-rust/arc-cmpi.mlir
@@ -2,242 +2,242 @@
 // RUN: arc-mlir-rust-test %t-roundtrip-scf %s -rustinclude %s.rust-tests -canonicalize -remove-scf -canonicalize -to-scf -canonicalize
 
 module @arctorustcmpi {
-func @eq_ui8(%a : ui8, %b : ui8) -> i1 {
+func.func @eq_ui8(%a : ui8, %b : ui8) -> i1 {
   %r = arc.cmpi "eq", %a, %b : ui8
   return %r : i1
 }
 
-func @ne_ui8(%a : ui8, %b : ui8) -> i1 {
+func.func @ne_ui8(%a : ui8, %b : ui8) -> i1 {
   %r = arc.cmpi "ne", %a, %b : ui8
   return %r : i1
 }
 
-func @lt_ui8(%a : ui8, %b : ui8) -> i1 {
+func.func @lt_ui8(%a : ui8, %b : ui8) -> i1 {
   %r = arc.cmpi "lt", %a, %b : ui8
   return %r : i1
 }
 
-func @le_ui8(%a : ui8, %b : ui8) -> i1 {
+func.func @le_ui8(%a : ui8, %b : ui8) -> i1 {
   %r = arc.cmpi "le", %a, %b : ui8
   return %r : i1
 }
 
-func @gt_ui8(%a : ui8, %b : ui8) -> i1 {
+func.func @gt_ui8(%a : ui8, %b : ui8) -> i1 {
   %r = arc.cmpi "gt", %a, %b : ui8
   return %r : i1
 }
 
-func @ge_ui8(%a : ui8, %b : ui8) -> i1 {
+func.func @ge_ui8(%a : ui8, %b : ui8) -> i1 {
   %r = arc.cmpi "ge", %a, %b : ui8
   return %r : i1
 }
 
-func @eq_ui16(%a : ui16, %b : ui16) -> i1 {
+func.func @eq_ui16(%a : ui16, %b : ui16) -> i1 {
   %r = arc.cmpi "eq", %a, %b : ui16
   return %r : i1
 }
 
-func @ne_ui16(%a : ui16, %b : ui16) -> i1 {
+func.func @ne_ui16(%a : ui16, %b : ui16) -> i1 {
   %r = arc.cmpi "ne", %a, %b : ui16
   return %r : i1
 }
 
-func @lt_ui16(%a : ui16, %b : ui16) -> i1 {
+func.func @lt_ui16(%a : ui16, %b : ui16) -> i1 {
   %r = arc.cmpi "lt", %a, %b : ui16
   return %r : i1
 }
 
-func @le_ui16(%a : ui16, %b : ui16) -> i1 {
+func.func @le_ui16(%a : ui16, %b : ui16) -> i1 {
   %r = arc.cmpi "le", %a, %b : ui16
   return %r : i1
 }
 
-func @gt_ui16(%a : ui16, %b : ui16) -> i1 {
+func.func @gt_ui16(%a : ui16, %b : ui16) -> i1 {
   %r = arc.cmpi "gt", %a, %b : ui16
   return %r : i1
 }
 
-func @ge_ui16(%a : ui16, %b : ui16) -> i1 {
+func.func @ge_ui16(%a : ui16, %b : ui16) -> i1 {
   %r = arc.cmpi "ge", %a, %b : ui16
   return %r : i1
 }
 
-func @eq_ui32(%a : ui32, %b : ui32) -> i1 {
+func.func @eq_ui32(%a : ui32, %b : ui32) -> i1 {
   %r = arc.cmpi "eq", %a, %b : ui32
   return %r : i1
 }
 
-func @ne_ui32(%a : ui32, %b : ui32) -> i1 {
+func.func @ne_ui32(%a : ui32, %b : ui32) -> i1 {
   %r = arc.cmpi "ne", %a, %b : ui32
   return %r : i1
 }
 
-func @lt_ui32(%a : ui32, %b : ui32) -> i1 {
+func.func @lt_ui32(%a : ui32, %b : ui32) -> i1 {
   %r = arc.cmpi "lt", %a, %b : ui32
   return %r : i1
 }
 
-func @le_ui32(%a : ui32, %b : ui32) -> i1 {
+func.func @le_ui32(%a : ui32, %b : ui32) -> i1 {
   %r = arc.cmpi "le", %a, %b : ui32
   return %r : i1
 }
 
-func @gt_ui32(%a : ui32, %b : ui32) -> i1 {
+func.func @gt_ui32(%a : ui32, %b : ui32) -> i1 {
   %r = arc.cmpi "gt", %a, %b : ui32
   return %r : i1
 }
 
-func @ge_ui32(%a : ui32, %b : ui32) -> i1 {
+func.func @ge_ui32(%a : ui32, %b : ui32) -> i1 {
   %r = arc.cmpi "ge", %a, %b : ui32
   return %r : i1
 }
 
-func @eq_ui64(%a : ui64, %b : ui64) -> i1 {
+func.func @eq_ui64(%a : ui64, %b : ui64) -> i1 {
   %r = arc.cmpi "eq", %a, %b : ui64
   return %r : i1
 }
 
-func @ne_ui64(%a : ui64, %b : ui64) -> i1 {
+func.func @ne_ui64(%a : ui64, %b : ui64) -> i1 {
   %r = arc.cmpi "ne", %a, %b : ui64
   return %r : i1
 }
 
-func @lt_ui64(%a : ui64, %b : ui64) -> i1 {
+func.func @lt_ui64(%a : ui64, %b : ui64) -> i1 {
   %r = arc.cmpi "lt", %a, %b : ui64
   return %r : i1
 }
 
-func @le_ui64(%a : ui64, %b : ui64) -> i1 {
+func.func @le_ui64(%a : ui64, %b : ui64) -> i1 {
   %r = arc.cmpi "le", %a, %b : ui64
   return %r : i1
 }
 
-func @gt_ui64(%a : ui64, %b : ui64) -> i1 {
+func.func @gt_ui64(%a : ui64, %b : ui64) -> i1 {
   %r = arc.cmpi "gt", %a, %b : ui64
   return %r : i1
 }
 
-func @ge_ui64(%a : ui64, %b : ui64) -> i1 {
+func.func @ge_ui64(%a : ui64, %b : ui64) -> i1 {
   %r = arc.cmpi "ge", %a, %b : ui64
   return %r : i1
 }
 
-func @eq_si8(%a : si8, %b : si8) -> i1 {
+func.func @eq_si8(%a : si8, %b : si8) -> i1 {
   %r = arc.cmpi "eq", %a, %b : si8
   return %r : i1
 }
 
-func @ne_si8(%a : si8, %b : si8) -> i1 {
+func.func @ne_si8(%a : si8, %b : si8) -> i1 {
   %r = arc.cmpi "ne", %a, %b : si8
   return %r : i1
 }
 
-func @lt_si8(%a : si8, %b : si8) -> i1 {
+func.func @lt_si8(%a : si8, %b : si8) -> i1 {
   %r = arc.cmpi "lt", %a, %b : si8
   return %r : i1
 }
 
-func @le_si8(%a : si8, %b : si8) -> i1 {
+func.func @le_si8(%a : si8, %b : si8) -> i1 {
   %r = arc.cmpi "le", %a, %b : si8
   return %r : i1
 }
 
-func @gt_si8(%a : si8, %b : si8) -> i1 {
+func.func @gt_si8(%a : si8, %b : si8) -> i1 {
   %r = arc.cmpi "gt", %a, %b : si8
   return %r : i1
 }
 
-func @ge_si8(%a : si8, %b : si8) -> i1 {
+func.func @ge_si8(%a : si8, %b : si8) -> i1 {
   %r = arc.cmpi "ge", %a, %b : si8
   return %r : i1
 }
 
-func @eq_si16(%a : si16, %b : si16) -> i1 {
+func.func @eq_si16(%a : si16, %b : si16) -> i1 {
   %r = arc.cmpi "eq", %a, %b : si16
   return %r : i1
 }
 
-func @ne_si16(%a : si16, %b : si16) -> i1 {
+func.func @ne_si16(%a : si16, %b : si16) -> i1 {
   %r = arc.cmpi "ne", %a, %b : si16
   return %r : i1
 }
 
-func @lt_si16(%a : si16, %b : si16) -> i1 {
+func.func @lt_si16(%a : si16, %b : si16) -> i1 {
   %r = arc.cmpi "lt", %a, %b : si16
   return %r : i1
 }
 
-func @le_si16(%a : si16, %b : si16) -> i1 {
+func.func @le_si16(%a : si16, %b : si16) -> i1 {
   %r = arc.cmpi "le", %a, %b : si16
   return %r : i1
 }
 
-func @gt_si16(%a : si16, %b : si16) -> i1 {
+func.func @gt_si16(%a : si16, %b : si16) -> i1 {
   %r = arc.cmpi "gt", %a, %b : si16
   return %r : i1
 }
 
-func @ge_si16(%a : si16, %b : si16) -> i1 {
+func.func @ge_si16(%a : si16, %b : si16) -> i1 {
   %r = arc.cmpi "ge", %a, %b : si16
   return %r : i1
 }
 
-func @eq_si32(%a : si32, %b : si32) -> i1 {
+func.func @eq_si32(%a : si32, %b : si32) -> i1 {
   %r = arc.cmpi "eq", %a, %b : si32
   return %r : i1
 }
 
-func @ne_si32(%a : si32, %b : si32) -> i1 {
+func.func @ne_si32(%a : si32, %b : si32) -> i1 {
   %r = arc.cmpi "ne", %a, %b : si32
   return %r : i1
 }
 
-func @lt_si32(%a : si32, %b : si32) -> i1 {
+func.func @lt_si32(%a : si32, %b : si32) -> i1 {
   %r = arc.cmpi "lt", %a, %b : si32
   return %r : i1
 }
 
-func @le_si32(%a : si32, %b : si32) -> i1 {
+func.func @le_si32(%a : si32, %b : si32) -> i1 {
   %r = arc.cmpi "le", %a, %b : si32
   return %r : i1
 }
 
-func @gt_si32(%a : si32, %b : si32) -> i1 {
+func.func @gt_si32(%a : si32, %b : si32) -> i1 {
   %r = arc.cmpi "gt", %a, %b : si32
   return %r : i1
 }
 
-func @ge_si32(%a : si32, %b : si32) -> i1 {
+func.func @ge_si32(%a : si32, %b : si32) -> i1 {
   %r = arc.cmpi "ge", %a, %b : si32
   return %r : i1
 }
 
-func @eq_si64(%a : si64, %b : si64) -> i1 {
+func.func @eq_si64(%a : si64, %b : si64) -> i1 {
   %r = arc.cmpi "eq", %a, %b : si64
   return %r : i1
 }
 
-func @ne_si64(%a : si64, %b : si64) -> i1 {
+func.func @ne_si64(%a : si64, %b : si64) -> i1 {
   %r = arc.cmpi "ne", %a, %b : si64
   return %r : i1
 }
 
-func @lt_si64(%a : si64, %b : si64) -> i1 {
+func.func @lt_si64(%a : si64, %b : si64) -> i1 {
   %r = arc.cmpi "lt", %a, %b : si64
   return %r : i1
 }
 
-func @le_si64(%a : si64, %b : si64) -> i1 {
+func.func @le_si64(%a : si64, %b : si64) -> i1 {
   %r = arc.cmpi "le", %a, %b : si64
   return %r : i1
 }
 
-func @gt_si64(%a : si64, %b : si64) -> i1 {
+func.func @gt_si64(%a : si64, %b : si64) -> i1 {
   %r = arc.cmpi "gt", %a, %b : si64
   return %r : i1
 }
 
-func @ge_si64(%a : si64, %b : si64) -> i1 {
+func.func @ge_si64(%a : si64, %b : si64) -> i1 {
   %r = arc.cmpi "ge", %a, %b : si64
   return %r : i1
 }

--- a/arc-mlir/src/tests/arc-to-rust/bad-tasks.mlir
+++ b/arc-mlir/src/tests/arc-to-rust/bad-tasks.mlir
@@ -3,7 +3,7 @@
 module @toplevel {
   // expected-error@+2 {{'rust.func' op : task event handlers are expected to have 3 arguments, found 2}}
   // expected-note@+1 {{see current operation:}}
-  func @my_handler(%in   : !arc.enum<A : si32, B : si32>,
+  func.func @my_handler(%in   : !arc.enum<A : si32, B : si32>,
                    %out  : !arc.stream<!arc.enum<C : si32, D : si32>>)
                 -> ()
                 attributes { "arc.mod_name" = "my_task",
@@ -25,7 +25,7 @@ module @toplevel {
     return
   }
 
-  func @init(%this : !arc.struct<x : si32>) -> ()
+  func.func @init(%this : !arc.struct<x : si32>) -> ()
                 attributes { "arc.mod_name" = "my_task",
                              "arc.task_name" = "MyTask",
 			     "arc.is_init"}
@@ -39,7 +39,7 @@ module @toplevel {
 module @toplevel {
   // expected-error@+2 {{'rust.func' op : The first argument to a task event handler is expected to be a struct}}
   // expected-note@+1 {{see current operation:}}
-  func @my_handler(%in   : !arc.enum<A : si32, B : si32>,
+  func.func @my_handler(%in   : !arc.enum<A : si32, B : si32>,
                    %this : !arc.struct<x : si32>,
                    %out  : !arc.stream<!arc.enum<C : si32, D : si32>>)
                 -> ()
@@ -62,7 +62,7 @@ module @toplevel {
     return
   }
 
-  func @init(%this : !arc.struct<x : si32>) -> ()
+  func.func @init(%this : !arc.struct<x : si32>) -> ()
                 attributes { "arc.mod_name" = "my_task",
                              "arc.task_name" = "MyTask",
 			     "arc.is_init"}
@@ -76,7 +76,7 @@ module @toplevel {
 module @toplevel {
   // expected-error@+2 {{'rust.func' op : The second argument to a task event handler is expected to be an enum}}
   // expected-note@+1 {{see current operation:}}
-  func @my_handler(%this : !arc.struct<x : si32>,
+  func.func @my_handler(%this : !arc.struct<x : si32>,
                    %out  : !arc.stream<!arc.enum<C : si32, D : si32>>,
                    %in   : !arc.enum<A : si32, B : si32>)
                 -> ()
@@ -99,7 +99,7 @@ module @toplevel {
     return
   }
 
-  func @init(%this : !arc.struct<x : si32>) -> ()
+  func.func @init(%this : !arc.struct<x : si32>) -> ()
                 attributes { "arc.mod_name" = "my_task",
                              "arc.task_name" = "MyTask",
 			     "arc.is_init"}
@@ -113,7 +113,7 @@ module @toplevel {
 module @toplevel {
   // expected-error@+2 {{The third argument to a task event handler is expected to be a stream}}
   // expected-note@+1 {{see current operation:}}
-  func @my_handler(%this : !arc.struct<x : si32>,
+  func.func @my_handler(%this : !arc.struct<x : si32>,
                    %in   : !arc.enum<A : si32, B : si32>,
                    %out  : !arc.enum<C : si32, D : si32>)
                 -> ()
@@ -136,7 +136,7 @@ module @toplevel {
     return
   }
 
-  func @init(%this : !arc.struct<x : si32>) -> ()
+  func.func @init(%this : !arc.struct<x : si32>) -> ()
                 attributes { "arc.mod_name" = "my_task",
                              "arc.task_name" = "MyTask",
 			     "arc.is_init"}

--- a/arc-mlir/src/tests/arc-to-rust/bool-ops.mlir
+++ b/arc-mlir/src/tests/arc-to-rust/bool-ops.mlir
@@ -3,32 +3,32 @@
 
 
 module @toplevel {
-  func @and_i1(%arg0: i1, %arg1: i1) -> i1 {
+  func.func @and_i1(%arg0: i1, %arg1: i1) -> i1 {
     %0 = arith.andi %arg0, %arg1 : i1
     return %0 : i1
   }
-  func @or_i1(%arg0: i1, %arg1: i1) -> i1 {
+  func.func @or_i1(%arg0: i1, %arg1: i1) -> i1 {
     %0 = arith.ori %arg0, %arg1 : i1
     return %0 : i1
   }
-  func @xor_i1(%arg0: i1, %arg1: i1) -> i1 {
+  func.func @xor_i1(%arg0: i1, %arg1: i1) -> i1 {
     %0 = arith.xori %arg0, %arg1 : i1
     return %0 : i1
   }
-  func @eq_i1(%a : i1, %b : i1) -> i1 attributes {rust.declare} {
+  func.func @eq_i1(%a : i1, %b : i1) -> i1 attributes {rust.declare} {
     %r = arith.cmpi "eq", %a, %b : i1
     return %r : i1
   }
-  func @ne_i1(%a : i1, %b : i1) -> i1 attributes {rust.declare} {
+  func.func @ne_i1(%a : i1, %b : i1) -> i1 attributes {rust.declare} {
     %r = arith.cmpi "ne", %a, %b : i1
     return %r : i1
   }
-  func @not_i1(%arg0: i1) -> i1 {
+  func.func @not_i1(%arg0: i1) -> i1 {
     %0 = arith.constant 1 : i1
     %1 = arith.xori %arg0, %0 : i1
     return %1 : i1
   }
-  func @not_select_i1(%arg0: i1) -> i1 {
+  func.func @not_select_i1(%arg0: i1) -> i1 {
     %0 = arith.constant 0 : i1
     %1 = arith.constant 1 : i1
     %2 = arith.select %arg0, %0, %1 : i1

--- a/arc-mlir/src/tests/arc-to-rust/calls-streams.mlir
+++ b/arc-mlir/src/tests/arc-to-rust/calls-streams.mlir
@@ -7,7 +7,7 @@ module @toplevel {
 
   func private @crate_Identity() -> ((!arc.stream.source<!arc.struct<key: si32, value: si32>>) -> !arc.stream.source<!arc.struct<key: si32, value: si32>>)
 
-    func @crate_main(%input_0: !arc.stream.source<!arc.struct<key: si32, value: si32>>) -> !arc.stream.source<!arc.struct<key: si32, value: si32>> {
+    func.func @crate_main(%input_0: !arc.stream.source<!arc.struct<key: si32, value: si32>>) -> !arc.stream.source<!arc.struct<key: si32, value: si32>> {
         %x_8 = constant @crate_Identity : () -> ((!arc.stream.source<!arc.struct<key: si32, value: si32>>) -> !arc.stream.source<!arc.struct<key: si32, value: si32>>)
         %x_9 = call_indirect %x_8() : () -> ((!arc.stream.source<!arc.struct<key: si32, value: si32>>) -> !arc.stream.source<!arc.struct<key: si32, value: si32>>)
         %x_A = call_indirect %x_9(%input_0) : (!arc.stream.source<!arc.struct<key: si32, value: si32>>) -> !arc.stream.source<!arc.struct<key: si32, value: si32>>

--- a/arc-mlir/src/tests/arc-to-rust/calls.mlir
+++ b/arc-mlir/src/tests/arc-to-rust/calls.mlir
@@ -4,68 +4,68 @@
 
 module @toplevel {
 
-  func @callee_void_void() -> () attributes { rust.declare } {
+  func.func @callee_void_void() -> () attributes { rust.declare } {
     return
   }
 
-  func @callee_si32_si32(%in : si32) -> si32 attributes { rust.declare } {
+  func.func @callee_si32_si32(%in : si32) -> si32 attributes { rust.declare } {
     return %in : si32
   }
 
-  func @callee_si32_x2_si32(%a : si32, %b : si32) -> si32 attributes { rust.declare } {
+  func.func @callee_si32_x2_si32(%a : si32, %b : si32) -> si32 attributes { rust.declare } {
     return %b : si32
   }
 
-  func @callee_struct(%in : !arc.struct<foo : si32>)
+  func.func @callee_struct(%in : !arc.struct<foo : si32>)
        -> !arc.struct<foo : si32> attributes { rust.declare } {
     return %in : !arc.struct<foo : si32>
   }
 
-  func @callee_tuple(%in : tuple<si32,si32>) -> tuple<si32,si32> attributes { rust.declare } {
+  func.func @callee_tuple(%in : tuple<si32,si32>) -> tuple<si32,si32> attributes { rust.declare } {
     return %in : tuple<si32,si32>
   }
 
-  func @callee_mixed(%in : tuple<si32,si32,!arc.struct<a : si32>>)
+  func.func @callee_mixed(%in : tuple<si32,si32,!arc.struct<a : si32>>)
        -> tuple<si32,si32,!arc.struct<a : si32>> attributes { rust.declare }  {
     return %in : tuple<si32,si32,!arc.struct<a : si32>>
   }
 
-  func @caller0() -> () attributes { rust.declare }  {
+  func.func @caller0() -> () attributes { rust.declare }  {
     call @callee_void_void() : () -> ()
     return
   }
 
-  func @caller1(%in : si32) -> (si32) attributes { rust.declare }  {
+  func.func @caller1(%in : si32) -> (si32) attributes { rust.declare }  {
     %r = call @callee_si32_si32(%in) : (si32) -> si32
     return %r : si32
   }
 
-  func @caller2(%in0 : si32, %in1 : si32) -> (si32) attributes { rust.declare }  {
+  func.func @caller2(%in0 : si32, %in1 : si32) -> (si32) attributes { rust.declare }  {
     %r = call @callee_si32_x2_si32(%in0, %in1) : (si32,si32) -> si32
     return %r : si32
   }
 
 
-  func @caller_struct(%in : !arc.struct<foo : si32>)
+  func.func @caller_struct(%in : !arc.struct<foo : si32>)
        -> !arc.struct<foo : si32> {
     %r = call @callee_struct(%in) : (!arc.struct<foo : si32>)
        	      			     -> !arc.struct<foo : si32>
     return %r : !arc.struct<foo : si32>
   }
 
-  func @caller_tuple(%in : tuple<si32,si32>) -> tuple<si32,si32> attributes { rust.declare } {
+  func.func @caller_tuple(%in : tuple<si32,si32>) -> tuple<si32,si32> attributes { rust.declare } {
     %r = call @callee_tuple(%in) : (tuple<si32,si32>) -> tuple<si32,si32>
     return %r : tuple<si32,si32>
   }
 
-  func @caller_mixed(%in : tuple<si32,si32,!arc.struct<a : si32>>)
+  func.func @caller_mixed(%in : tuple<si32,si32,!arc.struct<a : si32>>)
        -> tuple<si32,si32,!arc.struct<a : si32>> attributes { rust.declare } {
     %r = call @callee_mixed(%in) : (tuple<si32,si32,!arc.struct<a : si32>>)
        	      			    -> tuple<si32,si32,!arc.struct<a : si32>>
     return %in : tuple<si32,si32,!arc.struct<a : si32>>
   }
 
-  func @indir_call0(%in : tuple<si32,si32,!arc.struct<a : si32>>)
+  func.func @indir_call0(%in : tuple<si32,si32,!arc.struct<a : si32>>)
        -> tuple<si32,si32,!arc.struct<a : si32>> attributes { rust.declare } {
     %f = constant @caller_mixed : (tuple<si32,si32,!arc.struct<a : si32>>)
          -> tuple<si32,si32,!arc.struct<a : si32>>
@@ -74,12 +74,12 @@ module @toplevel {
     return %r : tuple<si32,si32,!arc.struct<a : si32>>
   }
 
-  func @enumfun(%in : !arc.enum<ea : si32, eb : f32>)
+  func.func @enumfun(%in : !arc.enum<ea : si32, eb : f32>)
        -> !arc.enum<ea : si32, eb : f32> attributes { rust.declare } {
     return %in : !arc.enum<ea : si32, eb : f32>
   }
 
-  func @indir_call1(%in : !arc.enum<ea : si32, eb : f32>)
+  func.func @indir_call1(%in : !arc.enum<ea : si32, eb : f32>)
        -> !arc.enum<ea : si32, eb : f32> attributes { rust.declare } {
     %f = constant @enumfun : (!arc.enum<ea : si32, eb : f32>)
          -> !arc.enum<ea : si32, eb : f32>
@@ -88,12 +88,12 @@ module @toplevel {
     return %r : !arc.enum<ea : si32, eb : f32>
   }
 
-  // func @tensorfun(%in : tensor<5xi32>)
+  // func.func @tensorfun(%in : tensor<5xi32>)
   //      -> tensor<5xi32> attributes { rust.declare } {
   //   return %in : tensor<5xi32>
   // }
 
-  // func @indir_call2(%in : tensor<5xi32>)
+  // func.func @indir_call2(%in : tensor<5xi32>)
   //      -> tensor<5xi32> attributes { rust.declare } {
   //   %f = constant @tensorfun : (tensor<5xi32>)
   //        -> tensor<5xi32>
@@ -102,14 +102,14 @@ module @toplevel {
   //   return %r : tensor<5xi32>
   // }
 
-  func private @an_external_fun0(si32) -> f32 attributes { rust.declare }
+  func.func private @an_external_fun0(si32) -> f32 attributes { rust.declare }
 
-  func @call_external0(%in : si32) -> f32 attributes { rust.declare } {
+  func.func @call_external0(%in : si32) -> f32 attributes { rust.declare } {
     %r = call @an_external_fun0(%in) : (si32) -> f32
     return %r : f32
   }
 
-  func @call_external_indirect0(%in : si32) -> f32 attributes { rust.declare } {
+  func.func @call_external_indirect0(%in : si32) -> f32 attributes { rust.declare } {
     %f = constant @an_external_fun0 : (si32) -> f32
     %r = call_indirect %f(%in) : (si32) -> f32
     return %r : f32
@@ -118,32 +118,32 @@ module @toplevel {
   // TODO: Try to find a way to support returning functions into Arc-Lang
   // func private @an_external_fun1() -> ((si32) -> si32) attributes { rust.declare }
 
-  // func @call_external1(%in : si32) -> si32 attributes { rust.declare } {
+  // func.func @call_external1(%in : si32) -> si32 attributes { rust.declare } {
   //   %f = call @an_external_fun1() : () -> ((si32) -> si32)
   //   %r = call_indirect %f(%in) : (si32) -> si32
   //   return %r : si32
   // }
 
-  // func @call_external_indirect1(%in : si32) -> si32 attributes { rust.declare } {
+  // func.func @call_external_indirect1(%in : si32) -> si32 attributes { rust.declare } {
   //   %thunk = constant @an_external_fun1 : () -> ((si32) -> si32)
   //   %f = call_indirect %thunk() : () -> ((si32) -> si32)
   //   %r = call_indirect %f(%in) : (si32) -> si32
   //   return %r : si32
   // }
 
-  func private @an_external_fun_with_other_name0(si32) -> si32 attributes { rust.declare, "arc.rust_name" = "the_name_on_the_rust_side" }
+  func.func private @an_external_fun_with_other_name0(si32) -> si32 attributes { rust.declare, "arc.rust_name" = "the_name_on_the_rust_side" }
 
-  func @call_external2(%in : si32) -> si32 attributes { rust.declare } {
+  func.func @call_external2(%in : si32) -> si32 attributes { rust.declare } {
     %r = call @an_external_fun_with_other_name0(%in) : (si32) -> si32
     return %r : si32
   }
 
-  func private @a_function_called_something_else_in_rust(%in : si32) -> si32
+  func.func private @a_function_called_something_else_in_rust(%in : si32) -> si32
      attributes { "arc.rust_name" = "defined_in_arc" } {
     return %in : si32
   }
 
-  func @call_renamed_local(%in : si32) -> si32 attributes { rust.declare } {
+  func.func @call_renamed_local(%in : si32) -> si32 attributes { rust.declare } {
     %r = call @a_function_called_something_else_in_rust(%in) : (si32) -> si32
     return %r : si32
   }

--- a/arc-mlir/src/tests/arc-to-rust/enums.mlir
+++ b/arc-mlir/src/tests/arc-to-rust/enums.mlir
@@ -3,25 +3,25 @@
 // RUN: arc-mlir-rust-test %t-roundtrip-scf %s -rustinclude %s.rust-tests -canonicalize -remove-scf -canonicalize -to-scf -canonicalize
 
 module @toplevel {
-  func @ok0() -> !arc.enum<a : si32, b : f32> {
+  func.func @ok0() -> !arc.enum<a : si32, b : f32> {
     %a = arc.constant 4 : si32
     %r = arc.make_enum (%a : si32) as "a" : !arc.enum<a : si32, b : f32>
     return %r : !arc.enum<a : si32, b : f32>
   }
 
-  func @ok1() -> !arc.enum<a : si32, b : f32> {
+  func.func @ok1() -> !arc.enum<a : si32, b : f32> {
     %b = arith.constant 3.14 : f32
     %r = arc.make_enum (%b : f32) as "b" : !arc.enum<a : si32, b : f32>
     return %r : !arc.enum<a : si32, b : f32>
   }
 
-  func @ok2() -> !arc.enum<a : si32> {
+  func.func @ok2() -> !arc.enum<a : si32> {
     %a = arc.constant 4 : si32
     %r = arc.make_enum (%a : si32) as "a" : !arc.enum<a : si32>
     return %r : !arc.enum<a : si32>
   }
 
-  func @ok3() -> !arc.enum<a : si32, b : !arc.enum<a : si32> > {
+  func.func @ok3() -> !arc.enum<a : si32, b : !arc.enum<a : si32> > {
     %a = arc.constant 4 : si32
     %b = arc.constant 3 : si32
     %s = arc.make_enum (%a : si32) as "a" : !arc.enum<a : si32>
@@ -29,7 +29,7 @@ module @toplevel {
     return %r : !arc.enum<a : si32, b : !arc.enum<a : si32>>
   }
 
-  func @ok4() -> !arc.enum<a : si32, b : !arc.enum<a : si32> > {
+  func.func @ok4() -> !arc.enum<a : si32, b : !arc.enum<a : si32> > {
     %a = arc.constant 4 : si32
     %b = arc.constant 3 : si32
     %s = arc.make_enum (%a : si32) as "a" : !arc.enum<a : si32>
@@ -37,27 +37,27 @@ module @toplevel {
     return %r : !arc.enum<a : si32, b : !arc.enum<a : si32>>
   }
 
-  func @ok5() -> !arc.enum<no_value : none> {
+  func.func @ok5() -> !arc.enum<no_value : none> {
     %r = arc.make_enum () as "no_value" : !arc.enum<no_value : none>
     return %r : !arc.enum<no_value : none>
   }
 
-  func @ok6() -> !arc.enum<no_value : none, b : f32> {
+  func.func @ok6() -> !arc.enum<no_value : none, b : f32> {
     %r = arc.make_enum () as "no_value" : !arc.enum<no_value : none, b : f32>
     return %r : !arc.enum<no_value : none, b : f32>
   }
 
-  func @access0(%e : !arc.enum<a : si32, b : f32>) -> si32 {
+  func.func @access0(%e : !arc.enum<a : si32, b : f32>) -> si32 {
     %r = arc.enum_access "a" in (%e : !arc.enum<a : si32, b : f32>) : si32
     return %r : si32
   }
 
-  func @access1(%e : !arc.enum<a : si32, b : f32>) -> f32 {
+  func.func @access1(%e : !arc.enum<a : si32, b : f32>) -> f32 {
     %r = arc.enum_access "b" in (%e : !arc.enum<a : si32, b : f32>) : f32
     return %r : f32
   }
 
-  func @check0(%e : !arc.enum<a : si32, b : f32>) -> i1 {
+  func.func @check0(%e : !arc.enum<a : si32, b : f32>) -> i1 {
     %r = arc.enum_check (%e : !arc.enum<a : si32, b : f32>) is "a" : i1
     return %r : i1
   }

--- a/arc-mlir/src/tests/arc-to-rust/float-tensor-arith.mlir
+++ b/arc-mlir/src/tests/arc-to-rust/float-tensor-arith.mlir
@@ -3,52 +3,52 @@
 // RUN: arc-mlir-rust-test %t-roundtrip-scf %s -rustinclude %s.rust-tests -canonicalize -remove-scf -canonicalize -to-scf -canonicalize
 
 module @arctorustfloattensorarith {
-func @addf_tensor2x2xf32(%a : tensor<2x2xf32>, %b : tensor<2x2xf32>) -> tensor<2x2xf32> {
+func.func @addf_tensor2x2xf32(%a : tensor<2x2xf32>, %b : tensor<2x2xf32>) -> tensor<2x2xf32> {
   %c = arith.addf %a, %b : tensor<2x2xf32>
   return %c : tensor<2x2xf32>
 }
 
-func @subf_tensor2x2xf32(%a : tensor<2x2xf32>, %b : tensor<2x2xf32>) -> tensor<2x2xf32> {
+func.func @subf_tensor2x2xf32(%a : tensor<2x2xf32>, %b : tensor<2x2xf32>) -> tensor<2x2xf32> {
   %c = arith.subf %a, %b : tensor<2x2xf32>
   return %c : tensor<2x2xf32>
 }
 
-func @mulf_tensor2x2xf32(%a : tensor<2x2xf32>, %b : tensor<2x2xf32>) -> tensor<2x2xf32> {
+func.func @mulf_tensor2x2xf32(%a : tensor<2x2xf32>, %b : tensor<2x2xf32>) -> tensor<2x2xf32> {
   %c = arith.mulf %a, %b : tensor<2x2xf32>
   return %c : tensor<2x2xf32>
 }
 
-func @divf_tensor2x2xf32(%a : tensor<2x2xf32>, %b : tensor<2x2xf32>) -> tensor<2x2xf32> {
+func.func @divf_tensor2x2xf32(%a : tensor<2x2xf32>, %b : tensor<2x2xf32>) -> tensor<2x2xf32> {
   %c = arith.divf %a, %b : tensor<2x2xf32>
   return %c : tensor<2x2xf32>
 }
 
-func @remf_tensor2x2xf32(%a : tensor<2x2xf32>, %b : tensor<2x2xf32>) -> tensor<2x2xf32> {
+func.func @remf_tensor2x2xf32(%a : tensor<2x2xf32>, %b : tensor<2x2xf32>) -> tensor<2x2xf32> {
   %c = arith.remf %a, %b : tensor<2x2xf32>
   return %c : tensor<2x2xf32>
 }
 
-func @addf_tensor2x2xf64(%a : tensor<2x2xf64>, %b : tensor<2x2xf64>) -> tensor<2x2xf64> {
+func.func @addf_tensor2x2xf64(%a : tensor<2x2xf64>, %b : tensor<2x2xf64>) -> tensor<2x2xf64> {
   %c = arith.addf %a, %b : tensor<2x2xf64>
   return %c : tensor<2x2xf64>
 }
 
-func @subf_tensor2x2xf64(%a : tensor<2x2xf64>, %b : tensor<2x2xf64>) -> tensor<2x2xf64> {
+func.func @subf_tensor2x2xf64(%a : tensor<2x2xf64>, %b : tensor<2x2xf64>) -> tensor<2x2xf64> {
   %c = arith.subf %a, %b : tensor<2x2xf64>
   return %c : tensor<2x2xf64>
 }
 
-func @mulf_tensor2x2xf64(%a : tensor<2x2xf64>, %b : tensor<2x2xf64>) -> tensor<2x2xf64> {
+func.func @mulf_tensor2x2xf64(%a : tensor<2x2xf64>, %b : tensor<2x2xf64>) -> tensor<2x2xf64> {
   %c = arith.mulf %a, %b : tensor<2x2xf64>
   return %c : tensor<2x2xf64>
 }
 
-func @divf_tensor2x2xf64(%a : tensor<2x2xf64>, %b : tensor<2x2xf64>) -> tensor<2x2xf64> {
+func.func @divf_tensor2x2xf64(%a : tensor<2x2xf64>, %b : tensor<2x2xf64>) -> tensor<2x2xf64> {
   %c = arith.divf %a, %b : tensor<2x2xf64>
   return %c : tensor<2x2xf64>
 }
 
-func @remf_tensor2x2xf64(%a : tensor<2x2xf64>, %b : tensor<2x2xf64>) -> tensor<2x2xf64> {
+func.func @remf_tensor2x2xf64(%a : tensor<2x2xf64>, %b : tensor<2x2xf64>) -> tensor<2x2xf64> {
   %c = arith.remf %a, %b : tensor<2x2xf64>
   return %c : tensor<2x2xf64>
 }

--- a/arc-mlir/src/tests/arc-to-rust/foreign-calls.mlir
+++ b/arc-mlir/src/tests/arc-to-rust/foreign-calls.mlir
@@ -4,32 +4,32 @@
 
 module @arctorustforeigncalls {
 
-  func private @callee_void_void() -> ()
+  func.func private @callee_void_void() -> ()
 
-  func private @callee_si32_si32(%in : si32) -> si32
+  func.func private @callee_si32_si32(%in : si32) -> si32
 
-  func private @callee_si32_x2_si32(%a : si32, %b : si32) -> si32
+  func.func private @callee_si32_x2_si32(%a : si32, %b : si32) -> si32
 
-  func private @callee_struct(%in : !arc.struct<foo : si32>)
+  func.func private @callee_struct(%in : !arc.struct<foo : si32>)
        -> !arc.struct<foo : si32>
 
-  func @caller0() -> () {
+  func.func @caller0() -> () {
     call @callee_void_void() : () -> ()
     return
   }
 
-  func @caller1(%in : si32) -> (si32) {
+  func.func @caller1(%in : si32) -> (si32) {
     %r = call @callee_si32_si32(%in) : (si32) -> si32
     return %r : si32
   }
 
-  func @caller2(%in0 : si32, %in1 : si32) -> (si32) {
+  func.func @caller2(%in0 : si32, %in1 : si32) -> (si32) {
     %r = call @callee_si32_x2_si32(%in0, %in1) : (si32,si32) -> si32
     return %r : si32
   }
 
 
-  func @caller_struct(%in : !arc.struct<foo : si32>)
+  func.func @caller_struct(%in : !arc.struct<foo : si32>)
        -> !arc.struct<foo : si32> {
     %r = call @callee_struct(%in) : (!arc.struct<foo : si32>)
        	      			     -> !arc.struct<foo : si32>

--- a/arc-mlir/src/tests/arc-to-rust/func-arguments.mlir
+++ b/arc-mlir/src/tests/arc-to-rust/func-arguments.mlir
@@ -2,16 +2,16 @@
 // RUN: arc-mlir-rust-test %t-roundtrip-scf %s -rustinclude %s.rust-tests -canonicalize -remove-scf -canonicalize -to-scf -canonicalize
 
 module @arctorustfuncarguments {
-  func @zero_args() -> ui16 {
+  func.func @zero_args() -> ui16 {
     %t = arc.constant 4711 : ui16
     return %t : ui16
   }
 
-  func @one_arg(%a : ui16) -> ui16 {
+  func.func @one_arg(%a : ui16) -> ui16 {
     return %a : ui16
   }
 
-  func @two_args(%a : ui16, %b : ui16) -> ui16 {
+  func.func @two_args(%a : ui16, %b : ui16) -> ui16 {
     return %b : ui16
   }
 }

--- a/arc-mlir/src/tests/arc-to-rust/ifs.mlir
+++ b/arc-mlir/src/tests/arc-to-rust/ifs.mlir
@@ -2,7 +2,7 @@
 // RUN: arc-mlir-rust-test %t-roundtrip-scf %s -rustinclude %s.rust-tests -canonicalize -remove-scf -canonicalize -to-scf -canonicalize
 
 module @arctorustifs {
-  func @test_0() -> si32 {
+  func.func @test_0() -> si32 {
     %0 = arc.constant 65 : si32
     %1 = arc.constant 66 : si32
     %2 = arith.constant 1 : i1
@@ -13,7 +13,7 @@ module @arctorustifs {
     }) : (i1) -> si32
     return %3 : si32
   }
-  func @test_1(%c: i1, %arg0: ui32, %arg1: ui32) -> ui32 {
+  func.func @test_1(%c: i1, %arg0: ui32, %arg1: ui32) -> ui32 {
     %3 = "arc.if"(%c) ({
       "arc.block.result"(%arg0) : (ui32) -> ()
     }, {
@@ -21,7 +21,7 @@ module @arctorustifs {
     }) : (i1) -> ui32
     return %3 : ui32
   }
-  func @test_2(%c: i1, %arg0: ui32, %arg1: ui32) -> () {
+  func.func @test_2(%c: i1, %arg0: ui32, %arg1: ui32) -> () {
     "arc.if"(%c) ({
       "arc.block.result"() : () -> ()
     }, {
@@ -30,7 +30,7 @@ module @arctorustifs {
     return
   }
 
-  func @test_3(%c: i1, %arg0: ui32, %arg1: ui32) -> ui32 {
+  func.func @test_3(%c: i1, %arg0: ui32, %arg1: ui32) -> ui32 {
     %3 = "arc.if"(%c) ({
       "arc.return"(%arg0) : (ui32) -> ()
     }, {
@@ -38,7 +38,7 @@ module @arctorustifs {
     }) : (i1) -> ui32
     return %3 : ui32
   }
-  func @test_4(%c: i1, %arg0: ui32, %arg1: ui32) -> ui32 {
+  func.func @test_4(%c: i1, %arg0: ui32, %arg1: ui32) -> ui32 {
     %3 = "arc.if"(%c) ({
       "arc.block.result"(%arg1) : (ui32) -> ()
     }, {

--- a/arc-mlir/src/tests/arc-to-rust/int-arith.mlir
+++ b/arc-mlir/src/tests/arc-to-rust/int-arith.mlir
@@ -2,202 +2,202 @@
 // RUN: arc-mlir-rust-test %t-roundtrip-scf %s -rustinclude %s.rust-tests -canonicalize -remove-scf -canonicalize -to-scf -canonicalize
 
 module @arctorustintarith {
-func @addi_ui8(%a : ui8, %b : ui8) -> ui8 {
+func.func @addi_ui8(%a : ui8, %b : ui8) -> ui8 {
   %c = arc.addi %a, %b : ui8
   return %c : ui8
 }
 
-func @subi_ui8(%a : ui8, %b : ui8) -> ui8 {
+func.func @subi_ui8(%a : ui8, %b : ui8) -> ui8 {
   %c = arc.subi %a, %b : ui8
   return %c : ui8
 }
 
-func @muli_ui8(%a : ui8, %b : ui8) -> ui8 {
+func.func @muli_ui8(%a : ui8, %b : ui8) -> ui8 {
   %c = arc.muli %a, %b : ui8
   return %c : ui8
 }
 
-func @divi_ui8(%a : ui8, %b : ui8) -> ui8 {
+func.func @divi_ui8(%a : ui8, %b : ui8) -> ui8 {
   %c = arc.divi %a, %b : ui8
   return %c : ui8
 }
 
-func @remi_ui8(%a : ui8, %b : ui8) -> ui8 {
+func.func @remi_ui8(%a : ui8, %b : ui8) -> ui8 {
   %c = arc.remi %a, %b : ui8
   return %c : ui8
 }
 
-func @addi_ui16(%a : ui16, %b : ui16) -> ui16 {
+func.func @addi_ui16(%a : ui16, %b : ui16) -> ui16 {
   %c = arc.addi %a, %b : ui16
   return %c : ui16
 }
 
-func @subi_ui16(%a : ui16, %b : ui16) -> ui16 {
+func.func @subi_ui16(%a : ui16, %b : ui16) -> ui16 {
   %c = arc.subi %a, %b : ui16
   return %c : ui16
 }
 
-func @muli_ui16(%a : ui16, %b : ui16) -> ui16 {
+func.func @muli_ui16(%a : ui16, %b : ui16) -> ui16 {
   %c = arc.muli %a, %b : ui16
   return %c : ui16
 }
 
-func @divi_ui16(%a : ui16, %b : ui16) -> ui16 {
+func.func @divi_ui16(%a : ui16, %b : ui16) -> ui16 {
   %c = arc.divi %a, %b : ui16
   return %c : ui16
 }
 
-func @remi_ui16(%a : ui16, %b : ui16) -> ui16 {
+func.func @remi_ui16(%a : ui16, %b : ui16) -> ui16 {
   %c = arc.remi %a, %b : ui16
   return %c : ui16
 }
 
-func @addi_ui32(%a : ui32, %b : ui32) -> ui32 {
+func.func @addi_ui32(%a : ui32, %b : ui32) -> ui32 {
   %c = arc.addi %a, %b : ui32
   return %c : ui32
 }
 
-func @subi_ui32(%a : ui32, %b : ui32) -> ui32 {
+func.func @subi_ui32(%a : ui32, %b : ui32) -> ui32 {
   %c = arc.subi %a, %b : ui32
   return %c : ui32
 }
 
-func @muli_ui32(%a : ui32, %b : ui32) -> ui32 {
+func.func @muli_ui32(%a : ui32, %b : ui32) -> ui32 {
   %c = arc.muli %a, %b : ui32
   return %c : ui32
 }
 
-func @divi_ui32(%a : ui32, %b : ui32) -> ui32 {
+func.func @divi_ui32(%a : ui32, %b : ui32) -> ui32 {
   %c = arc.divi %a, %b : ui32
   return %c : ui32
 }
 
-func @remi_ui32(%a : ui32, %b : ui32) -> ui32 {
+func.func @remi_ui32(%a : ui32, %b : ui32) -> ui32 {
   %c = arc.remi %a, %b : ui32
   return %c : ui32
 }
 
-func @addi_ui64(%a : ui64, %b : ui64) -> ui64 {
+func.func @addi_ui64(%a : ui64, %b : ui64) -> ui64 {
   %c = arc.addi %a, %b : ui64
   return %c : ui64
 }
 
-func @subi_ui64(%a : ui64, %b : ui64) -> ui64 {
+func.func @subi_ui64(%a : ui64, %b : ui64) -> ui64 {
   %c = arc.subi %a, %b : ui64
   return %c : ui64
 }
 
-func @muli_ui64(%a : ui64, %b : ui64) -> ui64 {
+func.func @muli_ui64(%a : ui64, %b : ui64) -> ui64 {
   %c = arc.muli %a, %b : ui64
   return %c : ui64
 }
 
-func @divi_ui64(%a : ui64, %b : ui64) -> ui64 {
+func.func @divi_ui64(%a : ui64, %b : ui64) -> ui64 {
   %c = arc.divi %a, %b : ui64
   return %c : ui64
 }
 
-func @remi_ui64(%a : ui64, %b : ui64) -> ui64 {
+func.func @remi_ui64(%a : ui64, %b : ui64) -> ui64 {
   %c = arc.remi %a, %b : ui64
   return %c : ui64
 }
 
-func @addi_si8(%a : si8, %b : si8) -> si8 {
+func.func @addi_si8(%a : si8, %b : si8) -> si8 {
   %c = arc.addi %a, %b : si8
   return %c : si8
 }
 
-func @subi_si8(%a : si8, %b : si8) -> si8 {
+func.func @subi_si8(%a : si8, %b : si8) -> si8 {
   %c = arc.subi %a, %b : si8
   return %c : si8
 }
 
-func @muli_si8(%a : si8, %b : si8) -> si8 {
+func.func @muli_si8(%a : si8, %b : si8) -> si8 {
   %c = arc.muli %a, %b : si8
   return %c : si8
 }
 
-func @divi_si8(%a : si8, %b : si8) -> si8 {
+func.func @divi_si8(%a : si8, %b : si8) -> si8 {
   %c = arc.divi %a, %b : si8
   return %c : si8
 }
 
-func @remi_si8(%a : si8, %b : si8) -> si8 {
+func.func @remi_si8(%a : si8, %b : si8) -> si8 {
   %c = arc.remi %a, %b : si8
   return %c : si8
 }
 
-func @addi_si16(%a : si16, %b : si16) -> si16 {
+func.func @addi_si16(%a : si16, %b : si16) -> si16 {
   %c = arc.addi %a, %b : si16
   return %c : si16
 }
 
-func @subi_si16(%a : si16, %b : si16) -> si16 {
+func.func @subi_si16(%a : si16, %b : si16) -> si16 {
   %c = arc.subi %a, %b : si16
   return %c : si16
 }
 
-func @muli_si16(%a : si16, %b : si16) -> si16 {
+func.func @muli_si16(%a : si16, %b : si16) -> si16 {
   %c = arc.muli %a, %b : si16
   return %c : si16
 }
 
-func @divi_si16(%a : si16, %b : si16) -> si16 {
+func.func @divi_si16(%a : si16, %b : si16) -> si16 {
   %c = arc.divi %a, %b : si16
   return %c : si16
 }
 
-func @remi_si16(%a : si16, %b : si16) -> si16 {
+func.func @remi_si16(%a : si16, %b : si16) -> si16 {
   %c = arc.remi %a, %b : si16
   return %c : si16
 }
 
-func @addi_si32(%a : si32, %b : si32) -> si32 {
+func.func @addi_si32(%a : si32, %b : si32) -> si32 {
   %c = arc.addi %a, %b : si32
   return %c : si32
 }
 
-func @subi_si32(%a : si32, %b : si32) -> si32 {
+func.func @subi_si32(%a : si32, %b : si32) -> si32 {
   %c = arc.subi %a, %b : si32
   return %c : si32
 }
 
-func @muli_si32(%a : si32, %b : si32) -> si32 {
+func.func @muli_si32(%a : si32, %b : si32) -> si32 {
   %c = arc.muli %a, %b : si32
   return %c : si32
 }
 
-func @divi_si32(%a : si32, %b : si32) -> si32 {
+func.func @divi_si32(%a : si32, %b : si32) -> si32 {
   %c = arc.divi %a, %b : si32
   return %c : si32
 }
 
-func @remi_si32(%a : si32, %b : si32) -> si32 {
+func.func @remi_si32(%a : si32, %b : si32) -> si32 {
   %c = arc.remi %a, %b : si32
   return %c : si32
 }
 
-func @addi_si64(%a : si64, %b : si64) -> si64 {
+func.func @addi_si64(%a : si64, %b : si64) -> si64 {
   %c = arc.addi %a, %b : si64
   return %c : si64
 }
 
-func @subi_si64(%a : si64, %b : si64) -> si64 {
+func.func @subi_si64(%a : si64, %b : si64) -> si64 {
   %c = arc.subi %a, %b : si64
   return %c : si64
 }
 
-func @muli_si64(%a : si64, %b : si64) -> si64 {
+func.func @muli_si64(%a : si64, %b : si64) -> si64 {
   %c = arc.muli %a, %b : si64
   return %c : si64
 }
 
-func @divi_si64(%a : si64, %b : si64) -> si64 {
+func.func @divi_si64(%a : si64, %b : si64) -> si64 {
   %c = arc.divi %a, %b : si64
   return %c : si64
 }
 
-func @remi_si64(%a : si64, %b : si64) -> si64 {
+func.func @remi_si64(%a : si64, %b : si64) -> si64 {
   %c = arc.remi %a, %b : si64
   return %c : si64
 }

--- a/arc-mlir/src/tests/arc-to-rust/int-bitops.mlir
+++ b/arc-mlir/src/tests/arc-to-rust/int-bitops.mlir
@@ -2,99 +2,99 @@
 // RUN: arc-mlir-rust-test %t-roundtrip-scf %s -rustinclude %s.rust-tests -canonicalize -remove-scf -canonicalize -to-scf -canonicalize
 
 module @arctorustintbitops {
-  func @and_ui8(%arg0: ui8, %arg1: ui8) -> ui8 {
+  func.func @and_ui8(%arg0: ui8, %arg1: ui8) -> ui8 {
     %0 = arc.and %arg0, %arg1 : ui8
     return %0 : ui8
   }
-  func @or_ui8(%arg0: ui8, %arg1: ui8) -> ui8 {
+  func.func @or_ui8(%arg0: ui8, %arg1: ui8) -> ui8 {
     %0 = arc.or %arg0, %arg1 : ui8
     return %0 : ui8
   }
-  func @xor_ui8(%arg0: ui8, %arg1: ui8) -> ui8 {
+  func.func @xor_ui8(%arg0: ui8, %arg1: ui8) -> ui8 {
     %0 = arc.xor %arg0, %arg1 : ui8
     return %0 : ui8
   }
-  func @and_ui16(%arg0: ui16, %arg1: ui16) -> ui16 {
+  func.func @and_ui16(%arg0: ui16, %arg1: ui16) -> ui16 {
     %0 = arc.and %arg0, %arg1 : ui16
     return %0 : ui16
   }
-  func @or_ui16(%arg0: ui16, %arg1: ui16) -> ui16 {
+  func.func @or_ui16(%arg0: ui16, %arg1: ui16) -> ui16 {
     %0 = arc.or %arg0, %arg1 : ui16
     return %0 : ui16
   }
-  func @xor_ui16(%arg0: ui16, %arg1: ui16) -> ui16 {
+  func.func @xor_ui16(%arg0: ui16, %arg1: ui16) -> ui16 {
     %0 = arc.xor %arg0, %arg1 : ui16
     return %0 : ui16
   }
-  func @and_ui32(%arg0: ui32, %arg1: ui32) -> ui32 {
+  func.func @and_ui32(%arg0: ui32, %arg1: ui32) -> ui32 {
     %0 = arc.and %arg0, %arg1 : ui32
     return %0 : ui32
   }
-  func @or_ui32(%arg0: ui32, %arg1: ui32) -> ui32 {
+  func.func @or_ui32(%arg0: ui32, %arg1: ui32) -> ui32 {
     %0 = arc.or %arg0, %arg1 : ui32
     return %0 : ui32
   }
-  func @xor_ui32(%arg0: ui32, %arg1: ui32) -> ui32 {
+  func.func @xor_ui32(%arg0: ui32, %arg1: ui32) -> ui32 {
     %0 = arc.xor %arg0, %arg1 : ui32
     return %0 : ui32
   }
-  func @and_ui64(%arg0: ui64, %arg1: ui64) -> ui64 {
+  func.func @and_ui64(%arg0: ui64, %arg1: ui64) -> ui64 {
     %0 = arc.and %arg0, %arg1 : ui64
     return %0 : ui64
   }
-  func @or_ui64(%arg0: ui64, %arg1: ui64) -> ui64 {
+  func.func @or_ui64(%arg0: ui64, %arg1: ui64) -> ui64 {
     %0 = arc.or %arg0, %arg1 : ui64
     return %0 : ui64
   }
-  func @xor_ui64(%arg0: ui64, %arg1: ui64) -> ui64 {
+  func.func @xor_ui64(%arg0: ui64, %arg1: ui64) -> ui64 {
     %0 = arc.xor %arg0, %arg1 : ui64
     return %0 : ui64
   }
-  func @and_si8(%arg0: si8, %arg1: si8) -> si8 {
+  func.func @and_si8(%arg0: si8, %arg1: si8) -> si8 {
     %0 = arc.and %arg0, %arg1 : si8
     return %0 : si8
   }
-  func @or_si8(%arg0: si8, %arg1: si8) -> si8 {
+  func.func @or_si8(%arg0: si8, %arg1: si8) -> si8 {
     %0 = arc.or %arg0, %arg1 : si8
     return %0 : si8
   }
-  func @xor_si8(%arg0: si8, %arg1: si8) -> si8 {
+  func.func @xor_si8(%arg0: si8, %arg1: si8) -> si8 {
     %0 = arc.xor %arg0, %arg1 : si8
     return %0 : si8
   }
-  func @and_si16(%arg0: si16, %arg1: si16) -> si16 {
+  func.func @and_si16(%arg0: si16, %arg1: si16) -> si16 {
     %0 = arc.and %arg0, %arg1 : si16
     return %0 : si16
   }
-  func @or_si16(%arg0: si16, %arg1: si16) -> si16 {
+  func.func @or_si16(%arg0: si16, %arg1: si16) -> si16 {
     %0 = arc.or %arg0, %arg1 : si16
     return %0 : si16
   }
-  func @xor_si16(%arg0: si16, %arg1: si16) -> si16 {
+  func.func @xor_si16(%arg0: si16, %arg1: si16) -> si16 {
     %0 = arc.xor %arg0, %arg1 : si16
     return %0 : si16
   }
-  func @and_si32(%arg0: si32, %arg1: si32) -> si32 {
+  func.func @and_si32(%arg0: si32, %arg1: si32) -> si32 {
     %0 = arc.and %arg0, %arg1 : si32
     return %0 : si32
   }
-  func @or_si32(%arg0: si32, %arg1: si32) -> si32 {
+  func.func @or_si32(%arg0: si32, %arg1: si32) -> si32 {
     %0 = arc.or %arg0, %arg1 : si32
     return %0 : si32
   }
-  func @xor_si32(%arg0: si32, %arg1: si32) -> si32 {
+  func.func @xor_si32(%arg0: si32, %arg1: si32) -> si32 {
     %0 = arc.xor %arg0, %arg1 : si32
     return %0 : si32
   }
-  func @and_si64(%arg0: si64, %arg1: si64) -> si64 {
+  func.func @and_si64(%arg0: si64, %arg1: si64) -> si64 {
     %0 = arc.and %arg0, %arg1 : si64
     return %0 : si64
   }
-  func @or_si64(%arg0: si64, %arg1: si64) -> si64 {
+  func.func @or_si64(%arg0: si64, %arg1: si64) -> si64 {
     %0 = arc.or %arg0, %arg1 : si64
     return %0 : si64
   }
-  func @xor_si64(%arg0: si64, %arg1: si64) -> si64 {
+  func.func @xor_si64(%arg0: si64, %arg1: si64) -> si64 {
     %0 = arc.xor %arg0, %arg1 : si64
     return %0 : si64
   }

--- a/arc-mlir/src/tests/arc-to-rust/int-tensor-arith.mlir
+++ b/arc-mlir/src/tests/arc-to-rust/int-tensor-arith.mlir
@@ -3,202 +3,202 @@
 // RUN: arc-mlir-rust-test %t-roundtrip-scf %s -rustinclude %s.rust-tests -canonicalize -remove-scf -canonicalize -to-scf -canonicalize
 
 module @arctorustinttensorarith {
-func @addi_tensor2x2xui8(%a : tensor<2x2xui8>, %b : tensor<2x2xui8>) -> tensor<2x2xui8> {
+func.func @addi_tensor2x2xui8(%a : tensor<2x2xui8>, %b : tensor<2x2xui8>) -> tensor<2x2xui8> {
   %c = arc.addi %a, %b : tensor<2x2xui8>
   return %c : tensor<2x2xui8>
 }
 
-func @subi_tensor2x2xui8(%a : tensor<2x2xui8>, %b : tensor<2x2xui8>) -> tensor<2x2xui8> {
+func.func @subi_tensor2x2xui8(%a : tensor<2x2xui8>, %b : tensor<2x2xui8>) -> tensor<2x2xui8> {
   %c = arc.subi %a, %b : tensor<2x2xui8>
   return %c : tensor<2x2xui8>
 }
 
-func @muli_tensor2x2xui8(%a : tensor<2x2xui8>, %b : tensor<2x2xui8>) -> tensor<2x2xui8> {
+func.func @muli_tensor2x2xui8(%a : tensor<2x2xui8>, %b : tensor<2x2xui8>) -> tensor<2x2xui8> {
   %c = arc.muli %a, %b : tensor<2x2xui8>
   return %c : tensor<2x2xui8>
 }
 
-func @divi_tensor2x2xui8(%a : tensor<2x2xui8>, %b : tensor<2x2xui8>) -> tensor<2x2xui8> {
+func.func @divi_tensor2x2xui8(%a : tensor<2x2xui8>, %b : tensor<2x2xui8>) -> tensor<2x2xui8> {
   %c = arc.divi %a, %b : tensor<2x2xui8>
   return %c : tensor<2x2xui8>
 }
 
-func @remi_tensor2x2xui8(%a : tensor<2x2xui8>, %b : tensor<2x2xui8>) -> tensor<2x2xui8> {
+func.func @remi_tensor2x2xui8(%a : tensor<2x2xui8>, %b : tensor<2x2xui8>) -> tensor<2x2xui8> {
   %c = arc.remi %a, %b : tensor<2x2xui8>
   return %c : tensor<2x2xui8>
 }
 
-func @addi_tensor2x2xui16(%a : tensor<2x2xui16>, %b : tensor<2x2xui16>) -> tensor<2x2xui16> {
+func.func @addi_tensor2x2xui16(%a : tensor<2x2xui16>, %b : tensor<2x2xui16>) -> tensor<2x2xui16> {
   %c = arc.addi %a, %b : tensor<2x2xui16>
   return %c : tensor<2x2xui16>
 }
 
-func @subi_tensor2x2xui16(%a : tensor<2x2xui16>, %b : tensor<2x2xui16>) -> tensor<2x2xui16> {
+func.func @subi_tensor2x2xui16(%a : tensor<2x2xui16>, %b : tensor<2x2xui16>) -> tensor<2x2xui16> {
   %c = arc.subi %a, %b : tensor<2x2xui16>
   return %c : tensor<2x2xui16>
 }
 
-func @muli_tensor2x2xui16(%a : tensor<2x2xui16>, %b : tensor<2x2xui16>) -> tensor<2x2xui16> {
+func.func @muli_tensor2x2xui16(%a : tensor<2x2xui16>, %b : tensor<2x2xui16>) -> tensor<2x2xui16> {
   %c = arc.muli %a, %b : tensor<2x2xui16>
   return %c : tensor<2x2xui16>
 }
 
-func @divi_tensor2x2xui16(%a : tensor<2x2xui16>, %b : tensor<2x2xui16>) -> tensor<2x2xui16> {
+func.func @divi_tensor2x2xui16(%a : tensor<2x2xui16>, %b : tensor<2x2xui16>) -> tensor<2x2xui16> {
   %c = arc.divi %a, %b : tensor<2x2xui16>
   return %c : tensor<2x2xui16>
 }
 
-func @remi_tensor2x2xui16(%a : tensor<2x2xui16>, %b : tensor<2x2xui16>) -> tensor<2x2xui16> {
+func.func @remi_tensor2x2xui16(%a : tensor<2x2xui16>, %b : tensor<2x2xui16>) -> tensor<2x2xui16> {
   %c = arc.remi %a, %b : tensor<2x2xui16>
   return %c : tensor<2x2xui16>
 }
 
-func @addi_tensor2x2xui32(%a : tensor<2x2xui32>, %b : tensor<2x2xui32>) -> tensor<2x2xui32> {
+func.func @addi_tensor2x2xui32(%a : tensor<2x2xui32>, %b : tensor<2x2xui32>) -> tensor<2x2xui32> {
   %c = arc.addi %a, %b : tensor<2x2xui32>
   return %c : tensor<2x2xui32>
 }
 
-func @subi_tensor2x2xui32(%a : tensor<2x2xui32>, %b : tensor<2x2xui32>) -> tensor<2x2xui32> {
+func.func @subi_tensor2x2xui32(%a : tensor<2x2xui32>, %b : tensor<2x2xui32>) -> tensor<2x2xui32> {
   %c = arc.subi %a, %b : tensor<2x2xui32>
   return %c : tensor<2x2xui32>
 }
 
-func @muli_tensor2x2xui32(%a : tensor<2x2xui32>, %b : tensor<2x2xui32>) -> tensor<2x2xui32> {
+func.func @muli_tensor2x2xui32(%a : tensor<2x2xui32>, %b : tensor<2x2xui32>) -> tensor<2x2xui32> {
   %c = arc.muli %a, %b : tensor<2x2xui32>
   return %c : tensor<2x2xui32>
 }
 
-func @divi_tensor2x2xui32(%a : tensor<2x2xui32>, %b : tensor<2x2xui32>) -> tensor<2x2xui32> {
+func.func @divi_tensor2x2xui32(%a : tensor<2x2xui32>, %b : tensor<2x2xui32>) -> tensor<2x2xui32> {
   %c = arc.divi %a, %b : tensor<2x2xui32>
   return %c : tensor<2x2xui32>
 }
 
-func @remi_tensor2x2xui32(%a : tensor<2x2xui32>, %b : tensor<2x2xui32>) -> tensor<2x2xui32> {
+func.func @remi_tensor2x2xui32(%a : tensor<2x2xui32>, %b : tensor<2x2xui32>) -> tensor<2x2xui32> {
   %c = arc.remi %a, %b : tensor<2x2xui32>
   return %c : tensor<2x2xui32>
 }
 
-func @addi_tensor2x2xui64(%a : tensor<2x2xui64>, %b : tensor<2x2xui64>) -> tensor<2x2xui64> {
+func.func @addi_tensor2x2xui64(%a : tensor<2x2xui64>, %b : tensor<2x2xui64>) -> tensor<2x2xui64> {
   %c = arc.addi %a, %b : tensor<2x2xui64>
   return %c : tensor<2x2xui64>
 }
 
-func @subi_tensor2x2xui64(%a : tensor<2x2xui64>, %b : tensor<2x2xui64>) -> tensor<2x2xui64> {
+func.func @subi_tensor2x2xui64(%a : tensor<2x2xui64>, %b : tensor<2x2xui64>) -> tensor<2x2xui64> {
   %c = arc.subi %a, %b : tensor<2x2xui64>
   return %c : tensor<2x2xui64>
 }
 
-func @muli_tensor2x2xui64(%a : tensor<2x2xui64>, %b : tensor<2x2xui64>) -> tensor<2x2xui64> {
+func.func @muli_tensor2x2xui64(%a : tensor<2x2xui64>, %b : tensor<2x2xui64>) -> tensor<2x2xui64> {
   %c = arc.muli %a, %b : tensor<2x2xui64>
   return %c : tensor<2x2xui64>
 }
 
-func @divi_tensor2x2xui64(%a : tensor<2x2xui64>, %b : tensor<2x2xui64>) -> tensor<2x2xui64> {
+func.func @divi_tensor2x2xui64(%a : tensor<2x2xui64>, %b : tensor<2x2xui64>) -> tensor<2x2xui64> {
   %c = arc.divi %a, %b : tensor<2x2xui64>
   return %c : tensor<2x2xui64>
 }
 
-func @remi_tensor2x2xui64(%a : tensor<2x2xui64>, %b : tensor<2x2xui64>) -> tensor<2x2xui64> {
+func.func @remi_tensor2x2xui64(%a : tensor<2x2xui64>, %b : tensor<2x2xui64>) -> tensor<2x2xui64> {
   %c = arc.remi %a, %b : tensor<2x2xui64>
   return %c : tensor<2x2xui64>
 }
 
-func @addi_tensor2x2xsi8(%a : tensor<2x2xsi8>, %b : tensor<2x2xsi8>) -> tensor<2x2xsi8> {
+func.func @addi_tensor2x2xsi8(%a : tensor<2x2xsi8>, %b : tensor<2x2xsi8>) -> tensor<2x2xsi8> {
   %c = arc.addi %a, %b : tensor<2x2xsi8>
   return %c : tensor<2x2xsi8>
 }
 
-func @subi_tensor2x2xsi8(%a : tensor<2x2xsi8>, %b : tensor<2x2xsi8>) -> tensor<2x2xsi8> {
+func.func @subi_tensor2x2xsi8(%a : tensor<2x2xsi8>, %b : tensor<2x2xsi8>) -> tensor<2x2xsi8> {
   %c = arc.subi %a, %b : tensor<2x2xsi8>
   return %c : tensor<2x2xsi8>
 }
 
-func @muli_tensor2x2xsi8(%a : tensor<2x2xsi8>, %b : tensor<2x2xsi8>) -> tensor<2x2xsi8> {
+func.func @muli_tensor2x2xsi8(%a : tensor<2x2xsi8>, %b : tensor<2x2xsi8>) -> tensor<2x2xsi8> {
   %c = arc.muli %a, %b : tensor<2x2xsi8>
   return %c : tensor<2x2xsi8>
 }
 
-func @divi_tensor2x2xsi8(%a : tensor<2x2xsi8>, %b : tensor<2x2xsi8>) -> tensor<2x2xsi8> {
+func.func @divi_tensor2x2xsi8(%a : tensor<2x2xsi8>, %b : tensor<2x2xsi8>) -> tensor<2x2xsi8> {
   %c = arc.divi %a, %b : tensor<2x2xsi8>
   return %c : tensor<2x2xsi8>
 }
 
-func @remi_tensor2x2xsi8(%a : tensor<2x2xsi8>, %b : tensor<2x2xsi8>) -> tensor<2x2xsi8> {
+func.func @remi_tensor2x2xsi8(%a : tensor<2x2xsi8>, %b : tensor<2x2xsi8>) -> tensor<2x2xsi8> {
   %c = arc.remi %a, %b : tensor<2x2xsi8>
   return %c : tensor<2x2xsi8>
 }
 
-func @addi_tensor2x2xsi16(%a : tensor<2x2xsi16>, %b : tensor<2x2xsi16>) -> tensor<2x2xsi16> {
+func.func @addi_tensor2x2xsi16(%a : tensor<2x2xsi16>, %b : tensor<2x2xsi16>) -> tensor<2x2xsi16> {
   %c = arc.addi %a, %b : tensor<2x2xsi16>
   return %c : tensor<2x2xsi16>
 }
 
-func @subi_tensor2x2xsi16(%a : tensor<2x2xsi16>, %b : tensor<2x2xsi16>) -> tensor<2x2xsi16> {
+func.func @subi_tensor2x2xsi16(%a : tensor<2x2xsi16>, %b : tensor<2x2xsi16>) -> tensor<2x2xsi16> {
   %c = arc.subi %a, %b : tensor<2x2xsi16>
   return %c : tensor<2x2xsi16>
 }
 
-func @muli_tensor2x2xsi16(%a : tensor<2x2xsi16>, %b : tensor<2x2xsi16>) -> tensor<2x2xsi16> {
+func.func @muli_tensor2x2xsi16(%a : tensor<2x2xsi16>, %b : tensor<2x2xsi16>) -> tensor<2x2xsi16> {
   %c = arc.muli %a, %b : tensor<2x2xsi16>
   return %c : tensor<2x2xsi16>
 }
 
-func @divi_tensor2x2xsi16(%a : tensor<2x2xsi16>, %b : tensor<2x2xsi16>) -> tensor<2x2xsi16> {
+func.func @divi_tensor2x2xsi16(%a : tensor<2x2xsi16>, %b : tensor<2x2xsi16>) -> tensor<2x2xsi16> {
   %c = arc.divi %a, %b : tensor<2x2xsi16>
   return %c : tensor<2x2xsi16>
 }
 
-func @remi_tensor2x2xsi16(%a : tensor<2x2xsi16>, %b : tensor<2x2xsi16>) -> tensor<2x2xsi16> {
+func.func @remi_tensor2x2xsi16(%a : tensor<2x2xsi16>, %b : tensor<2x2xsi16>) -> tensor<2x2xsi16> {
   %c = arc.remi %a, %b : tensor<2x2xsi16>
   return %c : tensor<2x2xsi16>
 }
 
-func @addi_tensor2x2xsi32(%a : tensor<2x2xsi32>, %b : tensor<2x2xsi32>) -> tensor<2x2xsi32> {
+func.func @addi_tensor2x2xsi32(%a : tensor<2x2xsi32>, %b : tensor<2x2xsi32>) -> tensor<2x2xsi32> {
   %c = arc.addi %a, %b : tensor<2x2xsi32>
   return %c : tensor<2x2xsi32>
 }
 
-func @subi_tensor2x2xsi32(%a : tensor<2x2xsi32>, %b : tensor<2x2xsi32>) -> tensor<2x2xsi32> {
+func.func @subi_tensor2x2xsi32(%a : tensor<2x2xsi32>, %b : tensor<2x2xsi32>) -> tensor<2x2xsi32> {
   %c = arc.subi %a, %b : tensor<2x2xsi32>
   return %c : tensor<2x2xsi32>
 }
 
-func @muli_tensor2x2xsi32(%a : tensor<2x2xsi32>, %b : tensor<2x2xsi32>) -> tensor<2x2xsi32> {
+func.func @muli_tensor2x2xsi32(%a : tensor<2x2xsi32>, %b : tensor<2x2xsi32>) -> tensor<2x2xsi32> {
   %c = arc.muli %a, %b : tensor<2x2xsi32>
   return %c : tensor<2x2xsi32>
 }
 
-func @divi_tensor2x2xsi32(%a : tensor<2x2xsi32>, %b : tensor<2x2xsi32>) -> tensor<2x2xsi32> {
+func.func @divi_tensor2x2xsi32(%a : tensor<2x2xsi32>, %b : tensor<2x2xsi32>) -> tensor<2x2xsi32> {
   %c = arc.divi %a, %b : tensor<2x2xsi32>
   return %c : tensor<2x2xsi32>
 }
 
-func @remi_tensor2x2xsi32(%a : tensor<2x2xsi32>, %b : tensor<2x2xsi32>) -> tensor<2x2xsi32> {
+func.func @remi_tensor2x2xsi32(%a : tensor<2x2xsi32>, %b : tensor<2x2xsi32>) -> tensor<2x2xsi32> {
   %c = arc.remi %a, %b : tensor<2x2xsi32>
   return %c : tensor<2x2xsi32>
 }
 
-func @addi_tensor2x2xsi64(%a : tensor<2x2xsi64>, %b : tensor<2x2xsi64>) -> tensor<2x2xsi64> {
+func.func @addi_tensor2x2xsi64(%a : tensor<2x2xsi64>, %b : tensor<2x2xsi64>) -> tensor<2x2xsi64> {
   %c = arc.addi %a, %b : tensor<2x2xsi64>
   return %c : tensor<2x2xsi64>
 }
 
-func @subi_tensor2x2xsi64(%a : tensor<2x2xsi64>, %b : tensor<2x2xsi64>) -> tensor<2x2xsi64> {
+func.func @subi_tensor2x2xsi64(%a : tensor<2x2xsi64>, %b : tensor<2x2xsi64>) -> tensor<2x2xsi64> {
   %c = arc.subi %a, %b : tensor<2x2xsi64>
   return %c : tensor<2x2xsi64>
 }
 
-func @muli_tensor2x2xsi64(%a : tensor<2x2xsi64>, %b : tensor<2x2xsi64>) -> tensor<2x2xsi64> {
+func.func @muli_tensor2x2xsi64(%a : tensor<2x2xsi64>, %b : tensor<2x2xsi64>) -> tensor<2x2xsi64> {
   %c = arc.muli %a, %b : tensor<2x2xsi64>
   return %c : tensor<2x2xsi64>
 }
 
-func @divi_tensor2x2xsi64(%a : tensor<2x2xsi64>, %b : tensor<2x2xsi64>) -> tensor<2x2xsi64> {
+func.func @divi_tensor2x2xsi64(%a : tensor<2x2xsi64>, %b : tensor<2x2xsi64>) -> tensor<2x2xsi64> {
   %c = arc.divi %a, %b : tensor<2x2xsi64>
   return %c : tensor<2x2xsi64>
 }
 
-func @remi_tensor2x2xsi64(%a : tensor<2x2xsi64>, %b : tensor<2x2xsi64>) -> tensor<2x2xsi64> {
+func.func @remi_tensor2x2xsi64(%a : tensor<2x2xsi64>, %b : tensor<2x2xsi64>) -> tensor<2x2xsi64> {
   %c = arc.remi %a, %b : tensor<2x2xsi64>
   return %c : tensor<2x2xsi64>
 }

--- a/arc-mlir/src/tests/arc-to-rust/loops.mlir
+++ b/arc-mlir/src/tests/arc-to-rust/loops.mlir
@@ -4,7 +4,7 @@
 
 module @arctorustloops {
 
-  func @a_while_loop(%first : ui64, %limit : ui64, %accum : ui64) -> ui64 attributes { rust.declare } {
+  func.func @a_while_loop(%first : ui64, %limit : ui64, %accum : ui64) -> ui64 attributes { rust.declare } {
        %res_cnt, %res_sum = scf.while (%arg1 = %first, %sum = %accum) : (ui64, ui64) -> (ui64, ui64) {
          %condition = arc.cmpi "lt", %arg1, %limit : ui64
          scf.condition(%condition) %arg1, %sum : ui64, ui64
@@ -18,7 +18,7 @@ module @arctorustloops {
        return %res_sum : ui64
   }
 
-  func @a_while_loop_with_a_break_in_before(%first : ui64, %limit : ui64, %accum : ui64) -> ui64 attributes { rust.declare } {
+  func.func @a_while_loop_with_a_break_in_before(%first : ui64, %limit : ui64, %accum : ui64) -> ui64 attributes { rust.declare } {
        %res_cnt, %res_sum = scf.while (%arg1 = %first, %sum = %accum) : (ui64, ui64) -> (ui64, ui64) {
          %condition = arc.cmpi "lt", %arg1, %limit : ui64
 
@@ -41,7 +41,7 @@ module @arctorustloops {
        return %res_sum : ui64
   }
 
-  func @a_while_loop_with_a_break_in_after(%first : ui64, %limit : ui64, %accum : ui64) -> ui64 attributes { rust.declare } {
+  func.func @a_while_loop_with_a_break_in_after(%first : ui64, %limit : ui64, %accum : ui64) -> ui64 attributes { rust.declare } {
        %res_cnt, %res_sum = scf.while (%arg1 = %first, %sum = %accum) : (ui64, ui64) -> (ui64, ui64) {
          %condition = arc.cmpi "lt", %arg1, %limit : ui64
          scf.condition(%condition) %arg1, %sum : ui64, ui64
@@ -64,7 +64,7 @@ module @arctorustloops {
        return %res_sum : ui64
   }
 
-  func @a_while_loop_with_a_return_in_before(%first : ui64, %limit : ui64, %accum : ui64) -> ui64 attributes { rust.declare } {
+  func.func @a_while_loop_with_a_return_in_before(%first : ui64, %limit : ui64, %accum : ui64) -> ui64 attributes { rust.declare } {
        %res_cnt, %res_sum = scf.while (%arg1 = %first, %sum = %accum) : (ui64, ui64) -> (ui64, ui64) {
          %condition = arc.cmpi "lt", %arg1, %limit : ui64
 
@@ -87,7 +87,7 @@ module @arctorustloops {
        return %res_sum : ui64
   }
 
-  func @a_while_loop_with_a_return_in_after(%first : ui64, %limit : ui64, %accum : ui64) -> ui64 attributes { rust.declare } {
+  func.func @a_while_loop_with_a_return_in_after(%first : ui64, %limit : ui64, %accum : ui64) -> ui64 attributes { rust.declare } {
        %res_cnt, %res_sum = scf.while (%arg1 = %first, %sum = %accum) : (ui64, ui64) -> (ui64, ui64) {
          %condition = arc.cmpi "lt", %arg1, %limit : ui64
          scf.condition(%condition) %arg1, %sum : ui64, ui64

--- a/arc-mlir/src/tests/arc-to-rust/panic.mlir
+++ b/arc-mlir/src/tests/arc-to-rust/panic.mlir
@@ -3,12 +3,12 @@
 // RUN: arc-mlir-rust-test %t-roundtrip-scf %s -canonicalize -remove-scf -canonicalize -to-scf -canonicalize
 
 module @toplevel {
-  func @trigger_panic0() -> () {
+  func.func @trigger_panic0() -> () {
     arc.panic()
     return
   }
 
-  func @trigger_panic1() -> () {
+  func.func @trigger_panic1() -> () {
     arc.panic("foo")
     return
   }

--- a/arc-mlir/src/tests/arc-to-rust/select.mlir
+++ b/arc-mlir/src/tests/arc-to-rust/select.mlir
@@ -2,7 +2,7 @@
 // RUN: arc-mlir-rust-test %t-roundtrip-scf %s -rustinclude %s.rust-tests -canonicalize -remove-scf -canonicalize -to-scf -canonicalize
 
 module @arctorustifs  {
-  func @test_0(%arg0: i1, %arg1: ui32, %arg2: ui32) -> ui32 {
+  func.func @test_0(%arg0: i1, %arg1: ui32, %arg2: ui32) -> ui32 {
     %0 = arith.select %arg0, %arg1, %arg2 : ui32
     return %0 : ui32
   }

--- a/arc-mlir/src/tests/arc-to-rust/simple.mlir
+++ b/arc-mlir/src/tests/arc-to-rust/simple.mlir
@@ -3,59 +3,59 @@
 // RUN: arc-mlir-rust-test %t-roundtrip-scf %s -rustinclude %s.rust-tests -canonicalize -remove-scf -canonicalize -to-scf -canonicalize
 
 module @arctorustsimple {
-  func @returnf64() -> f64 {
+  func.func @returnf64() -> f64 {
     %b = arith.constant 3.14 : f64
     return %b : f64
   }
-  func @returnf32() -> f32 {
+  func.func @returnf32() -> f32 {
     %b = arith.constant 0.69315 : f32
     return %b : f32
   }
-  func @return_true() -> i1 {
+  func.func @return_true() -> i1 {
     %b = arith.constant 1 : i1
     return %b : i1
   }
-  func @return_false() -> i1 {
+  func.func @return_false() -> i1 {
     %b = arith.constant 0 : i1
     return %b : i1
   }
 
-  func @return_ui8() -> ui8 {
+  func.func @return_ui8() -> ui8 {
     %b = arc.constant 255 : ui8
     return %b : ui8
   }
 
-  func @return_ui16() -> ui16 {
+  func.func @return_ui16() -> ui16 {
     %b = arc.constant 65535 : ui16
     return %b : ui16
   }
 
-  func @return_ui32() -> ui32 {
+  func.func @return_ui32() -> ui32 {
     %b = arc.constant 4294967295 : ui32
     return %b : ui32
   }
 
-  func @return_ui64() -> ui64 {
+  func.func @return_ui64() -> ui64 {
     %b = arc.constant 18446744073709551615 : ui64
     return %b : ui64
   }
 
-  func @return_si8() -> si8 {
+  func.func @return_si8() -> si8 {
     %b = arc.constant -128 : si8
     return %b : si8
   }
 
-  func @return_si16() -> si16 {
+  func.func @return_si16() -> si16 {
     %b = arc.constant -32768 : si16
     return %b : si16
   }
 
-  func @return_si32() -> si32 {
+  func.func @return_si32() -> si32 {
     %b = arc.constant -2147483648 : si32
     return %b : si32
   }
 
-  func @return_si64() -> si64 {
+  func.func @return_si64() -> si64 {
     %b = arc.constant -9223372036854775808 : si64
     return %b : si64
   }

--- a/arc-mlir/src/tests/arc-to-rust/structs.mlir
+++ b/arc-mlir/src/tests/arc-to-rust/structs.mlir
@@ -4,33 +4,33 @@
 
 module @arctoruststructs {
 
-  func @ok0(%in : !arc.struct<foo : si32>) -> !arc.struct<foo : si32> {
+  func.func @ok0(%in : !arc.struct<foo : si32>) -> !arc.struct<foo : si32> {
     return %in : !arc.struct<foo : si32>
   }
 
-  func @ok1(%in : !arc.struct<foo : si32, bar : f32>) ->
+  func.func @ok1(%in : !arc.struct<foo : si32, bar : f32>) ->
       !arc.struct<foo : si32,bar : f32> {
     return %in : !arc.struct<foo : si32, bar: f32>
   }
 
-  func @ok2(%in : !arc.struct<foo : si32, bar : f32, inner_struct : !arc.struct<nested : si32>>) -> () {
+  func.func @ok2(%in : !arc.struct<foo : si32, bar : f32, inner_struct : !arc.struct<nested : si32>>) -> () {
     return
   }
 
-  func @ok3() -> !arc.struct<a : si32, b : f32> {
+  func.func @ok3() -> !arc.struct<a : si32, b : f32> {
     %a = arc.constant 4 : si32
     %b = arith.constant 3.14 : f32
     %r = arc.make_struct(%a, %b : si32, f32) : !arc.struct<a : si32, b : f32>
     return %r : !arc.struct<a : si32, b : f32>
   }
 
-  func @ok4() -> !arc.struct<a : si32> {
+  func.func @ok4() -> !arc.struct<a : si32> {
     %a = arc.constant 4 : si32
     %r = arc.make_struct(%a : si32) : !arc.struct<a : si32>
     return %r : !arc.struct<a : si32>
   }
 
-  func @ok5() -> !arc.struct<a : si32, b : !arc.struct<a : si32> > {
+  func.func @ok5() -> !arc.struct<a : si32, b : !arc.struct<a : si32> > {
     %a = arc.constant 4 : si32
     %b = arc.constant 3 : si32
     %s = arc.make_struct(%b : si32) : !arc.struct<a : si32>
@@ -38,7 +38,7 @@ module @arctoruststructs {
     return %r : !arc.struct<a : si32, b : !arc.struct<a : si32>>
   }
 
-  func @ok6() -> si32 {
+  func.func @ok6() -> si32 {
     %a = arc.constant 4 : si32
     %b = arc.constant 3 : si32
     %s = arc.make_struct(%b : si32) : !arc.struct<a : si32>
@@ -47,7 +47,7 @@ module @arctoruststructs {
     return %r_a : si32
   }
 
-  func @ok7() -> si32 {
+  func.func @ok7() -> si32 {
     %a = arc.constant 4 : si32
     %b = arc.constant 3 : si32
     %s = arc.make_struct(%b : si32) : !arc.struct<a : si32>
@@ -57,16 +57,16 @@ module @arctoruststructs {
     return %r_b_a : si32
   }
 
-  func @ok8(%a : !arc.struct<a : si32>, %b : !arc.struct<a : si32>) -> !arc.struct<a : si32> {
+  func.func @ok8(%a : !arc.struct<a : si32>, %b : !arc.struct<a : si32>) -> !arc.struct<a : si32> {
     return %a : !arc.struct<a : si32>
   }
 
-  func @ok9(%a : !arc.struct<a : si32, b : !arc.struct<a : si32>>) -> !arc.struct<a : si32> {
+  func.func @ok9(%a : !arc.struct<a : si32, b : !arc.struct<a : si32>>) -> !arc.struct<a : si32> {
     %r = "arc.struct_access"(%a) { field = "b" } : (!arc.struct<a : si32, b : !arc.struct<a : si32>>) -> !arc.struct<a : si32>
     return %r : !arc.struct<a : si32>
   }
 
-  func @ok10() -> si32 {
+  func.func @ok10() -> si32 {
     %a = arc.constant 4 : si32
     %b = arc.constant 3 : si32
     %s = arc.make_struct(%b : si32) : !arc.struct<a : si32>
@@ -76,11 +76,11 @@ module @arctoruststructs {
     return %a : si32
   }
 
-  func @ok11(%in : !arc.struct<>) -> !arc.struct<> {
+  func.func @ok11(%in : !arc.struct<>) -> !arc.struct<> {
     return %in : !arc.struct<>
   }
 
-  func @ok12() -> !arc.struct<> {
+  func.func @ok12() -> !arc.struct<> {
     %r = arc.make_struct() : !arc.struct<>
     return %r : !arc.struct<>
   }

--- a/arc-mlir/src/tests/arc-to-rust/tensors.mlir
+++ b/arc-mlir/src/tests/arc-to-rust/tensors.mlir
@@ -4,17 +4,17 @@
 // RUN: arc-mlir-rust-test %t-roundtrip-scf %s -rustinclude %s.rust-tests -canonicalize -remove-scf -canonicalize -to-scf -canonicalize
 
 module @arctorusttensors {
-  func @in_out_0(%0 : tensor<4xsi32>) -> tensor<4xsi32> {
+  func.func @in_out_0(%0 : tensor<4xsi32>) -> tensor<4xsi32> {
     return %0 : tensor<4xsi32>
   }
-  func @in_out_1(%0 : tensor<4x5xsi32>) -> tensor<4x5xsi32> {
+  func.func @in_out_1(%0 : tensor<4x5xsi32>) -> tensor<4x5xsi32> {
     return %0 : tensor<4x5xsi32>
   }
-  func @in_out_2(%0 : tensor<?xsi32>) -> tensor<?xsi32> {
+  func.func @in_out_2(%0 : tensor<?xsi32>) -> tensor<?xsi32> {
     return %0 : tensor<?xsi32>
   }
 
-  func @make_0() -> tensor<1xf32> {
+  func.func @make_0() -> tensor<1xf32> {
     %a = arith.constant 0.0 : f32
 
     %0 = "arc.make_tensor"(%a) : (f32)
@@ -22,7 +22,7 @@ module @arctorusttensors {
     return %0 : tensor<1xf32>
   }
 
-  func @make_1() -> tensor<2xf32> {
+  func.func @make_1() -> tensor<2xf32> {
     %a = arith.constant 0.0 : f32
     %b = arith.constant 1.0 : f32
 
@@ -31,7 +31,7 @@ module @arctorusttensors {
     return %0 : tensor<2xf32>
   }
 
-  func @make_2() -> tensor<3xf32> {
+  func.func @make_2() -> tensor<3xf32> {
     %a = arith.constant 0.0 : f32
     %b = arith.constant 1.0 : f32
     %c = arith.constant 2.0 : f32
@@ -41,7 +41,7 @@ module @arctorusttensors {
     return %0 : tensor<3xf32>
   }
 
-  func @make_3() -> tensor<2x3x4xf32> {
+  func.func @make_3() -> tensor<2x3x4xf32> {
     %v0 = arith.constant 0.0 : f32
     %v1 = arith.constant 1.0 : f32
     %v2 = arith.constant 2.0 : f32

--- a/arc-mlir/src/tests/arc-to-rust/unary-ops.mlir
+++ b/arc-mlir/src/tests/arc-to-rust/unary-ops.mlir
@@ -2,122 +2,122 @@
 // RUN: arc-mlir-rust-test %t-roundtrip-scf %s -rustinclude %s.rust-tests -canonicalize -remove-scf -canonicalize -to-scf -canonicalize
 
 module @arctorustunaryops {
-func @acos_f32(%a : f32) -> f32 {
+func.func @acos_f32(%a : f32) -> f32 {
   %r = arc.acos %a : f32
   return %r : f32
 }
 
-func @asin_f32(%a : f32) -> f32 {
+func.func @asin_f32(%a : f32) -> f32 {
   %r = arc.asin %a : f32
   return %r : f32
 }
 
-func @atan_f32(%a : f32) -> f32 {
+func.func @atan_f32(%a : f32) -> f32 {
   %r = math.atan %a : f32
   return %r : f32
 }
 
-func @cos_f32(%a : f32) -> f32 {
+func.func @cos_f32(%a : f32) -> f32 {
   %r = math.cos %a : f32
   return %r : f32
 }
 
-func @cosh_f32(%a : f32) -> f32 {
+func.func @cosh_f32(%a : f32) -> f32 {
   %r = arc.cosh %a : f32
   return %r : f32
 }
 
-func @exp_f32(%a : f32) -> f32 {
+func.func @exp_f32(%a : f32) -> f32 {
   %r = math.exp %a : f32
   return %r : f32
 }
 
-func @log_f32(%a : f32) -> f32 {
+func.func @log_f32(%a : f32) -> f32 {
   %r = math.log %a : f32
   return %r : f32
 }
 
-func @sin_f32(%a : f32) -> f32 {
+func.func @sin_f32(%a : f32) -> f32 {
   %r = math.sin %a : f32
   return %r : f32
 }
 
-func @sinh_f32(%a : f32) -> f32 {
+func.func @sinh_f32(%a : f32) -> f32 {
   %r = arc.sinh %a : f32
   return %r : f32
 }
 
-func @sqrt_f32(%a : f32) -> f32 {
+func.func @sqrt_f32(%a : f32) -> f32 {
   %r = math.sqrt %a : f32
   return %r : f32
 }
 
-func @tan_f32(%a : f32) -> f32 {
+func.func @tan_f32(%a : f32) -> f32 {
   %r = arc.tan %a : f32
   return %r : f32
 }
 
-func @tanh_f32(%a : f32) -> f32 {
+func.func @tanh_f32(%a : f32) -> f32 {
   %r = math.tanh %a : f32
   return %r : f32
 }
 
-func @acos_f64(%a : f64) -> f64 {
+func.func @acos_f64(%a : f64) -> f64 {
   %r = arc.acos %a : f64
   return %r : f64
 }
 
-func @asin_f64(%a : f64) -> f64 {
+func.func @asin_f64(%a : f64) -> f64 {
   %r = arc.asin %a : f64
   return %r : f64
 }
 
-func @atan_f64(%a : f64) -> f64 {
+func.func @atan_f64(%a : f64) -> f64 {
   %r = math.atan %a : f64
   return %r : f64
 }
 
-func @cos_f64(%a : f64) -> f64 {
+func.func @cos_f64(%a : f64) -> f64 {
   %r = math.cos %a : f64
   return %r : f64
 }
 
-func @cosh_f64(%a : f64) -> f64 {
+func.func @cosh_f64(%a : f64) -> f64 {
   %r = arc.cosh %a : f64
   return %r : f64
 }
 
-func @exp_f64(%a : f64) -> f64 {
+func.func @exp_f64(%a : f64) -> f64 {
   %r = math.exp %a : f64
   return %r : f64
 }
 
-func @log_f64(%a : f64) -> f64 {
+func.func @log_f64(%a : f64) -> f64 {
   %r = math.log %a : f64
   return %r : f64
 }
 
-func @sin_f64(%a : f64) -> f64 {
+func.func @sin_f64(%a : f64) -> f64 {
   %r = math.sin %a : f64
   return %r : f64
 }
 
-func @sinh_f64(%a : f64) -> f64 {
+func.func @sinh_f64(%a : f64) -> f64 {
   %r = arc.sinh %a : f64
   return %r : f64
 }
 
-func @sqrt_f64(%a : f64) -> f64 {
+func.func @sqrt_f64(%a : f64) -> f64 {
   %r = math.sqrt %a : f64
   return %r : f64
 }
 
-func @tan_f64(%a : f64) -> f64 {
+func.func @tan_f64(%a : f64) -> f64 {
   %r = arc.tan %a : f64
   return %r : f64
 }
 
-func @tanh_f64(%a : f64) -> f64 {
+func.func @tanh_f64(%a : f64) -> f64 {
   %r = math.tanh %a : f64
   return %r : f64
 }

--- a/arc-mlir/src/tests/ops/adt.mlir
+++ b/arc-mlir/src/tests/ops/adt.mlir
@@ -3,12 +3,12 @@
 // RUN: arc-mlir -canonicalize %s | arc-mlir
 
 module @toplevel {
-  func @ok0() -> !arc.adt<"i32"> {
+  func.func @ok0() -> !arc.adt<"i32"> {
     %out = arc.adt_constant "4711" : !arc.adt<"i32">
     return %out : !arc.adt<"i32">
   }
 
-  func @ok1() -> !arc.adt<"(i32, bool)"> {
+  func.func @ok1() -> !arc.adt<"(i32, bool)"> {
     %pair = arc.adt_constant "(17, false)" : !arc.adt<"(i32, bool)">
     return %pair : !arc.adt<"(i32, bool)">
   }

--- a/arc-mlir/src/tests/ops/bad-enums.mlir
+++ b/arc-mlir/src/tests/ops/bad-enums.mlir
@@ -1,7 +1,7 @@
 // RUN: arc-mlir %s -split-input-file -verify-diagnostics
 
 module @toplevel {
-  func @bad() -> !arc.enum<a : i32, b : f32> {
+  func.func @bad() -> !arc.enum<a : i32, b : f32> {
     %a = arith.constant 4 : i32
     // expected-error@+2 {{'arc.make_enum' op : variant 'c' does not exist in '!arc.enum<a : i32, b : f32>'}}
     // expected-note@+1 {{see current operation:}}
@@ -13,7 +13,7 @@ module @toplevel {
 // -----
 
 module @toplevel {
-  func @bad() -> !arc.enum<a : i32, b : f32> {
+  func.func @bad() -> !arc.enum<a : i32, b : f32> {
     %a = arith.constant 3.14 : f32
     // expected-error@+2 {{'arc.make_enum' op : variant 'a' does not have a matching type, expected 'f32' but found 'i32'}}
     // expected-note@+1 {{see current operation:}}
@@ -25,7 +25,7 @@ module @toplevel {
 // -----
 
 module @toplevel {
-  func @access0(%e : !arc.enum<a : i32, b : f32>) -> i32 {
+  func.func @access0(%e : !arc.enum<a : i32, b : f32>) -> i32 {
     // expected-error@+2 {{'arc.enum_access' op : variant 'b' does not have a matching type, expected 'i32' but found 'f32'}}
     // expected-note@+1 {{see current operation:}}
     %r = arc.enum_access "b" in (%e : !arc.enum<a : i32, b : f32>) : i32
@@ -36,7 +36,7 @@ module @toplevel {
 // -----
 
 module @toplevel {
-  func @access0(%e : !arc.enum<a : i32, b : f32>) -> i32 {
+  func.func @access0(%e : !arc.enum<a : i32, b : f32>) -> i32 {
     // expected-error@+2 {{'arc.enum_access' op : variant 'c' does not exist in '!arc.enum<a : i32, b : f32>'}}
     // expected-note@+1 {{see current operation:}}
     %r = arc.enum_access "c" in (%e : !arc.enum<a : i32, b : f32>) : i32
@@ -47,7 +47,7 @@ module @toplevel {
 // -----
 
 module @toplevel {
-  func @check2(%e : !arc.enum<a : i32, b : f32>) -> i1 {
+  func.func @check2(%e : !arc.enum<a : i32, b : f32>) -> i1 {
     // expected-error@+2 {{'arc.enum_check' op : variant 'c' does not exist in '!arc.enum<a : i32, b : f32>'}}
     // expected-note@+1 {{see current operation:}}
     %r = arc.enum_check (%e : !arc.enum<a : i32, b : f32>) is "c" : i1
@@ -58,7 +58,7 @@ module @toplevel {
 // -----
 
 module @toplevel {
-  func @bad() -> !arc.enum<bad : i32, b : f32> {
+  func.func @bad() -> !arc.enum<bad : i32, b : f32> {
     %a = arith.constant 4 : i32
     // expected-error@+2 {{'arc.make_enum' op : variant 'bad' does not have a matching type, expected 'none' but found 'i32'}}
     // expected-note@+1 {{see current operation}}
@@ -70,7 +70,7 @@ module @toplevel {
 // -----
 
 module @toplevel {
-  func @bad() -> !arc.enum<a : i32, b : f32> {
+  func.func @bad() -> !arc.enum<a : i32, b : f32> {
     %b = arith.constant 3.14 : f32
     // expected-error@+2 {{'arc.make_enum' op : only a single value expected}}
     // expected-note@+1 {{see current operation}}
@@ -81,7 +81,7 @@ module @toplevel {
 
 // -----
 module @toplevel {
-   func @access2(%e : !arc.enum<a : si32, b : f32, no_value : none>) -> none {
+   func.func @access2(%e : !arc.enum<a : si32, b : f32, no_value : none>) -> none {
     // expected-error@+2 {{accessing a 'none'-typed variant does not make sense}}
     // expected-note@+1 {{see current operation}}
     %r = arc.enum_access "no_value" in (%e : !arc.enum<a : si32, b : f32, no_value : none>) : none

--- a/arc-mlir/src/tests/ops/bad-streams.mlir
+++ b/arc-mlir/src/tests/ops/bad-streams.mlir
@@ -1,7 +1,7 @@
 // RUN: arc-mlir %s -split-input-file -verify-diagnostics
 
 module @toplevel {
-  func @bad0(%v : si64, %s : !arc.stream.sink<si32>) -> ()
+  func.func @bad0(%v : si64, %s : !arc.stream.sink<si32>) -> ()
   attributes { "arc.is_task" } {
 // expected-error@+2 {{'arc.send' op Can't send value of type 'si64' on a '!arc.stream.sink<si32>' stream}}
 // expected-note@+1 {{see current operation: "arc.send"}}
@@ -13,7 +13,7 @@ module @toplevel {
 // -----
 
 module @toplevel {
-  func @bad1(%v : si64, %s : !arc.stream.source<si64>) -> ()
+  func.func @bad1(%v : si64, %s : !arc.stream.source<si64>) -> ()
   attributes { "arc.is_task" } {
 // expected-error@+2 {{'arc.send' op operand #1 must be a sink stream, but got '!arc.stream.source<si64>'}}
 // expected-note@+1 {{see current operation: "arc.send"}}
@@ -25,7 +25,7 @@ module @toplevel {
 // -----
 
 module @toplevel {
-  func @bad2(%v : si32, %s : !arc.stream.sink<si32>) -> () {
+  func.func @bad2(%v : si32, %s : !arc.stream.sink<si32>) -> () {
 // expected-error@+2 {{'arc.send' op can only be used inside a task}}
 // expected-note@+1 {{see current operation: "arc.send"}}
     "arc.send"(%v, %s) : (si32, !arc.stream.sink<si32>) -> ()
@@ -36,7 +36,7 @@ module @toplevel {
 // -----
 
 module @toplevel {
-  func @bad3(%s : !arc.stream.sink<si32>) -> si32
+  func.func @bad3(%s : !arc.stream.sink<si32>) -> si32
     attributes { "arc.is_task" } {
 // expected-error@+2 {{'arc.receive' op operand #0 must be a source stream, but got '!arc.stream.sink<si32>'}}
 // expected-note@+1 {{see current operation:}}
@@ -48,7 +48,7 @@ module @toplevel {
 // -----
 
 module @toplevel {
-  func @bad3(%s : !arc.stream.source<si32>) -> si64
+  func.func @bad3(%s : !arc.stream.source<si32>) -> si64
     attributes { "arc.is_task" } {
 // expected-error@+2 {{'arc.receive' op Can't receive a value of type 'si64' from a '!arc.stream.source<si32>' stream}}
 // expected-note@+1 {{see current operation:}}

--- a/arc-mlir/src/tests/ops/bad-structs.mlir
+++ b/arc-mlir/src/tests/ops/bad-structs.mlir
@@ -1,7 +1,7 @@
 // RUN: arc-mlir %s -split-input-file -verify-diagnostics
 
 module @toplevel {
-  func @bad0() -> !arc.struct<a : i32, b : f32> {
+  func.func @bad0() -> !arc.struct<a : i32, b : f32> {
     %a = arith.constant 4 : i32
     %b = arith.constant 3.14 : f32
     // expected-error@+2 {{'arc.make_struct' op expected 2 fields, but found 0}}
@@ -14,7 +14,7 @@ module @toplevel {
 // -----
 
 module @toplevel {
-  func @bad0() -> !arc.struct<a : i32, b : f32> {
+  func.func @bad0() -> !arc.struct<a : i32, b : f32> {
     %a = arith.constant 4 : i32
     %b = arith.constant 3.14 : f32
     // expected-error@+2 {{'arc.make_struct' op expected 2 fields, but found 1}}
@@ -27,7 +27,7 @@ module @toplevel {
 // -----
 
 module @toplevel {
-  func @bad0() -> !arc.struct<a : i32, b : f32> {
+  func.func @bad0() -> !arc.struct<a : i32, b : f32> {
     %a = arith.constant 4 : i32
     %b = arith.constant 3.14 : f32
     %c = arith.constant 47.11 : f64
@@ -41,7 +41,7 @@ module @toplevel {
 // -----
 
 module @toplevel {
-  func @bad() -> si32 {
+  func.func @bad() -> si32 {
     %a = arc.constant 4 : si32
     %b = arc.constant 3 : si32
     %s = arc.make_struct(%b : si32) : !arc.struct<a : si32>
@@ -56,7 +56,7 @@ module @toplevel {
 // -----
 
 module @toplevel {
-  func @bad() -> si32 {
+  func.func @bad() -> si32 {
     %a = arc.constant 4 : si32
     %b = arith.constant 3.14 : f32
     %r = arc.make_struct(%a, %b : si32, f32) : !arc.struct<a : si32, b : f32>

--- a/arc-mlir/src/tests/ops/bad-task.mlir
+++ b/arc-mlir/src/tests/ops/bad-task.mlir
@@ -1,7 +1,7 @@
 // RUN: arc-mlir %s -split-input-file -verify-diagnostics
 module @toplevel {
 
-  func @MyOperator(// Imutables
+  func.func @MyOperator(// Imutables
                    !arc.struct<dummy : si32>,
 		   // State
                    !arc.struct<dummy : si32>,
@@ -26,7 +26,7 @@ module @toplevel {
 
 module @toplevel {
 
-  func @MyOperator(// Imutables
+  func.func @MyOperator(// Imutables
                    !arc.struct<p0 : f32, p1 : si32>,
 		   // State
                    !arc.struct<state1 : !arc.arcon.value<!arc.struct<i : si32, f : f32>>,
@@ -62,7 +62,7 @@ module @toplevel {
 
 module @toplevel {
 
-  func @MyOperator(// Imutables
+  func.func @MyOperator(// Imutables
                    !arc.struct<p0 : f32, p1 : si32>,
 		   // State
                    !arc.struct<state1 : !arc.arcon.value<!arc.struct<i : si32, f : f32>>,
@@ -95,7 +95,7 @@ module @toplevel {
 
 module @toplevel {
 
-  func @MyOperator(// Imutables
+  func.func @MyOperator(// Imutables
                    !arc.struct<p0 : f32, p1 : si32>,
 		   // State
                    !arc.struct<state1 : !arc.arcon.value<!arc.struct<i : si32, f : f32>>,
@@ -131,11 +131,11 @@ module @toplevel {
 // -----
 
 module @toplevel {
-  func @FoldFun() -> () {
+  func.func @FoldFun() -> () {
     return
   }
 
-  func @MyOperator(// Imutables
+  func.func @MyOperator(// Imutables
                    !arc.struct<p0 : f32, p1 : si32>,
 		   // State
                    !arc.struct<state1 : !arc.arcon.value<!arc.struct<i : si32, f : f32>>,
@@ -178,12 +178,12 @@ module @toplevel {
 
 module @toplevel {
 
-  func @FoldFun(si32, si32) -> () {
+  func.func @FoldFun(si32, si32) -> () {
   ^bb0(%a: si32, %b : si32):
     return
   }
 
-  func @MyOperator(// Imutables
+  func.func @MyOperator(// Imutables
                    !arc.struct<p0 : f32, p1 : si32>,
 		   // State
                    !arc.struct<state1 : !arc.arcon.value<!arc.struct<i : si32, f : f32>>,
@@ -226,13 +226,13 @@ module @toplevel {
 
 module @toplevel {
 
-  func @FoldFun(si32, si32) -> si32 {
+  func.func @FoldFun(si32, si32) -> si32 {
   ^bb0(%a: si32, %b : si32):
     %i = arc.constant 4 : si32
     return %i : si32
   }
 
-  func @MyOperator(// Imutables
+  func.func @MyOperator(// Imutables
                    !arc.struct<p0 : f32, p1 : si32>,
 		   // State
                    !arc.struct<state1 : !arc.arcon.value<!arc.struct<i : si32, f : f32>>,
@@ -275,13 +275,13 @@ module @toplevel {
 
 module @toplevel {
 
-  func @FoldFun(f32, si32) -> si32 {
+  func.func @FoldFun(f32, si32) -> si32 {
   ^bb0(%a: f32, %b : si32):
     %i = arc.constant 4 : si32
     return %i : si32
   }
 
-  func @MyOperator(// Imutables
+  func.func @MyOperator(// Imutables
                    !arc.struct<p0 : f32, p1 : si32>,
 		   // State
                    !arc.struct<state1 : !arc.arcon.value<!arc.struct<i : si32, f : f32>>,
@@ -324,13 +324,13 @@ module @toplevel {
 
 module @toplevel {
 
-  func @FoldFun(f32, si32) -> f32 {
+  func.func @FoldFun(f32, si32) -> f32 {
   ^bb0(%a: f32, %b : si32):
     %f = arith.constant 3.14 : f32
     return %f : f32
   }
 
-  func @MyOperator(// Imutables
+  func.func @MyOperator(// Imutables
                    !arc.struct<p0 : f32, p1 : si32>,
 		   // State
                    !arc.struct<state1 : !arc.arcon.value<!arc.struct<i : si32, f : f32>>,
@@ -373,13 +373,13 @@ module @toplevel {
 
 module @toplevel {
 
-  func @FoldFun(f32, !arc.struct<i : si32, f : f32>) -> f32 {
+  func.func @FoldFun(f32, !arc.struct<i : si32, f : f32>) -> f32 {
   ^bb0(%a: f32, %b : !arc.struct<i : si32, f : f32>):
     %f = arith.constant 3.14 : f32
     return %f : f32
   }
 
-  func @MyOperator(// Imutables
+  func.func @MyOperator(// Imutables
                    !arc.struct<p0 : f32, p1 : si32>,
 		   // State
                    !arc.struct<state1 : !arc.arcon.value<!arc.struct<i : si32, f : f32>>,
@@ -417,13 +417,13 @@ module @toplevel {
 // -----
 module @toplevel {
 
-  func @FoldFun(f32, !arc.struct<i : si32, f : f32>) -> f32 {
+  func.func @FoldFun(f32, !arc.struct<i : si32, f : f32>) -> f32 {
   ^bb0(%a: f32, %b : !arc.struct<i : si32, f : f32>):
     %f = arith.constant 3.14 : f32
     return %f : f32
   }
 
-  func @MyOperator(// Imutables
+  func.func @MyOperator(// Imutables
                    !arc.struct<p0 : f32, p1 : si32>,
 		   // State
                    !arc.struct<state1 : !arc.arcon.value<!arc.struct<i : si32, f : f32>>,
@@ -462,13 +462,13 @@ module @toplevel {
 // -----
 module @toplevel {
 
-  func @FoldFun(f32, !arc.struct<i : si32, f : f32>) -> f32 {
+  func.func @FoldFun(f32, !arc.struct<i : si32, f : f32>) -> f32 {
   ^bb0(%a: f32, %b : !arc.struct<i : si32, f : f32>):
     %f = arith.constant 3.14 : f32
     return %f : f32
   }
 
-  func @MyOperator(// Imutables
+  func.func @MyOperator(// Imutables
                    !arc.struct<p0 : f32, p1 : si32>,
 		   // State
                    !arc.struct<state1 : !arc.arcon.value<!arc.struct<i : si32, f : f32>>,
@@ -506,13 +506,13 @@ return
 // -----
 module @toplevel {
 
-  func @FoldFun(f32, !arc.struct<i : si32, f : f32>) -> f32 {
+  func.func @FoldFun(f32, !arc.struct<i : si32, f : f32>) -> f32 {
   ^bb0(%a: f32, %b : !arc.struct<i : si32, f : f32>):
     %f = arith.constant 3.14 : f32
     return %f : f32
   }
 
-  func @MyOperator(// Imutables
+  func.func @MyOperator(// Imutables
                    !arc.struct<p0 : f32, p1 : si32>,
 		   // State
                    !arc.struct<state1 : !arc.arcon.value<!arc.struct<i : si32, f : f32>>,
@@ -549,13 +549,13 @@ return
 // -----
 module @toplevel {
 
-  func @FoldFun(f32, !arc.struct<i : si32, f : f32>) -> f32 {
+  func.func @FoldFun(f32, !arc.struct<i : si32, f : f32>) -> f32 {
   ^bb0(%a: f32, %b : !arc.struct<i : si32, f : f32>):
     %f = arith.constant 3.14 : f32
     return %f : f32
   }
 
-  func @MyOperator(// Imutables
+  func.func @MyOperator(// Imutables
                    !arc.struct<p0 : f32, p1 : si32>,
 		   // State
                    !arc.struct<state1 : !arc.arcon.value<!arc.struct<i : si32, f : f32>>,
@@ -593,13 +593,13 @@ return
 // -----
 module @toplevel {
 
-  func @FoldFun(f32, !arc.struct<i : si32, f : f32>) -> f32 {
+  func.func @FoldFun(f32, !arc.struct<i : si32, f : f32>) -> f32 {
   ^bb0(%a: f32, %b : !arc.struct<i : si32, f : f32>):
     %f = arith.constant 3.14 : f32
     return %f : f32
   }
 
-  func @MyOperator(// Imutables
+  func.func @MyOperator(// Imutables
                    !arc.struct<p0 : f32, p1 : si32>,
 		   // State
                    !arc.struct<state1 : !arc.arcon.value<!arc.struct<i : si32, f : f32>>,

--- a/arc-mlir/src/tests/ops/bad-tensors.mlir
+++ b/arc-mlir/src/tests/ops/bad-tensors.mlir
@@ -1,7 +1,7 @@
 // RUN: arc-mlir %s -split-input-file -verify-diagnostics
 
 module @toplevel {
-  func @make_0() -> tensor<?x2xf32> {
+  func.func @make_0() -> tensor<?x2xf32> {
     %a = arith.constant 0.0 : f32
     %b = arith.constant 1.0 : f32
     %c = arith.constant 2.0 : f32
@@ -18,7 +18,7 @@ module @toplevel {
 // -----
 
 module @toplevel {
-  func @make_0() -> tensor<*xf32> {
+  func.func @make_0() -> tensor<*xf32> {
     %a = arith.constant 0.0 : f32
     %b = arith.constant 1.0 : f32
     %c = arith.constant 2.0 : f32
@@ -34,7 +34,7 @@ module @toplevel {
 
 // -----
 
-func @make_0() -> tensor<2x2xf32> {
+func.func @make_0() -> tensor<2x2xf32> {
     %a = arith.constant 0.0 : f32
     %b = arith.constant 1.0 : f32
     %c = arith.constant 2.0 : f64
@@ -49,7 +49,7 @@ func @make_0() -> tensor<2x2xf32> {
 
 // -----
 
-func @make_0() -> tensor<1x2xf32> {
+func.func @make_0() -> tensor<1x2xf32> {
     %a = arith.constant 0.0 : f32
     %b = arith.constant 1.0 : f32
     %c = arith.constant 2.0 : f32

--- a/arc-mlir/src/tests/ops/empty-struct.mlir
+++ b/arc-mlir/src/tests/ops/empty-struct.mlir
@@ -3,11 +3,11 @@
 // RUN: arc-mlir -canonicalize %s | arc-mlir
 
 module @toplevel {
-  func @empty_struct(%in : !arc.struct<>) -> !arc.struct<> {
+  func.func @empty_struct(%in : !arc.struct<>) -> !arc.struct<> {
     return %in : !arc.struct<>
   }
 
-  func @make_empty_struct() -> !arc.struct<> {
+  func.func @make_empty_struct() -> !arc.struct<> {
     %r = arc.make_struct() : !arc.struct<>
     return %r : !arc.struct<>
   }

--- a/arc-mlir/src/tests/ops/enums.mlir
+++ b/arc-mlir/src/tests/ops/enums.mlir
@@ -3,25 +3,25 @@
 // RUN: arc-mlir -canonicalize %s | arc-mlir
 
 module @toplevel {
-  func @ok0() -> !arc.enum<a : i32, b : f32> {
+  func.func @ok0() -> !arc.enum<a : i32, b : f32> {
     %a = arith.constant 4 : i32
     %r = arc.make_enum (%a : i32) as "a" : !arc.enum<a : i32, b : f32>
     return %r : !arc.enum<a : i32, b : f32>
   }
 
-  func @ok1() -> !arc.enum<a : i32, b : f32> {
+  func.func @ok1() -> !arc.enum<a : i32, b : f32> {
     %b = arith.constant 3.14 : f32
     %r = arc.make_enum (%b : f32) as "b" : !arc.enum<a : i32, b : f32>
     return %r : !arc.enum<a : i32, b : f32>
   }
 
-  func @ok2() -> !arc.enum<a : i32> {
+  func.func @ok2() -> !arc.enum<a : i32> {
     %a = arith.constant 4 : i32
     %r = arc.make_enum (%a : i32) as "a" : !arc.enum<a : i32>
     return %r : !arc.enum<a : i32>
   }
 
-  func @ok3() -> !arc.enum<a : i32, b : !arc.enum<a : i32> > {
+  func.func @ok3() -> !arc.enum<a : i32, b : !arc.enum<a : i32> > {
     %a = arith.constant 4 : i32
     %b = arith.constant 3 : i32
     %s = arc.make_enum (%a : i32) as "a" : !arc.enum<a : i32>
@@ -29,7 +29,7 @@ module @toplevel {
     return %r : !arc.enum<a : i32, b : !arc.enum<a : i32>>
   }
 
-  func @ok4() -> !arc.enum<a : i32, b : !arc.enum<a : i32> > {
+  func.func @ok4() -> !arc.enum<a : i32, b : !arc.enum<a : i32> > {
     %a = arith.constant 4 : i32
     %b = arith.constant 3 : i32
     %s = arc.make_enum (%a : i32) as "a" : !arc.enum<a : i32>
@@ -37,28 +37,28 @@ module @toplevel {
     return %r : !arc.enum<a : i32, b : !arc.enum<a : i32>>
   }
 
-  func @ok5() -> !arc.enum<no_value : none, b : f32> {
+  func.func @ok5() -> !arc.enum<no_value : none, b : f32> {
     %a = arith.constant 4 : i32
     %r = arc.make_enum () as "no_value" : !arc.enum<no_value : none, b : f32>
     return %r : !arc.enum<no_value : none, b : f32>
   }
 
-  func @access0(%e : !arc.enum<a : i32, b : f32>) -> i32 {
+  func.func @access0(%e : !arc.enum<a : i32, b : f32>) -> i32 {
     %r = arc.enum_access "a" in (%e : !arc.enum<a : i32, b : f32>) : i32
     return %r : i32
   }
 
-  func @access1(%e : !arc.enum<a : i32, b : f32>) -> f32 {
+  func.func @access1(%e : !arc.enum<a : i32, b : f32>) -> f32 {
     %r = arc.enum_access "b" in (%e : !arc.enum<a : i32, b : f32>) : f32
     return %r : f32
   }
 
-  func @check0(%e : !arc.enum<a : i32, b : f32>) -> i1 {
+  func.func @check0(%e : !arc.enum<a : i32, b : f32>) -> i1 {
     %r = arc.enum_check (%e : !arc.enum<a : i32, b : f32>) is "a" : i1
     return %r : i1
   }
 
-  func @check1(%e : !arc.enum<a : i32, b : f32>) -> i1 {
+  func.func @check1(%e : !arc.enum<a : i32, b : f32>) -> i1 {
     %r = arc.enum_check (%e : !arc.enum<a : i32, b : f32>) is "b" : i1
     return %r : i1
   }

--- a/arc-mlir/src/tests/ops/identity-task.mlir
+++ b/arc-mlir/src/tests/ops/identity-task.mlir
@@ -3,7 +3,7 @@
 // RUN: arc-mlir -canonicalize %s | arc-mlir
 module @toplevel {
 
-  func @MyOperator(// Imutables
+  func.func @MyOperator(// Imutables
                    !arc.struct<dummy : si32>,
 		   // State
                    !arc.struct<dummy : si32>,

--- a/arc-mlir/src/tests/ops/if.mlir
+++ b/arc-mlir/src/tests/ops/if.mlir
@@ -3,7 +3,7 @@
 // -----
 
 module @toplevel {
-  func @main() {
+  func.func @main() {
     %a = arith.constant 0 : i1
     %b = arith.constant 3.14 : f64
     %c = arith.constant 0.693 : f64
@@ -20,7 +20,7 @@ module @toplevel {
 // -----
 
 module @toplevel {
-  func @main() {
+  func.func @main() {
     %a = arith.constant 0 : i1
     %f = arith.constant 3.14 : f64
 
@@ -34,7 +34,7 @@ module @toplevel {
 // -----
 
 module @toplevel {
-  func @main() {
+  func.func @main() {
     %a = arith.constant 0 : i1
     %b = arith.constant 3.14 : f32
     %c = arith.constant 0.693 : f64
@@ -53,7 +53,7 @@ module @toplevel {
 // -----
 
 module @toplevel {
-  func @main() {
+  func.func @main() {
     %a = arith.constant 0 : i1
     %b = arith.constant 3.14 : f32
     %c = arith.constant 0.693 : f64
@@ -66,7 +66,7 @@ module @toplevel {
 // -----
 
 module @toplevel {
-  func @main() {
+  func.func @main() {
     %a = arith.constant 0 : i1
     %b = arith.constant 3.14 : f32
     %c = arith.constant 0.693 : f64
@@ -80,7 +80,7 @@ module @toplevel {
 // -----
 
 module @toplevel {
-  func @main() {
+  func.func @main() {
     %a = arith.constant 0 : i1
     %b = arith.constant 3.14 : f32
     %c = arith.constant 0.693 : f64
@@ -94,7 +94,7 @@ module @toplevel {
 // -----
 
 module @toplevel {
-  func @main() {
+  func.func @main() {
     %a = arith.constant 0 : i1
     %b = arith.constant 3.14 : f32
     %c = arith.constant 0.693 : f64
@@ -108,7 +108,7 @@ module @toplevel {
 // -----
 
 module @toplevel {
-  func @main() {
+  func.func @main() {
     %a = arith.constant 0 : i1
     %b = arith.constant 3.14 : f64
     %c = arith.constant 0.693 : f64
@@ -124,7 +124,7 @@ module @toplevel {
 // -----
 
 module @toplevel {
-  func @main() {
+  func.func @main() {
     %a = arith.constant 0 : i1
     %b = arith.constant 3.14 : f64
     %c = arith.constant 0.693 : f64
@@ -144,7 +144,7 @@ module @toplevel {
 // -----
 
 module @toplevel {
-  func @main() {
+  func.func @main() {
     %a = arith.constant 0 : i1
     %b = arith.constant 3.14 : f32
     %c = arith.constant 0.693 : f64
@@ -162,7 +162,7 @@ module @toplevel {
 // -----
 
 module @toplevel {
-  func @main() {
+  func.func @main() {
     %a = arith.constant 0 : i1
     %b = arith.constant 3.14 : f32
     %c = arith.constant 0.693 : f32
@@ -180,7 +180,7 @@ module @toplevel {
 // -----
 
 module @toplevel {
-  func @main() {
+  func.func @main() {
     %a = arith.constant 0 : i1
     %b = arith.constant 3.14 : f32
     %c = arith.constant 0.693 : f32
@@ -198,7 +198,7 @@ module @toplevel {
 // -----
 
 module @toplevel {
-  func @main() {
+  func.func @main() {
     %a = arith.constant 0 : i1
     %b = arith.constant 3.14 : f32
     %c = arith.constant 0.693 : f32
@@ -216,7 +216,7 @@ module @toplevel {
 // -----
 
 module @toplevel {
-  func @main() {
+  func.func @main() {
     %a = arith.constant 0 : i1
     %b = arith.constant 3.14 : f32
     %c = arith.constant 0.693 : f32
@@ -234,7 +234,7 @@ module @toplevel {
 // -----
 
 module @toplevel {
-  func @main() {
+  func.func @main() {
     %a = arith.constant 0 : i1
     %b = arc.constant 66 : ui64
     "arc.if"(%a) ( {
@@ -251,7 +251,7 @@ module @toplevel {
 // -----
 
 module @toplevel {
-  func @main() {
+  func.func @main() {
     %a = arith.constant 0 : i1
     %b = arc.constant 66 : ui64
     %c = arc.constant 7 : ui64
@@ -267,7 +267,7 @@ module @toplevel {
 // -----
 
 module @toplevel {
-  func @main() -> ui64 {
+  func.func @main() -> ui64 {
     %a = arith.constant 0 : i1
     %b = arc.constant 66 : ui64
     %c = arc.constant 7 : ui64
@@ -283,7 +283,7 @@ module @toplevel {
 // -----
 
 module @toplevel {
-  func @main() -> ui64 {
+  func.func @main() -> ui64 {
     %a = arith.constant 0 : i1
     %b = arc.constant 66 : ui64
     %c = arc.constant 7 : si64
@@ -301,7 +301,7 @@ module @toplevel {
 // -----
 
 module @toplevel {
-  func @main() {
+  func.func @main() {
     %a = arith.constant 0 : i1
     %b = arc.constant 66 : ui64
     %c = arc.constant 7 : ui64
@@ -319,7 +319,7 @@ module @toplevel {
 // -----
 
 module @toplevel {
-  func @main() -> ui64 {
+  func.func @main() -> ui64 {
     %a = arith.constant 0 : i1
     %b = arc.constant 66 : ui64
     "arc.if"(%a) ( {

--- a/arc-mlir/src/tests/ops/index_tuple.mlir
+++ b/arc-mlir/src/tests/ops/index_tuple.mlir
@@ -3,7 +3,7 @@
 // -----
 
 module @toplevel {
-  func @main() {
+  func.func @main() {
     %a = arith.constant false
     %b = arith.constant true
 
@@ -17,7 +17,7 @@ module @toplevel {
 // -----
 
 module @toplevel {
-  func @main() {
+  func.func @main() {
     %a = arith.constant false
     %b = arith.constant true
     %tuple = "arc.make_tuple"(%a, %b) : (i1, i1) -> tuple<i1,i1>
@@ -32,7 +32,7 @@ module @toplevel {
 // -----
 
 module @toplevel {
-  func @main() {
+  func.func @main() {
     %a = arith.constant false
     %b = arith.constant true
     %tuple = "arc.make_tuple"(%a, %b) : (i1, i1) -> tuple<i1,i1>
@@ -47,7 +47,7 @@ module @toplevel {
 // -----
 
 module @toplevel {
-  func @main() {
+  func.func @main() {
     %a = arith.constant false
     %b = arith.constant true
     %tuple = "arc.make_tuple"(%a, %b) : (i1, i1) -> tuple<i1,i1>
@@ -62,7 +62,7 @@ module @toplevel {
 // -----
 
 module @toplevel {
-  func @main() {
+  func.func @main() {
     %a = arith.constant false
     %b = arith.constant true
     %tuple = "arc.make_tuple"(%a, %b) : (i1, i1) -> tuple<i1,i1>

--- a/arc-mlir/src/tests/ops/loop.mlir
+++ b/arc-mlir/src/tests/ops/loop.mlir
@@ -3,7 +3,7 @@
 // -----
 
 module @toplevel {
-  func @main() {
+  func.func @main() {
     %a = arith.constant 0 : i1
     %b = arith.constant 3.14 : f32
     %c = arith.constant 0.693 : f32
@@ -22,7 +22,7 @@ module @toplevel {
 
 module @arctorustloops {
 
-  func @a_while_loop(%first : ui64, %limit : ui64, %accum : ui64) -> ui64 {
+  func.func @a_while_loop(%first : ui64, %limit : ui64, %accum : ui64) -> ui64 {
        %res_cnt, %res_sum = scf.while (%arg1 = %first, %sum = %accum) : (ui64, ui64) -> (ui64, ui64) {
          %condition = arc.cmpi "lt", %arg1, %limit : ui64
          scf.condition(%condition) %arg1, %sum : ui64, ui64
@@ -42,7 +42,7 @@ module @arctorustloops {
 
 module @arctorustloops {
 
-  func @a_while_loop_with_a_break_in_before(%first : ui64, %limit : ui64, %accum : ui64) -> ui64 {
+  func.func @a_while_loop_with_a_break_in_before(%first : ui64, %limit : ui64, %accum : ui64) -> ui64 {
        %res_cnt, %res_sum = scf.while (%arg1 = %first, %sum = %accum) : (ui64, ui64) -> (ui64, ui64) {
          %condition = arc.cmpi "lt", %arg1, %limit : ui64
 
@@ -71,7 +71,7 @@ module @arctorustloops {
 
 module @arctorustloops {
 
-  func @a_while_loop_with_a_break_in_after(%first : ui64, %limit : ui64, %accum : ui64) -> ui64 {
+  func.func @a_while_loop_with_a_break_in_after(%first : ui64, %limit : ui64, %accum : ui64) -> ui64 {
        %res_cnt, %res_sum = scf.while (%arg1 = %first, %sum = %accum) : (ui64, ui64) -> (ui64, ui64) {
          %condition = arc.cmpi "lt", %arg1, %limit : ui64
          scf.condition(%condition) %arg1, %sum : ui64, ui64
@@ -99,7 +99,7 @@ module @arctorustloops {
 
 module @arctorustloops {
 
-  func @a_while_loop_with_a_break_in_after(%first : ui64, %limit : ui64, %accum : ui64) -> ui64 {
+  func.func @a_while_loop_with_a_break_in_after(%first : ui64, %limit : ui64, %accum : ui64) -> ui64 {
        %res_cnt, %res_sum = scf.while (%arg1 = %first, %sum = %accum) : (ui64, ui64) -> (ui64, ui64) {
          %condition = arc.cmpi "lt", %arg1, %limit : ui64
          scf.condition(%condition) %arg1, %sum : ui64, ui64

--- a/arc-mlir/src/tests/ops/make_appender.mlir
+++ b/arc-mlir/src/tests/ops/make_appender.mlir
@@ -3,7 +3,7 @@
 // -----
 
 module @toplevel {
-  func @main() {
+  func.func @main() {
     %0 = "arc.make_appender"() : () -> !arc.appender<i32>
     %r = "arc.result"(%0) : (!arc.appender<i32>) -> tensor<i32>
     return
@@ -13,7 +13,7 @@ module @toplevel {
 // -----
 
 module @toplevel {
-  func @main() {
+  func.func @main() {
     %v = arith.constant 0 : i32
 
     // expected-error@+2 {{'arc.make_appender' op requires zero operands}}
@@ -28,7 +28,7 @@ module @toplevel {
 // -----
 
 module @toplevel {
-  func @main() {
+  func.func @main() {
     // SHOULD FAIL
     %0 = "arc.make_appender"() {size = -1} : () -> !arc.appender<i32>
     %b = "arc.result"(%0) : (!arc.appender<i32>) -> tensor<i32>
@@ -39,7 +39,7 @@ module @toplevel {
 // -----
 
 module @toplevel {
-  func @main() {
+  func.func @main() {
     // expected-error@+2 {{'arc.make_appender' op result #0 must be any appender, but got 'i32'}}
     // expected-note@+1 {{see current operation: %0 = "arc.make_appender"}}
     %0 = "arc.make_appender"() : () -> i32

--- a/arc-mlir/src/tests/ops/make_tuple.mlir
+++ b/arc-mlir/src/tests/ops/make_tuple.mlir
@@ -3,7 +3,7 @@
 // -----
 
 module @toplevel {
-  func @main() {
+  func.func @main() {
     %a = arith.constant 0 : i1
     %b = arith.constant 1 : i1
     %c = arith.constant 0 : i1
@@ -16,7 +16,7 @@ module @toplevel {
 // -----
 
 module @toplevel {
-  func @main() {
+  func.func @main() {
     %a = arith.constant 0 : i1
     %b = arith.constant 1 : i1
     // expected-error@+2 {{'arc.make_tuple' op operand types do not match: expected 'f32' but found 'i1'}}
@@ -29,7 +29,7 @@ module @toplevel {
 // -----
 
 module @toplevel {
-  func @main() {
+  func.func @main() {
     %a = arith.constant -3.40282347E+38 : f32 // expected-note {{prior use here}}
     %b = arith.constant 0 : i1
     // expected-error@+1 {{use of value '%a' expects different type than prior uses: 'i1' vs 'f32'}}
@@ -41,7 +41,7 @@ module @toplevel {
 // -----
 
 module @toplevel {
-  func @main() {
+  func.func @main() {
     %a = arith.constant 0 : i1
     %b = arith.constant 1 : i1
     // expected-error@+2 {{'arc.make_tuple' op result does not match the number of operands: expected 1 but found 2 operands}}
@@ -54,7 +54,7 @@ module @toplevel {
 // -----
 
 module @toplevel {
-  func @main() {
+  func.func @main() {
     // expected-error@+2 {{'arc.make_tuple' op tuple must contain at least one element}}
     // expected-note@+1 {{see current operation:}}
     %1 = "arc.make_tuple"() : () -> tuple<>

--- a/arc-mlir/src/tests/ops/make_vector.mlir
+++ b/arc-mlir/src/tests/ops/make_vector.mlir
@@ -1,7 +1,7 @@
 // RUN: arc-mlir %s -split-input-file -verify-diagnostics
 
 module @toplevel {
-  func @main() {
+  func.func @main() {
     %a = arith.constant -3.40282347E+38 : f32 // expected-note {{prior use here}}
     %b = arith.constant 0 : i1
     %c = arith.constant 1 : i1
@@ -16,7 +16,7 @@ module @toplevel {
 // -----
 
 module @toplevel {
-  func @main() {
+  func.func @main() {
     %b = arith.constant 0 : i1
     %c = arith.constant 1 : i1
     %d = arith.constant 0 : i1
@@ -31,7 +31,7 @@ module @toplevel {
 // -----
 
 module @toplevel {
-  func @main() {
+  func.func @main() {
     %b = arith.constant 0 : i1
     %c = arith.constant 1 : i1
     %d = arith.constant 0 : i1
@@ -46,7 +46,7 @@ module @toplevel {
 // -----
 
 module @toplevel {
-  func @main() {
+  func.func @main() {
     %b = arith.constant 0 : i1
     %c = arith.constant 1 : i1
     %d = arith.constant 0 : i1
@@ -61,7 +61,7 @@ module @toplevel {
 // -----
 
 module @toplevel {
-  func @main() {
+  func.func @main() {
     %b = arith.constant 0 : i1
     %c = arith.constant 1 : i1
     %d = arith.constant 0 : i1
@@ -76,7 +76,7 @@ module @toplevel {
 // -----
 
 module @toplevel {
-  func @main() {
+  func.func @main() {
     %b = arith.constant 0 : i1
     %c = arith.constant 1 : i1
     %d = arith.constant 0 : i1

--- a/arc-mlir/src/tests/ops/merge.mlir
+++ b/arc-mlir/src/tests/ops/merge.mlir
@@ -3,7 +3,7 @@
 // -----
 
 module @toplevel {
-  func @main() {
+  func.func @main() {
     %v = arith.constant 5 : i32
     %0 = "arc.make_appender"() : () -> !arc.appender<i32>
     %1 = "arc.merge"(%0, %v) : (!arc.appender<i32>, i32) -> !arc.appender<i32>
@@ -15,7 +15,7 @@ module @toplevel {
 // -----
 
 module @toplevel {
-  func @main() {
+  func.func @main() {
     %v = arith.constant 5 : i64
     %0 = "arc.make_appender"() : () -> !arc.appender<i32>
 
@@ -31,7 +31,7 @@ module @toplevel {
 // -----
 
 module @toplevel {
-  func @main() {
+  func.func @main() {
     %0 = "arc.make_appender"() : () -> !arc.appender<i32>
     %v = arith.constant 5 : i32
 
@@ -47,7 +47,7 @@ module @toplevel {
 // -----
 
 module @toplevel {
-  func @main() {
+  func.func @main() {
     %v1 = arith.constant 5 : i32
     %v2 = arith.constant 5 : i32
 

--- a/arc-mlir/src/tests/ops/panic.mlir
+++ b/arc-mlir/src/tests/ops/panic.mlir
@@ -3,12 +3,12 @@
 // RUN: arc-mlir -canonicalize %s | arc-mlir
 
 module @toplevel {
-  func @trigger_panic0() -> () {
+  func.func @trigger_panic0() -> () {
     arc.panic()
     return
   }
 
-  func @trigger_panic1() -> () {
+  func.func @trigger_panic1() -> () {
     arc.panic("foo")
     return
   }

--- a/arc-mlir/src/tests/ops/result.mlir
+++ b/arc-mlir/src/tests/ops/result.mlir
@@ -3,7 +3,7 @@
 // -----
 
 module @toplevel {
-  func @main() {
+  func.func @main() {
     %0 = "arc.make_appender"() : () -> !arc.appender<i32>
     %r = "arc.result"(%0) : (!arc.appender<i32>) -> tensor<i32>
     return
@@ -13,7 +13,7 @@ module @toplevel {
 // -----
 
 module @toplevel {
-  func @main() {
+  func.func @main() {
     %0 = "arc.make_appender"() : () -> !arc.appender<i32>
     // expected-error@+2 {{'arc.result' op result type does not match that of builder, found 'tensor<i64>' but expected 'tensor<i32>'}}
     // expected-note@+1 {{see current operation:}}

--- a/arc-mlir/src/tests/ops/streams.mlir
+++ b/arc-mlir/src/tests/ops/streams.mlir
@@ -3,23 +3,23 @@
 // RUN: arc-mlir -canonicalize %s | arc-mlir
 
 module @toplevel {
-  func @ok0(%in : !arc.stream.source<si32>) -> !arc.stream.source<si32>
+  func.func @ok0(%in : !arc.stream.source<si32>) -> !arc.stream.source<si32>
     attributes { "arc.is_task" } {
     return %in : !arc.stream.source<si32>
   }
 
-  func @ok1(%in : !arc.stream.sink<si32>) -> !arc.stream.sink<si32>
+  func.func @ok1(%in : !arc.stream.sink<si32>) -> !arc.stream.sink<si32>
     attributes { "arc.is_task" } {
     return %in : !arc.stream.sink<si32>
   }
 
-  func @ok2(%v : si32, %s : !arc.stream.sink<si32>) -> ()
+  func.func @ok2(%v : si32, %s : !arc.stream.sink<si32>) -> ()
     attributes { "arc.is_task" } {
     "arc.send"(%v, %s) : (si32, !arc.stream.sink<si32>) -> ()
     return
   }
 
-  func @ok3(%s : !arc.stream.source<si32>) -> si32
+  func.func @ok3(%s : !arc.stream.source<si32>) -> si32
     attributes { "arc.is_task" } {
     %v = "arc.receive"(%s) : (!arc.stream.source<si32>) -> si32
     return %v : si32

--- a/arc-mlir/src/tests/ops/structs.mlir
+++ b/arc-mlir/src/tests/ops/structs.mlir
@@ -3,20 +3,20 @@
 // RUN: arc-mlir -canonicalize %s | arc-mlir
 
 module @toplevel {
-  func @ok0() -> !arc.struct<a : i32, b : f32> {
+  func.func @ok0() -> !arc.struct<a : i32, b : f32> {
     %a = arith.constant 4 : i32
     %b = arith.constant 3.14 : f32
     %r = arc.make_struct(%a, %b : i32, f32) : !arc.struct<a : i32, b : f32>
     return %r : !arc.struct<a : i32, b : f32>
   }
 
-  func @ok1() -> !arc.struct<a : i32> {
+  func.func @ok1() -> !arc.struct<a : i32> {
     %a = arith.constant 4 : i32
     %r = arc.make_struct(%a : i32) : !arc.struct<a : i32>
     return %r : !arc.struct<a : i32>
   }
 
-  func @ok2() -> !arc.struct<a : i32, b : !arc.struct<a : i32> > {
+  func.func @ok2() -> !arc.struct<a : i32, b : !arc.struct<a : i32> > {
     %a = arith.constant 4 : i32
     %b = arith.constant 3 : i32
     %s = arc.make_struct(%b : i32) : !arc.struct<a : i32>
@@ -24,7 +24,7 @@ module @toplevel {
     return %r : !arc.struct<a : i32, b : !arc.struct<a : i32>>
   }
 
-  func @ok6() -> si32 {
+  func.func @ok6() -> si32 {
     %a = arc.constant 4 : si32
     %b = arc.constant 3 : si32
     %s = arc.make_struct(%b : si32) : !arc.struct<a : si32>
@@ -33,7 +33,7 @@ module @toplevel {
     return %r_a : si32
   }
 
-  func @ok7() -> si32 {
+  func.func @ok7() -> si32 {
     %a = arc.constant 4 : si32
     %b = arc.constant 3 : si32
     %s = arc.make_struct(%b : si32) : !arc.struct<a : si32>

--- a/arc-mlir/src/tests/ops/task-state.mlir
+++ b/arc-mlir/src/tests/ops/task-state.mlir
@@ -30,13 +30,13 @@
 
 module @toplevel {
 
-  func @FoldFun(f32, !arc.struct<i : si32, f : f32>) -> f32 {
+  func.func @FoldFun(f32, !arc.struct<i : si32, f : f32>) -> f32 {
   ^bb0(%a: f32, %b : !arc.struct<i : si32, f : f32>):
     %f = arith.constant 3.14 : f32
     return %f : f32
   }
 
-  func @MyOperator(// Imutables
+  func.func @MyOperator(// Imutables
                    !arc.struct<p0 : f32, p1 : si32>,
 		   // State
                    !arc.struct<state1 : !arc.arcon.value<!arc.struct<i : si32, f : f32>>,

--- a/arc-mlir/src/tests/ops/toy-task.mlir
+++ b/arc-mlir/src/tests/ops/toy-task.mlir
@@ -3,7 +3,7 @@
 // RUN: arc-mlir -canonicalize %s | arc-mlir
 
 module @toplevel {
-  func @id(%a : !arc.stream.source<si32>,
+  func.func @id(%a : !arc.stream.source<si32>,
            %b : !arc.stream.source<si32>,
            %c : !arc.stream.sink<si32>,
            %d : !arc.stream.sink<si32>) -> ()

--- a/arc-mlir/src/tests/ops/valid-int-constants.mlir
+++ b/arc-mlir/src/tests/ops/valid-int-constants.mlir
@@ -6,7 +6,7 @@
 // RUN: arc-mlir -mlir-print-op-generic %s | arc-mlir --canonicalize | FileCheck %s
 
 module @toplevel {
-  func @main() {
+  func.func @main() {
     %si8_min = arc.constant -128 : si8
 //CHECK-DAG: [[SI8MIN:%[^ ]+]] = arc.constant -128 : si8
     %si8_max = arc.constant 127 : si8

--- a/arc-mlir/src/tests/opts/arith-folding.mlir
+++ b/arc-mlir/src/tests/opts/arith-folding.mlir
@@ -1,6 +1,6 @@
 // RUN: arc-mlir --canonicalize %s | FileCheck %s
 module @toplevel {
-  func @main(%arg0 : i1) {
+  func.func @main(%arg0 : i1) {
 
     %cst_si16n32768 = arc.constant -32768: si16
     // CHECK-DAG: [[CSTsi16n32768:%[^ ]+]] = arc.constant -32768 : si16

--- a/arc-mlir/src/tests/opts/binops-folding.mlir
+++ b/arc-mlir/src/tests/opts/binops-folding.mlir
@@ -1,6 +1,6 @@
 // RUN: arc-mlir --canonicalize %s | FileCheck %s
 module @toplevel {
-  func @main(%arg0 : i64) {
+  func.func @main(%arg0 : i64) {
     %si8_max = arc.constant 127 : si8
     %si8_max_minus_1 = arc.constant 126 : si8
     %si8_one = arc.constant 1 : si8

--- a/arc-mlir/src/tests/opts/bitops-folding.mlir
+++ b/arc-mlir/src/tests/opts/bitops-folding.mlir
@@ -1,6 +1,6 @@
 // RUN: arc-mlir --canonicalize %s | FileCheck %s
 module @toplevel {
-  func @main(%arg0 : i1) {
+  func.func @main(%arg0 : i1) {
 
     %cst_0 = arc.constant 32837: ui16
     // CHECK-DAG: [[CST0:%[^ ]+]] = arc.constant 32837 : ui16

--- a/arc-mlir/src/tests/opts/canonicalization.mlir
+++ b/arc-mlir/src/tests/opts/canonicalization.mlir
@@ -1,6 +1,6 @@
 // RUN: arc-mlir --canonicalize %s | FileCheck %s
 module @toplevel {
-  func @main(%arg0 : i64) {
+  func.func @main(%arg0 : i64) {
     %cst_0 = arith.constant -3.40282347E+38 : f32
 // CHECK-DAG: [[V1XF32:%[^ ]+]] = arith.constant dense<-3.40282347E+38> : tensor<1xf32>
     %0 = "arc.make_vector"(%cst_0) : (f32) -> tensor<1xf32>

--- a/arc-mlir/src/tests/opts/enums.mlir
+++ b/arc-mlir/src/tests/opts/enums.mlir
@@ -1,7 +1,7 @@
 // RUN: arc-mlir -split-input-file --canonicalize %s | FileCheck %s
 
 module @toplevel {
-  func @main() -> i1 {
+  func.func @main() -> i1 {
     %a = arith.constant 0 : i1
     %b = arith.constant 1 : i1
 
@@ -17,7 +17,7 @@ module @toplevel {
 // -----
 
 module @toplevel {
-  func @main() -> i1 {
+  func.func @main() -> i1 {
     %a = arith.constant 0 : i1
     %b = arith.constant 1 : i1
 
@@ -33,7 +33,7 @@ module @toplevel {
 // -----
 
 module @toplevel {
-  func @main() -> si32 {
+  func.func @main() -> si32 {
     %a = arc.constant 17 : si32
     %b = arc.constant 7 : si32
 
@@ -49,7 +49,7 @@ module @toplevel {
 // -----
 
 module @toplevel {
-  func @main() -> si32 {
+  func.func @main() -> si32 {
     %a = arc.constant 17 : si32
     %b = arc.constant 7 : si32
 
@@ -65,7 +65,7 @@ module @toplevel {
 // -----
 
 module @toplevel {
-  func @main(%enum : !arc.enum<a : si32, b : si32>) -> si32 {
+  func.func @main(%enum : !arc.enum<a : si32, b : si32>) -> si32 {
     %elem = arc.enum_access "a" in (%enum : !arc.enum<a : si32, b : si32>) : si32
 
     return %elem : si32
@@ -77,7 +77,7 @@ module @toplevel {
 // -----
 
 module @toplevel {
-  func @main(%enum : !arc.enum<a : si32, b : si32>) -> si32 {
+  func.func @main(%enum : !arc.enum<a : si32, b : si32>) -> si32 {
     %elem = arc.enum_access "b" in (%enum : !arc.enum<a : si32, b : si32>) : si32
 
     return %elem : si32
@@ -89,7 +89,7 @@ module @toplevel {
 // -----
 
 module @toplevel {
-  func @main(%enum : !arc.enum<a : si32, b : si32>) -> i1 {
+  func.func @main(%enum : !arc.enum<a : si32, b : si32>) -> i1 {
     %bool = arc.enum_check (%enum : !arc.enum<a : si32, b : si32>) is "a" : i1
 
     return %bool : i1
@@ -101,7 +101,7 @@ module @toplevel {
 // -----
 
 module @toplevel {
-  func @main() -> i1 {
+  func.func @main() -> i1 {
     %a = arc.constant 17 : si32
     %b = arc.constant 7 : si32
 
@@ -117,7 +117,7 @@ module @toplevel {
 // -----
 
 module @toplevel {
-  func @main() -> i1 {
+  func.func @main() -> i1 {
     %a = arc.constant 17 : si32
     %b = arc.constant 7 : si32
 

--- a/arc-mlir/src/tests/opts/icmp-folding.mlir
+++ b/arc-mlir/src/tests/opts/icmp-folding.mlir
@@ -1,6 +1,6 @@
 // RUN: arc-mlir --canonicalize %s | FileCheck %s
 module @toplevel {
-  func @main(%arg0 : ui64) {
+  func.func @main(%arg0 : ui64) {
     %true = arith.constant 1 : i1
     %false = arith.constant 0 : i1
     // CHECK-DAG: [[TRUE:%[^ ]+]] = arith.constant true

--- a/arc-mlir/src/tests/opts/opt-constant-fold-if.mlir
+++ b/arc-mlir/src/tests/opts/opt-constant-fold-if.mlir
@@ -8,7 +8,7 @@
 //CHECK-DAG: [[C1000:%[^ ]+]] = arith.constant 1000 : i32
 
 module @toplevel {
-  func @main(%arg0: i1) -> () {
+  func.func @main(%arg0: i1) -> () {
     %false = arith.constant 0 : i1
     %true = arith.constant 1 : i1
 

--- a/arc-mlir/src/tests/opts/select-folding.mlir
+++ b/arc-mlir/src/tests/opts/select-folding.mlir
@@ -1,6 +1,6 @@
 // RUN: arc-mlir --canonicalize %s | FileCheck %s
 module @toplevel {
-  func @main(%arg0 : i1) {
+  func.func @main(%arg0 : i1) {
     %true = arith.constant 1 : i1
     %false = arith.constant 0 : i1
 

--- a/arc-mlir/src/tests/opts/structs.mlir
+++ b/arc-mlir/src/tests/opts/structs.mlir
@@ -1,7 +1,7 @@
 // RUN: arc-mlir -split-input-file --canonicalize %s | FileCheck %s
 
 module @toplevel {
-  func @main() -> i1 {
+  func.func @main() -> i1 {
     %a = arith.constant 0 : i1
     %b = arith.constant 1 : i1
 
@@ -17,7 +17,7 @@ module @toplevel {
 // -----
 
 module @toplevel {
-  func @main() -> si32 {
+  func.func @main() -> si32 {
     %a = arc.constant 7 : si32
     %b = arc.constant 17 : si32
 
@@ -34,7 +34,7 @@ module @toplevel {
 // -----
 
 module @toplevel {
-  func @main(%struct : !arc.struct<a : si32, b : si32>) -> si32 {
+  func.func @main(%struct : !arc.struct<a : si32, b : si32>) -> si32 {
     %elem = "arc.struct_access"(%struct) { field = "b" } : (!arc.struct<a : si32, b : si32>) -> si32
 
     return %elem : si32

--- a/arc-mlir/src/tests/opts/tuples.mlir
+++ b/arc-mlir/src/tests/opts/tuples.mlir
@@ -1,7 +1,7 @@
 // RUN: arc-mlir -split-input-file --canonicalize %s | FileCheck %s
 
 module @toplevel {
-  func @main() -> i1 {
+  func.func @main() -> i1 {
     %a = arith.constant 0 : i1
     %b = arith.constant 1 : i1
 
@@ -17,7 +17,7 @@ module @toplevel {
 // -----
 
 module @toplevel {
-  func @main() -> si32 {
+  func.func @main() -> si32 {
     %a = arc.constant 7 : si32
     %b = arc.constant 17 : si32
 
@@ -34,7 +34,7 @@ module @toplevel {
 // -----
 
 module @toplevel {
-  func @main(%tuple : tuple<si32,si32>) -> si32 {
+  func.func @main(%tuple : tuple<si32,si32>) -> si32 {
     %elem = "arc.index_tuple"(%tuple) { index = 1 } : (tuple<si32,si32>) -> si32
 
     return %elem : si32

--- a/arc-mlir/src/tests/types/adt.mlir
+++ b/arc-mlir/src/tests/types/adt.mlir
@@ -4,11 +4,11 @@
 
 module @toplevel {
 
-  func @ok0(%in : !arc.adt<"i32">) -> () {
+  func.func @ok0(%in : !arc.adt<"i32">) -> () {
     return
   }
 
-  func @ok2(%in : !arc.adt<"i32">) -> !arc.adt<"i32"> {
+  func.func @ok2(%in : !arc.adt<"i32">) -> !arc.adt<"i32"> {
     return %in : !arc.adt<"i32">
   }
 }

--- a/arc-mlir/src/tests/types/appender.mlir
+++ b/arc-mlir/src/tests/types/appender.mlir
@@ -3,7 +3,7 @@
 // -----
 
 module @toplevel {
-  func @main(%arg0: !arc.appender<i32>) {
+  func.func @main(%arg0: !arc.appender<i32>) {
     return
   }
 }
@@ -12,7 +12,7 @@ module @toplevel {
 
 module @toplevel {
   // expected-error@+1 {{appender merge type must be a value type: found '!arc.appender<i32>'}}
-  func @main(%arg0: !arc.appender<!arc.appender<i32>>) {
+  func.func @main(%arg0: !arc.appender<!arc.appender<i32>>) {
     return
   }
 }

--- a/arc-mlir/src/tests/types/bad-adt.mlir
+++ b/arc-mlir/src/tests/types/bad-adt.mlir
@@ -2,7 +2,7 @@
 
 module @toplevel {
 
-  func @ok2(%in : !arc.adt<"i16">) -> !arc.adt<"i32"> {
+  func.func @ok2(%in : !arc.adt<"i16">) -> !arc.adt<"i32"> {
   // expected-error@+2 {{type of return operand 0 ('!arc.adt<"i16">') doesn't match function result type ('!arc.adt<"i32">')}}
   // expected-note@+1 {{see current operation}}
     return %in : !arc.adt<"i16">

--- a/arc-mlir/src/tests/types/bad-structs.mlir
+++ b/arc-mlir/src/tests/types/bad-structs.mlir
@@ -2,7 +2,7 @@
 
 module @toplevel {
 // expected-error@+1 {{expected ':'}}
-  func @fail1(%in : !arc.struct<foo>) -> () {
+  func.func @fail1(%in : !arc.struct<foo>) -> () {
     return
   }
 }
@@ -11,7 +11,7 @@ module @toplevel {
 
 module @toplevel {
 // expected-error@+1 {{expected non-function type}}
-  func @fail2(%in : !arc.struct<foo : >) -> () {
+  func.func @fail2(%in : !arc.struct<foo : >) -> () {
     return
   }
 }
@@ -20,7 +20,7 @@ module @toplevel {
 
 module @toplevel {
 // expected-note@+1 {{prior use here}}
-  func @fail3(%in : !arc.struct<foo : i32, bar : f32,
+  func.func @fail3(%in : !arc.struct<foo : i32, bar : f32,
                               inner_struct : !arc.struct<nested : i32>>) -> () {
 // expected-error@+1 {{use of value '%in' expects different type than prior uses: '!arc.struct<foo : i32, bar : f32>' vs '!arc.struct<foo : i32, bar : f32, inner_struct : !arc.struct<nested : i32>>'}}
     return %in : !arc.struct<foo : i32, bar : f32>
@@ -30,7 +30,7 @@ module @toplevel {
 // -----
 
 module @toplevel {
-  func @fail4(%in : !arc.struct<foo : i32, bar : f32>) -> !arc.struct<foo : i32, baz : f32> {
+  func.func @fail4(%in : !arc.struct<foo : i32, bar : f32>) -> !arc.struct<foo : i32, baz : f32> {
   // expected-error@+2 {{type of return operand 0 ('!arc.struct<foo : i32, bar : f32>') doesn't match function result type ('!arc.struct<foo : i32, baz : f32>')}}
   // expected-note@+1 {{see current operation: "func.return"(%arg0) : (!arc.struct<foo : i32, bar : f32>) -> ()}}
     return %in : !arc.struct<foo : i32, bar : f32>

--- a/arc-mlir/src/tests/types/structs.mlir
+++ b/arc-mlir/src/tests/types/structs.mlir
@@ -3,19 +3,19 @@
 
 module @toplevel {
 
-  func @ok0(%in : !arc.struct<foo : i32>) -> () {
+  func.func @ok0(%in : !arc.struct<foo : i32>) -> () {
     return
   }
 
-  func @ok1(%in : !arc.struct<foo : i32, bar : f32>) -> () {
+  func.func @ok1(%in : !arc.struct<foo : i32, bar : f32>) -> () {
     return
   }
 
-  func @ok2(%in : !arc.struct<foo : i32, bar : f32>) -> !arc.struct<foo : i32, bar : f32> {
+  func.func @ok2(%in : !arc.struct<foo : i32, bar : f32>) -> !arc.struct<foo : i32, bar : f32> {
     return %in : !arc.struct<foo : i32, bar : f32>
   }
 
-  func @ok3(%in : !arc.struct<foo : i32, bar : f32, inner_struct : !arc.struct<nested : i32>>) -> () {
+  func.func @ok3(%in : !arc.struct<foo : i32, bar : f32, inner_struct : !arc.struct<nested : i32>>) -> () {
     return
   }
 }


### PR DESCRIPTION
Changes:

 * Upstream has removed the special case for parsing `FuncOp` which
   was put in place when moving `FuncOp` to the `func` dialect. We now
   have to use `func.func` in our MLIR.