### PR TITLE
LLVM Submodule update

### DIFF
--- a/arc-mlir/src/lib/Rust/Dialect.cpp
+++ b/arc-mlir/src/lib/Rust/Dialect.cpp
@@ -843,9 +843,13 @@ namespace rust {
 namespace types {
 
 struct RustTypeStorage : public TypeStorage {
-  RustTypeStorage(std::string type) : rustType(type) {}
+  RustTypeStorage(std::string type) : rustType(type), mangledName(type) {
+    if (rustType[0] == '"')
+      mangledName = rustType.substr(1, rustType.length() - 2);
+  }
 
   std::string rustType;
+  std::string mangledName;
 
   using KeyTy = std::string;
 
@@ -863,7 +867,9 @@ struct RustTypeStorage : public TypeStorage {
   void printAsMLIR(DialectAsmPrinter &os) const;
   void printAsRust(llvm::raw_ostream &o, rust::RustPrinterStream &ps);
 
-  std::string getMangledName(rust::RustPrinterStream &ps) { return rustType; };
+  std::string getMangledName(rust::RustPrinterStream &ps) const {
+    return mangledName;
+  };
 
   bool isBool() const;
 };
@@ -893,7 +899,9 @@ void RustType::printAsRust(llvm::raw_ostream &o, rust::RustPrinterStream &ps) {
   getImpl()->printAsRust(o, ps);
 }
 
-bool RustTypeStorage::isBool() const { return rustType.compare("bool") == 0; }
+bool RustTypeStorage::isBool() const {
+  return mangledName.compare("bool") == 0;
+}
 
 bool RustType::isBool() const { return getImpl()->isBool(); }
 

--- a/arc-mlir/src/tests/rust/crate.mlir
+++ b/arc-mlir/src/tests/rust/crate.mlir
@@ -51,7 +51,7 @@ module @"name-of-the-crate-2" {
 // -----
 
 module @"name-of-the-crate-3" {
-// expected-error@+2 {{'rust.func' op expected body region argument #0 to be of type '!rust.f64', found '!rust.f32'}}
+// expected-error@+2 {{'rust.func' op expected body region argument #0 to be of type '!rust<"f64">', found '!rust<"f32">'}}
 // expected-note@+1 {{see current operation: "rust.func"() (}}
 "rust.func"() ( {
  ^bb0(%arg0: !rust<"f32">):
@@ -65,7 +65,7 @@ module @"name-of-the-crate-3" {
 module @"name-of-the-crate-3" {
 "rust.func"() ( {
  ^bb0(%arg0: !rust<"f32">):
-// expected-error@+2 {{'rust.return' op result type does not match the type of the function: expected '!rust.f64' but found '!rust.f32'}}
+// expected-error@+2 {{'rust.return' op result type does not match the type of the function: expected '!rust<"f64">' but found '!rust<"f32">'}}
 // expected-note@+1 {{see current operation: "rust.return"}}
  "rust.return"(%arg0) : (!rust<"f32">) -> ()
 }) {sym_name = "the-function-name-1",


### PR DESCRIPTION
Changes needed:

  * The parsing of types has changed, the enclosing `"`s are now
    passed on to the TypeStorage. For our dialects it means that we have
    to strip the `"`s when constructing the mangled type for `RustType`.

  * The short type form when the dialect type doesn't contain any
    white-space is no longer done, i.e what previously was printed as
    `!dialect.foo` is no printed as `!dialect<"foo">`. This change
    requires some test-case updates.