### PR TITLE
LLVM Submodule update

### DIFF
--- a/arc-mlir/src/include/Rust/Rust.td
+++ b/arc-mlir/src/include/Rust/Rust.td
@@ -197,7 +197,9 @@ def Rust_RustFuncOp : Rust_Op<"func",
 
   let arguments = (ins SymbolNameAttr:$sym_name,
                        TypeAttrOf<FunctionType>:$function_type,
-                       OptionalAttr<StrAttr>:$sym_visibility);
+                       OptionalAttr<StrAttr>:$sym_visibility,
+                       OptionalAttr<DictArrayAttr>:$arg_attrs,
+                       OptionalAttr<DictArrayAttr>:$res_attrs);
   let extraClassDeclaration = [{
     /// Returns the argument types of this function.
     ArrayRef<Type> getArgumentTypes() {
@@ -230,7 +232,9 @@ def Rust_RustExtFuncOp : Rust_Op<"extfunc",
   let regions = (region AnyRegion:$empty_body);
   let arguments = (ins SymbolNameAttr:$sym_name,
                        TypeAttrOf<FunctionType>:$function_type,
-                       OptionalAttr<StrAttr>:$sym_visibility);
+                       OptionalAttr<StrAttr>:$sym_visibility,
+                       OptionalAttr<DictArrayAttr>:$arg_attrs,
+                       OptionalAttr<DictArrayAttr>:$res_attrs);
 
   let extraClassDeclaration = [{
     /// Returns the argument types of this function.

--- a/arc-mlir/src/lib/Arc/LowerToRust.cpp
+++ b/arc-mlir/src/lib/Arc/LowerToRust.cpp
@@ -70,7 +70,7 @@ struct ArcReturnOpLowering : public OpConversionPattern<ArcReturnOp> {
   matchAndRewrite(ArcReturnOp op, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const final {
     rewriter.replaceOpWithNewOp<rust::RustReturnOp>(
-        op, llvm::None,
+        op, std::nullopt,
         adaptor.getOperands().size() ? adaptor.getOperands()[0] : Value());
     return success();
   };
@@ -85,7 +85,7 @@ struct ReturnOpLowering : public OpConversionPattern<func::ReturnOp> {
   matchAndRewrite(func::ReturnOp op, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const final {
     rewriter.replaceOpWithNewOp<rust::RustReturnOp>(
-        op, llvm::None,
+        op, std::nullopt,
         adaptor.getOperands().size() ? adaptor.getOperands()[0] : Value());
     return success();
   };
@@ -136,7 +136,7 @@ struct SCFLoopConditionOpLowering
   matchAndRewrite(scf::ConditionOp op, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const final {
     rewriter.replaceOpWithNewOp<rust::RustLoopConditionOp>(
-        op, llvm::None, adaptor.getOperands());
+        op, std::nullopt, adaptor.getOperands());
     return success();
   };
 };
@@ -149,7 +149,7 @@ struct SCFLoopYieldOpLowering : public OpConversionPattern<scf::YieldOp> {
   LogicalResult
   matchAndRewrite(scf::YieldOp op, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const final {
-    rewriter.replaceOpWithNewOp<rust::RustLoopYieldOp>(op, llvm::None,
+    rewriter.replaceOpWithNewOp<rust::RustLoopYieldOp>(op, std::nullopt,
                                                        adaptor.getOperands());
     return success();
   };

--- a/arc-mlir/src/lib/Rust/Dialect.cpp
+++ b/arc-mlir/src/lib/Rust/Dialect.cpp
@@ -138,7 +138,7 @@ void RustDialect::printType(Type type, DialectAsmPrinter &os) const {
 LogicalResult RustFuncOp::verifyType() {
   Type type = getFunctionType();
   if (!type.isa<FunctionType>())
-    return emitOpError("requires '" + getTypeAttrName() +
+    return emitOpError("requires '" + getFunctionTypeAttrName().str() +
                        "' attribute of function type");
   return success();
 }
@@ -147,7 +147,7 @@ LogicalResult RustFuncOp::verifyType() {
 LogicalResult RustExtFuncOp::verifyType() {
   Type type = getFunctionType();
   if (!type.isa<FunctionType>())
-    return emitOpError("requires '" + getTypeAttrName() +
+    return emitOpError("requires '" + getFunctionTypeAttrName().str() +
                        "' attribute of function type");
   return success();
 }


### PR DESCRIPTION
Changes:

  * Switch from the deprecated `llvm::None` to `std::nullopt`.

  * Upstream has switched from required attributes to interface methods for the FunctionOpInterface, so change our implementation accordingly.