### PR TITLE
LLVM Submodule update

### DIFF
--- a/arc-mlir/src/include/Arc/Arc.td
+++ b/arc-mlir/src/include/Arc/Arc.td
@@ -807,7 +807,7 @@ def ArcReturnOp : Arc_Op<"return", [Terminator]> {
     by an incovation of the `function`.
   }];
 
-  let arguments = (ins Optional<AnyType>:$operands);
+  let arguments = (ins Optional<AnyType>:$returnedValue);
 
   let hasVerifier = 1;
 }

--- a/arc-mlir/src/include/Rust/Rust.td
+++ b/arc-mlir/src/include/Rust/Rust.td
@@ -333,7 +333,7 @@ def Rust_RustReturnOp : Rust_Op<"return", [Terminator]> {
     by an incovation of the `rust.func`.
   }];
 
-  let arguments = (ins Optional<AnyRustType>:$operands);
+  let arguments = (ins Optional<AnyRustType>:$returned_value);
 
   let hasVerifier = 1;
 

--- a/arc-mlir/src/lib/Arc/Dialect.cpp
+++ b/arc-mlir/src/lib/Arc/Dialect.cpp
@@ -686,10 +686,10 @@ LogicalResult ArcReturnOp::verify() {
 
   FunctionType funType = function.getFunctionType().cast<FunctionType>();
 
-  if (funType.getNumResults() == 0 && operands())
+  if (funType.getNumResults() == 0 && getReturnedValue())
     return emitOpError("cannot return a value from a void function");
 
-  if (!operands() && funType.getNumResults())
+  if (!getReturnedValue() && funType.getNumResults())
     return emitOpError("operation must return a ")
            << funType.getResult(0) << " value";
 

--- a/arc-mlir/src/lib/Arc/RemoveSCF.cpp
+++ b/arc-mlir/src/lib/Arc/RemoveSCF.cpp
@@ -148,7 +148,7 @@ LogicalResult IfLowering::matchAndRewrite(arc::IfOp ifOp,
 LogicalResult
 ArcReturnLowering::matchAndRewrite(ArcReturnOp op,
                                    PatternRewriter &rewriter) const {
-  rewriter.replaceOpWithNewOp<func::ReturnOp>(op, op.operands());
+  rewriter.replaceOpWithNewOp<func::ReturnOp>(op, op.getReturnedValue());
   return success();
 }
 

--- a/arc-mlir/src/lib/Arc/ToSCF.cpp
+++ b/arc-mlir/src/lib/Arc/ToSCF.cpp
@@ -347,7 +347,7 @@ private:
           SmallVector<Value, 1> values;
 
           if (r.getNumOperands())
-            values.push_back(map.lookup(r.operands()[0]));
+            values.push_back(map.lookup(r.getOperands()[0]));
           Value returnState = rewriter.create<MakeEnumOp>(
               f->getLoc(), stateTy, values, returnValueVariant.first);
           rewriter.create<arc::ArcBlockResultOp>(f->getLoc(), returnState);

--- a/arc-mlir/src/lib/Rust/Dialect.cpp
+++ b/arc-mlir/src/lib/Rust/Dialect.cpp
@@ -181,10 +181,10 @@ LogicalResult RustReturnOp::verify() {
 
   FunctionType funType = function.getFunctionType();
 
-  if (funType.getNumResults() == 0 && operands())
+  if (funType.getNumResults() == 0 && getReturnedValue())
     return emitOpError("cannot return a value from a void function");
 
-  if (!operands() && funType.getNumResults())
+  if (!getReturnedValue() && funType.getNumResults())
     return emitOpError("operation must return a ")
            << funType.getResult(0) << " value";
 
@@ -656,7 +656,7 @@ void RustMakeStructOp::writeRust(RustPrinterStream &PS) {
   auto r = getResult();
   RustStructType st = r.getType().cast<RustStructType>();
   PS.let(r) << "new!(" << st << " { ";
-  auto args = operands();
+  auto args = getOperands();
   for (unsigned i = 0; i < args.size(); i++) {
     if (i != 0)
       PS << ", ";
@@ -823,7 +823,7 @@ void RustTensorOp::writeRust(RustPrinterStream &PS) {
 void RustTupleOp::writeRust(RustPrinterStream &PS) {
   auto r = getResult();
   PS.let(r) << "(";
-  auto args = operands();
+  auto args = getOperands();
   for (unsigned i = 0; i < args.size(); i++) {
     auto v = args[i];
     PS << v << ", ";


### PR DESCRIPTION
Changes:

  * Upstream has now completely removed the support for non-prefixed accessors, so adapt to that. I order to avoid a name clash with accessors for the operands, we also rename the operand names in our dialect specific return instructions.