### PR TITLE
CI: Update CI ubuntu version

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -15,7 +15,7 @@ env:
 
 jobs:
   build-deploy:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
 
     steps:
     - name: Checkout source


### PR DESCRIPTION
It appears that Github is intentionally breaking CI using ubuntu-18.04.