### PR TITLE
rust-mlir: Use func.func and not no longer supported func

### DIFF
--- a/arc-mlir/src/tests/arc-to-rust/calls-streams.mlir
+++ b/arc-mlir/src/tests/arc-to-rust/calls-streams.mlir
@@ -5,7 +5,7 @@
 
 module @toplevel {
 
-  func private @crate_Identity() -> ((!arc.stream.source<!arc.struct<key: si32, value: si32>>) -> !arc.stream.source<!arc.struct<key: si32, value: si32>>)
+  func.func private @crate_Identity() -> ((!arc.stream.source<!arc.struct<key: si32, value: si32>>) -> !arc.stream.source<!arc.struct<key: si32, value: si32>>)
 
     func.func @crate_main(%input_0: !arc.stream.source<!arc.struct<key: si32, value: si32>>) -> !arc.stream.source<!arc.struct<key: si32, value: si32>> {
         %x_8 = constant @crate_Identity : () -> ((!arc.stream.source<!arc.struct<key: si32, value: si32>>) -> !arc.stream.source<!arc.struct<key: si32, value: si32>>)


### PR DESCRIPTION
Looks like this was missed when upstream removed `func` from the standard dialect.