### PR TITLE
LLVM Submodule update

### DIFF
--- a/arc-mlir/src/include/Arc/Arc.td
+++ b/arc-mlir/src/include/Arc/Arc.td
@@ -27,6 +27,7 @@
 include "../../mlir/include/mlir/IR/EnumAttr.td"
 include "../../mlir/include/mlir/IR/OpBase.td"
 include "../../mlir/include/mlir/IR/SymbolInterfaces.td"
+include "../../mlir/include/mlir/IR/BuiltinAttributeInterfaces.td"
 include "../../mlir/include/mlir/Interfaces/CallInterfaces.td"
 include "../../mlir/include/mlir/Interfaces/InferTypeOpInterface.td"
 include "../../mlir/include/mlir/Interfaces/SideEffectInterfaces.td"
@@ -432,7 +433,7 @@ def Arc_ConstantIntOp : Arc_Op<"constant", [ConstantLike, NoSideEffect]> {
   }];
 
   let arguments = (ins
-    AnyAttr:$value
+    TypedAttrInterface:$value
   );
 
   let results = (outs

--- a/arc-mlir/src/lib/Arc/Dialect.cpp
+++ b/arc-mlir/src/lib/Arc/Dialect.cpp
@@ -155,8 +155,7 @@ ParseResult ConstantIntOp::parse(OpAsmParser &parser, OperationState &state) {
   Attribute value;
   if (parser.parseAttribute(value, "value", state.attributes))
     return failure();
-
-  Type type = value.getType();
+  Type type = value.cast<TypedAttr>().getType();
   return parser.addTypeToList(type, state.types);
 }
 
@@ -166,7 +165,7 @@ void arc::ConstantIntOp::print(OpAsmPrinter &printer) {
 
 LogicalResult arc::ConstantIntOp::verify() {
   auto opType = getType();
-  auto v = value();
+  TypedAttr v = value();
   auto valueType = v.getType();
 
   // ODS already generates checks to make sure the result type is
@@ -241,7 +240,7 @@ OpFoldResult arc::CmpIOp::fold(ArrayRef<Attribute> operands) {
   auto rhs = operands.back().dyn_cast_or_null<IntegerAttr>();
   if (!lhs || !rhs)
     return {};
-  bool isUnsigned = operands[0].getType().isUnsignedInteger();
+  bool isUnsigned = lhs.cast<TypedAttr>().getType().isUnsignedInteger();
   auto val = applyCmpPredicate(getPredicate(), isUnsigned, lhs.getValue(),
                                rhs.getValue());
   return BoolAttr::get(getContext(), val);


### PR DESCRIPTION
Upstream has removed the type field from attributes. Typed attributes
have been replaced by the TypedAttr interface. For Arc-lang this only
impacts our signed/unsigned integer constants, where we have to switch
to using the TypedAttr interface.