### PR TITLE
LLVM submodule update

### DIFF
--- a/arc-mlir/src/lib/Arc/CMakeLists.txt
+++ b/arc-mlir/src/lib/Arc/CMakeLists.txt
@@ -15,6 +15,6 @@ add_mlir_dialect_library(ArcDialect
 target_link_libraries(ArcDialect
   PUBLIC
   MLIRIR
-  MLIRFunc
+  MLIRFuncDialect
   LLVMSupport
   )

--- a/arc-mlir/src/lib/Rust/CMakeLists.txt
+++ b/arc-mlir/src/lib/Rust/CMakeLists.txt
@@ -12,6 +12,6 @@ add_mlir_dialect_library(RustDialect
 target_link_libraries(RustDialect
   PUBLIC
   MLIRIR
-  MLIRFunc
+  MLIRFuncDialect
   LLVMSupport
 )


### PR DESCRIPTION
Changes needed:

  * The MLIRFunc library has been renamed to MLIRFuncDialect, so
    update our CMake files accordingly.