### PR TITLE
Frej/spawn

### DIFF
--- a/arc-mlir/src/include/Arc/Arc.h
+++ b/arc-mlir/src/include/Arc/Arc.h
@@ -23,10 +23,13 @@
 #ifndef ARC_DIALECT_H_
 #define ARC_DIALECT_H_
 
+#include <mlir/Dialect/Func/IR/FuncOps.h>
 #include <mlir/IR/Builders.h>
 #include <mlir/IR/BuiltinOps.h>
 #include <mlir/IR/Dialect.h>
+#include <mlir/IR/FunctionInterfaces.h>
 #include <mlir/IR/Operation.h>
+#include <mlir/Interfaces/CallInterfaces.h>
 #include <mlir/Interfaces/InferTypeOpInterface.h>
 #include <mlir/Interfaces/SideEffectInterfaces.h>
 

--- a/arc-mlir/src/include/Arc/Arc.td
+++ b/arc-mlir/src/include/Arc/Arc.td
@@ -26,6 +26,7 @@
 #ifndef OP_BASE
 include "../../mlir/include/mlir/IR/EnumAttr.td"
 include "../../mlir/include/mlir/IR/OpBase.td"
+include "../../mlir/include/mlir/IR/SymbolInterfaces.td"
 include "../../mlir/include/mlir/Interfaces/CallInterfaces.td"
 include "../../mlir/include/mlir/Interfaces/InferTypeOpInterface.td"
 include "../../mlir/include/mlir/Interfaces/SideEffectInterfaces.td"
@@ -828,6 +829,38 @@ def ArcReturnOp : Arc_Op<"return", [Terminator]> {
   let hasVerifier = 1;
 }
 
+def ArcSpawnOp : Arc_Op<"spawn", [
+      CallOpInterface,
+      DeclareOpInterfaceMethods<SymbolUserOpInterface>
+    ]> {
+  let summary = "Spawn a new task.";
+
+  let description = [{ Spawn a new task. The new task starts to
+    execute `fun` with the given parameters.  }];
+
+  let arguments = (ins FlatSymbolRefAttr:$callee, Variadic<AnyType>:$operands);
+
+  let extraClassDeclaration = [{
+    FunctionType getCalleeType();
+
+    /// Get the argument operands to the called function.
+    operand_range getArgOperands() {
+      return {arg_operand_begin(), arg_operand_end()};
+    }
+
+    operand_iterator arg_operand_begin() { return ++operand_begin(); }
+    operand_iterator arg_operand_end() { return operand_end(); }
+
+    /// Return the callee of this operation.
+    CallInterfaceCallable getCallableForCallee() {
+      return (*this)->getAttrOfType<SymbolRefAttr>("callee");
+    }
+  }];
+
+  let assemblyFormat = [{
+    $callee `(` $operands `)` attr-dict `:` functional-type($operands, results)
+  }];
+}
 
 
 #endif // ARC_OPS

--- a/arc-mlir/src/include/Rust/Rust.td
+++ b/arc-mlir/src/include/Rust/Rust.td
@@ -354,6 +354,34 @@ def Rust_RustReturnOp : Rust_Op<"return", [Terminator]> {
   }];
 }
 
