### PR TITLE
rust-mlir: Handle ADT generics in structs

### DIFF
--- a/arc-mlir/src/include/Rust/RustPrinterStream.h
+++ b/arc-mlir/src/include/Rust/RustPrinterStream.h
@@ -304,6 +304,11 @@ public:
     return *this;
   }
 
+  RustPrinterStream &print(llvm::raw_ostream &o, types::RustGenericADTType t) {
+    t.printAsRust(o, *this);
+    return *this;
+  }
+
   void writeEnumDefiniton(types::RustEnumType t) {
     unsigned id = t.getEnumTypeId();
 
@@ -390,6 +395,11 @@ public:
     }
     if (types::RustTupleType rt = ty.dyn_cast<types::RustTupleType>()) {
       rt.printAsRust(*this);
+      return s;
+    }
+    if (types::RustGenericADTType rt =
+            ty.dyn_cast<types::RustGenericADTType>()) {
+      this->print(s, rt);
       return s;
     }
     s << "unhandled type";

--- a/arc-mlir/src/include/Rust/Types.h
+++ b/arc-mlir/src/include/Rust/Types.h
@@ -172,7 +172,7 @@ public:
   using Base::Base;
 
   void print(DialectAsmPrinter &os) const;
-  rust::RustPrinterStream &printAsRust(rust::RustPrinterStream &os) const;
+  raw_ostream &printAsRust(raw_ostream &os, rust::RustPrinterStream &ps) const;
   raw_ostream &printAsRustNamedType(raw_ostream &os) const;
   std::string getRustType() const;
 

--- a/arc-mlir/src/tests/arc-to-rust/adt.mlir
+++ b/arc-mlir/src/tests/arc-to-rust/adt.mlir
@@ -31,4 +31,9 @@ module @arctorustadt {
     -> !arc.generic_adt<"crate::arctorustadt::tests::sharable_Bar::Bar", ui32, !arc.adt<"i32">> {
     return %in : !arc.generic_adt<"crate::arctorustadt::tests::sharable_Bar::Bar", ui32, !arc.adt<"i32">>
   }
+
+  func.func @ok9(%in : !arc.struct<foo : !arc.generic_adt<"crate::arctorustadt::tests::sharable_Bar::Bar", ui32, !arc.adt<"i32">>>)
+    -> !arc.struct<foo : !arc.generic_adt<"crate::arctorustadt::tests::sharable_Bar::Bar", ui32, !arc.adt<"i32">>> {
+    return %in : !arc.struct<foo : !arc.generic_adt<"crate::arctorustadt::tests::sharable_Bar::Bar", ui32, !arc.adt<"i32">>>
+  }
 }


### PR DESCRIPTION
Fix a bug in how the Rust dumper handles generic ADT types inside
structs. We have to mangle the type signature for the generic type to
something which is a valid Rust type name when creating the name for
the struct. As the type signature is no longer the same as the Rust
representation of the ADT type, we have also have to modify the MLIR
pretty printer.