### PR TITLE
LLVM Submodule update

### DIFF
--- a/arc-mlir/src/lib/Arc/LowerToRust.cpp
+++ b/arc-mlir/src/lib/Arc/LowerToRust.cpp
@@ -1180,7 +1180,7 @@ struct FuncOpLowering : public OpConversionPattern<mlir::func::FuncOp> {
     SmallVector<Value, 4> operandsArray;
     for (auto i : adaptor.getOperands())
       operandsArray.push_back(i);
-    ArrayRef<Value> operands = llvm::makeArrayRef(operandsArray);
+    ArrayRef<Value> operands = ArrayRef(operandsArray);
     if (func.isExternal())
       return buildExternalFun(rewriter, operands, attributes, func, func,
                               sigConv, ctx);

--- a/arc-mlir/src/lib/Arc/Opts.cpp
+++ b/arc-mlir/src/lib/Arc/Opts.cpp
@@ -25,7 +25,7 @@
 #include <llvm/Support/raw_ostream.h>
 #include <mlir/Dialect/Arith/IR/Arith.h>
 #include <mlir/Dialect/Func/IR/FuncOps.h>
-#include <mlir/IR/BlockAndValueMapping.h>
+#include <mlir/IR/IRMapping.h>
 #include <mlir/IR/Matchers.h>
 #include <mlir/IR/PatternMatch.h>
 
@@ -54,7 +54,7 @@ ConstantValuesToDenseAttributes(mlir::OpResult result,
     arith::ConstantOp def = cast<arith::ConstantOp>(a.getDefiningOp());
     attribs.push_back(def.getValue());
   }
-  return DenseElementsAttr::get(st, llvm::makeArrayRef(attribs));
+  return DenseElementsAttr::get(st, ArrayRef(attribs));
 }
 
 struct ConstantFoldIf : public mlir::OpRewritePattern<arc::IfOp> {
@@ -75,7 +75,7 @@ struct ConstantFoldIf : public mlir::OpRewritePattern<arc::IfOp> {
     Operation *block_result =
         block.getTerminator()->getOperand(0).getDefiningOp();
     Operation *cloned_result = nullptr;
-    BlockAndValueMapping mapper;
+    IRMapping mapper;
     // We do the rewrite manually and not using
     // PatternRewriter::cloneRegion*() as we don't want to preserve
     // the blocks.

--- a/arc-mlir/src/lib/Arc/RestartableTask.cpp
+++ b/arc-mlir/src/lib/Arc/RestartableTask.cpp
@@ -16,9 +16,9 @@
 #include "Arc/Passes.h"
 #include "mlir/Dialect/ControlFlow/IR/ControlFlowOps.h"
 #include "mlir/Dialect/SCF/IR/SCF.h"
-#include "mlir/IR/BlockAndValueMapping.h"
 #include "mlir/IR/BuiltinOps.h"
 #include "mlir/IR/BuiltinTypes.h"
+#include "mlir/IR/IRMapping.h"
 #include "mlir/IR/MLIRContext.h"
 #include "mlir/Support/LLVM.h"
 #include "mlir/Support/LogicalResult.h"
@@ -117,7 +117,7 @@ void RestartableTaskPass::runOnOperation() {
     });
 
     // Clone the while-loop into the new body function
-    BlockAndValueMapping map;
+    IRMapping map;
     IRRewriter rewriter(&getContext());
     Block *entryBB = rewriter.createBlock(&bodyFunc->getRegion(0));
     auto blockArgs = SmallVector<Location>(1, f->getLoc());

--- a/arc-mlir/src/lib/Arc/ToSCF.cpp
+++ b/arc-mlir/src/lib/Arc/ToSCF.cpp
@@ -17,9 +17,9 @@
 #include "mlir/Analysis/Liveness.h"
 #include "mlir/Dialect/ControlFlow/IR/ControlFlowOps.h"
 #include "mlir/Dialect/SCF/IR/SCF.h"
-#include "mlir/IR/BlockAndValueMapping.h"
 #include "mlir/IR/BuiltinOps.h"
 #include "mlir/IR/BuiltinTypes.h"
+#include "mlir/IR/IRMapping.h"
 #include "mlir/IR/MLIRContext.h"
 #include "mlir/Support/LLVM.h"
 #include "mlir/Support/LogicalResult.h"
@@ -105,8 +105,8 @@ private:
                 DenseMap<Block *, StringAttr> &block2variantName,
                 DenseMap<Block *, SmallVector<std::pair<Value, StringAttr>>>
                     &block2live2Field,
-                types::EnumType stateTy, BlockAndValueMapping &map,
-                Location loc, PatternRewriter &rewriter) const {
+                types::EnumType stateTy, IRMapping &map, Location loc,
+                PatternRewriter &rewriter) const {
     SmallVector<Value, 4> destArgs;
     for (auto a : destOps)
       destArgs.push_back(map.lookup(a));
@@ -294,7 +294,7 @@ private:
       // Prepare to clone the body by setting up a mapping which maps
       // the original values to values extracted from the state
       // struct.
-      BlockAndValueMapping map;
+      IRMapping map;
 
       // First extract the struct for this BB
       types::EnumType::VariantTy variantInfo = block2variant[b];


### PR DESCRIPTION
Changes needed:

 * mlir/IR/BlockAndValueMapping.h has been renamed to mlir/IR/IRMapping.h and BlockAndValueMapping has become IRMapping.

 * llvm::makeArrayRef() has been deprecated, use the ArrayRef() constructor instead.