+def RustSpawnOp : Rust_Op<"spawn", [CallOpInterface]> {
+    // Stolen in large parts from std.call
+  let summary = "spawn operation";
+  let arguments = (ins FlatSymbolRefAttr:$callee, Variadic<AnyType>:$operands);
+
+  let extraClassDeclaration = [{
+    // For the CallOpInterface
+    StringRef getCallee() { return callee(); }
+    FunctionType getCalleeType();
+
+    /// Get the argument operands to the called function.
+    operand_range getArgOperands() {
+      return {arg_operand_begin(), arg_operand_end()};
+    }
+
+    operand_iterator arg_operand_begin() { return operand_begin(); }
+    operand_iterator arg_operand_end() { return operand_end(); }
+
+    /// Return the callee of this operation.
+    CallInterfaceCallable getCallableForCallee() {
+      return (*this)->getAttrOfType<SymbolRefAttr>("callee");
+    }
+
+    // Write this op as Rust code to os
+    void writeRust(RustPrinterStream &os);
+  }];
+}
+
 def Rust_RustConstantOp : Rust_Op<"constant", [NoSideEffect]> {
   let summary = "a rust constant.";
   let description = [{

--- a/arc-mlir/src/lib/Arc/LowerToRust.cpp
+++ b/arc-mlir/src/lib/Arc/LowerToRust.cpp
@@ -150,6 +150,19 @@ struct SCFLoopYieldOpLowering : public OpConversionPattern<scf::YieldOp> {
   };
 };
 
+struct SpawnOpLowering : public OpConversionPattern<arc::ArcSpawnOp> {
+  SpawnOpLowering(MLIRContext *ctx, RustTypeConverter &typeConverter)
+      : OpConversionPattern<arc::ArcSpawnOp>(typeConverter, ctx, 1) {}
+
+  LogicalResult
+  matchAndRewrite(arc::ArcSpawnOp o, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const final {
+    rewriter.replaceOpWithNewOp<rust::RustSpawnOp>(o, adaptor.callee(),
+                                                   adaptor.getOperands());
+    return success();
+  };
+};
+
 struct StdCallOpLowering : public OpConversionPattern<func::CallOp> {
   StdCallOpLowering(MLIRContext *ctx, RustTypeConverter &typeConverter)
       : OpConversionPattern<func::CallOp>(typeConverter, ctx, 1),
@@ -1327,6 +1340,7 @@ void ArcToRustLoweringPass::runOnOperation() {
   patterns.insert<ArithSelectOpLowering>(&getContext(), typeConverter);
   patterns.insert<ReceiveOpLowering>(&getContext(), typeConverter);
   patterns.insert<SendOpLowering>(&getContext(), typeConverter);
+  patterns.insert<SpawnOpLowering>(&getContext(), typeConverter);
   patterns.insert<StructAccessOpLowering>(&getContext(), typeConverter);
   patterns.insert<StdCallOpLowering>(&getContext(), typeConverter);
   patterns.insert<StdCallIndirectOpLowering>(&getContext(), typeConverter);

--- a/arc-mlir/src/tests/arc-to-rust/spawn.mlir
+++ b/arc-mlir/src/tests/arc-to-rust/spawn.mlir
@@ -1,0 +1,31 @@
+// RUN: arc-mlir %s | arc-mlir
+// RUN: arc-mlir -canonicalize %s | arc-mlir
+
+module @arctorustspawn {
+
+  func.func @id(%in : !arc.stream.source<si32>,
+                %out : !arc.stream.sink<si32>) -> ()
+    attributes {
+      arc.is_task,
+      rust.async,
+      rust.annotation = "#[rewrite(nonpersistent)]"
+    } {
+      scf.while () : () -> () {
+        %condition = arith.constant 1 : i1
+        scf.condition(%condition)
+      } do {
+        ^bb0():
+        %x = "arc.receive"(%in) : (!arc.stream.source<si32>) -> si32
+        "arc.send"(%x, %out) : (si32, !arc.stream.sink<si32>) -> ()
+        scf.yield
+      }
+      return
+    }
+
+    func.func @main(%in : !arc.stream.source<si32>,
+                    %out : !arc.stream.sink<si32>) {
+       arc.spawn @id(%in, %out) : (!arc.stream.source<si32>,
+                                   !arc.stream.sink<si32>) -> ()
+       return
+    }
+}

--- a/arc-mlir/src/tests/arc-to-rust/spawn.mlir
+++ b/arc-mlir/src/tests/arc-to-rust/spawn.mlir
@@ -1,6 +1,6 @@
 // RUN: arc-mlir %s | arc-mlir
 // RUN: arc-mlir -canonicalize %s | arc-mlir
-
+// RUN: arc-mlir -canonicalize -arc-to-rust %s | FileCheck %s
 module @arctorustspawn {
 
   func.func @id(%in : !arc.stream.source<si32>,
@@ -26,6 +26,7 @@ module @arctorustspawn {
                     %out : !arc.stream.sink<si32>) {
        arc.spawn @id(%in, %out) : (!arc.stream.source<si32>,
                                    !arc.stream.sink<si32>) -> ()
+// CHECK: "rust.spawn"(%arg0, %arg1) {callee = @id} : (!rust<"<i32>">, !rust<"<i32>">) -> ()
        return
     }
 }

--- a/arc-mlir/src/tests/ops/bad-spawn.mlir
+++ b/arc-mlir/src/tests/ops/bad-spawn.mlir
@@ -1,0 +1,88 @@
+// RUN: arc-mlir %s -split-input-file -verify-diagnostics
+module @arctorustspawn {
+
+  func.func @id(%in : !arc.stream.source<si32>,
+                %out : !arc.stream.sink<si32>) -> ()
+    attributes {
+      arc.is_task,
+      rust.async,
+      rust.annotation = "#[rewrite(nonpersistent)]"
+    } {
+      scf.while () : () -> () {
+        %condition = arith.constant 1 : i1
+        scf.condition(%condition)
+      } do {
+        ^bb0():
+        %x = "arc.receive"(%in) : (!arc.stream.source<si32>) -> si32
+        "arc.send"(%x, %out) : (si32, !arc.stream.sink<si32>) -> ()
+        scf.yield
+      }
+      return
+    }
+
+    func.func @main(%in : !arc.stream.source<ui32>,
+                    %out : !arc.stream.sink<ui32>) {
+    // expected-error@+2 {{'arc.spawn' op operand type mismatch}}
+    // expected-note@+1 {{see current operation:}}
+       arc.spawn @id(%in, %out) : (!arc.stream.source<ui32>,
+                                   !arc.stream.sink<ui32>) -> ()
+       return
+    }
+}
+
+// -----
+
+module @arctorustspawn {
+
+  func.func @id(%in : !arc.stream.source<si32>,
+                %out : !arc.stream.sink<si32>) -> (si32)
+    attributes {
+      arc.is_task,
+      rust.async,
+      rust.annotation = "#[rewrite(nonpersistent)]"
+    } {
+      scf.while () : () -> () {
+        %condition = arith.constant 1 : i1
+        scf.condition(%condition)
+      } do {
+        ^bb0():
+        %x = "arc.receive"(%in) : (!arc.stream.source<si32>) -> si32
+        "arc.send"(%x, %out) : (si32, !arc.stream.sink<si32>) -> ()
+        scf.yield
+      }
+      %r = arc.constant 1 : si32
+      return %r : si32
+    }
+
+    func.func @main(%in : !arc.stream.source<si32>,
+                    %out : !arc.stream.sink<si32>) {
+    // expected-error@+2 {{op 'callee' should not have a result}}
+    // expected-note@+1 {{see current operation:}}
+       arc.spawn @id(%in, %out) : (!arc.stream.source<si32>,
+                                   !arc.stream.sink<si32>) -> ()
+       return
+    }
+}
+
+// -----
+
+module @arctorustspawn {
+
+  func.func @id(%in : !arc.stream.source<si32>,
+                %out : !arc.stream.sink<si32>) -> ()
+    attributes {
+      rust.async,
+      rust.annotation = "#[rewrite(nonpersistent)]"
+    } {
+      return
+    }
+
+    func.func @main(%in : !arc.stream.source<si32>,
+                    %out : !arc.stream.sink<si32>) {
+// expected-error@+2 {{'arc.spawn' op 'callee' must be a task}}
+// expected-note@+1 {{see current operation:}}
+       arc.spawn @id(%in, %out) : (!arc.stream.source<si32>,
+                                   !arc.stream.sink<si32>) -> ()
+       return
+    }
+}


### PR DESCRIPTION
Tests that try to compile the rust output are in the [frej/spawn-tests](https://github.com/cda-group/arc/commits/frej/spawn-tests) branch, but they require the updated runtime.

