### PR TITLE
LLVM submodule update

### DIFF
--- a/arc-mlir/src/lib/Arc/Dialect.cpp
+++ b/arc-mlir/src/lib/Arc/Dialect.cpp
@@ -1625,7 +1625,7 @@ Type StructType::parse(DialectAsmParser &parser) {
       return nullptr;
 
     elementTypes.push_back(elementType);
-    parser.parseOptionalComma();
+    (void)parser.parseOptionalComma();
   }
 }
 


### PR DESCRIPTION
Changes:
 * Avoid warning about return value of parseOptionalComma() not
   checked in arc-mlir dialect.