### PR TITLE
LLVM Submodule update

### DIFF
--- a/arc-mlir/src/include/Arc/Arc.td
+++ b/arc-mlir/src/include/Arc/Arc.td
@@ -45,7 +45,6 @@ def Arc_Dialect : Dialect {
       void printType(Type type, DialectAsmPrinter &os) const override;
   }];
   let hasConstantMaterializer = 1;
-  let useFoldAPI = kEmitFoldAdaptorFolder;
 }
 
 //===----------------------------------------------------------------------===//

--- a/arc-mlir/src/include/Rust/Rust.td
+++ b/arc-mlir/src/include/Rust/Rust.td
@@ -48,7 +48,6 @@ def Rust_Dialect : Dialect {
                       u8Ty, u16Ty, u32Ty, u64Ty,
                       noneTy;
   }];
-  let useFoldAPI = kEmitFoldAdaptorFolder;
 }
 
 //===----------------------------------------------------------------------===//


### PR DESCRIPTION
Changes:

 * The new fold method signature [1] is now the default. The Tablegen variable `useFoldAPI` is no longer required nor understood by Tablegen.

[1] https://discourse.llvm.org/t/psa-new-improved-fold-method-signature-has-landed-please-update-your-downstream-projects/67618