### PR TITLE
LLVM Submodule update

### DIFF
--- a/arc-mlir/src/lib/Arc/LowerToRust.cpp
+++ b/arc-mlir/src/lib/Arc/LowerToRust.cpp
@@ -499,9 +499,9 @@ struct PanicOpLowering : public OpConversionPattern<arc::PanicOp> {
   matchAndRewrite(PanicOp o, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const final {
     auto msg = o.msg();
-    if (msg.hasValue())
+    if (msg.has_value())
       rewriter.replaceOpWithNewOp<rust::RustPanicOp>(
-          o, StringAttr::get(Ctx, msg.getValue()));
+          o, StringAttr::get(Ctx, msg.value()));
     else
       rewriter.replaceOpWithNewOp<rust::RustPanicOp>(o, nullptr);
 

--- a/arc-mlir/src/lib/Rust/Dialect.cpp
+++ b/arc-mlir/src/lib/Rust/Dialect.cpp
@@ -772,8 +772,8 @@ void RustBlockResultOp::writeRust(RustPrinterStream &PS) {
 
 void RustPanicOp::writeRust(RustPrinterStream &PS) {
   PS << "panic!(";
-  if (msg().hasValue())
-    PS << "\"" << msg().getValue() << "\"";
+  if (msg().has_value())
+    PS << "\"" << msg().value() << "\"";
   PS << ");\n";
 }
 


### PR DESCRIPTION
Changes needed:

 * Switch from deprecated to recommended methods of llvm::Optional.