### PR TITLE
LLVM Submodule update

### DIFF
--- a/arc-mlir/src/include/Arc/Arc.td
+++ b/arc-mlir/src/include/Arc/Arc.td
@@ -586,7 +586,14 @@ def ArcSpawnOp : Arc_Op<"spawn", [
   let arguments = (ins FlatSymbolRefAttr:$callee, Variadic<AnyType>:$operands);
 
   let extraClassDeclaration = [{
+    // For the CallOpInterface
     FunctionType getCalleeType();
+
+    // For the CallOpInterface
+    void setCalleeFromCallable(CallInterfaceCallable callee) {
+      (*this)->setAttr("callee", callee.get<SymbolRefAttr>());
+    }
+
 
     /// Get the argument operands to the called function.
     operand_range getArgOperands() {

--- a/arc-mlir/src/include/Rust/Rust.td
+++ b/arc-mlir/src/include/Rust/Rust.td
@@ -103,6 +103,11 @@ def RustCallOp : Rust_Op<"call", [CallOpInterface]> {
     // For the CallOpInterface
     FunctionType getCalleeType();
 
+    // For the CallOpInterface
+    void setCalleeFromCallable(CallInterfaceCallable callee) {
+      (*this)->setAttr("callee", callee.get<SymbolRefAttr>());
+    }
+
     /// Get the argument operands to the called function.
     operand_range getArgOperands() {
       return {arg_operand_begin(), arg_operand_end()};
@@ -171,6 +176,11 @@ def RustCallIndirectOp : Rust_Op<"call_indirect", [
 
     /// Return the callee of this operation.
     CallInterfaceCallable getCallableForCallee() { return getCallee(); }
+
+    // For the CallOpInterface
+    void setCalleeFromCallable(CallInterfaceCallable callee) {
+      (*this)->setAttr("callee", callee.get<SymbolRefAttr>());
+    }
 
     // Write this op as Rust code to os
     void writeRust(RustPrinterStream &os);
@@ -347,6 +357,11 @@ def RustSpawnOp : Rust_Op<"spawn", [CallOpInterface]> {
   let extraClassDeclaration = [{
     // For the CallOpInterface
     FunctionType getCalleeType();
+
+    // For the CallOpInterface
+    void setCalleeFromCallable(CallInterfaceCallable callee) {
+      (*this)->setAttr("callee", callee.get<SymbolRefAttr>());
+    }
 
     /// Get the argument operands to the called function.
     operand_range getArgOperands() {

--- a/arc-mlir/src/lib/Arc/Dialect.cpp
+++ b/arc-mlir/src/lib/Arc/Dialect.cpp
@@ -169,10 +169,11 @@ Operation *ArcDialect::materializeConstant(OpBuilder &builder, Attribute value,
                                            Type type, Location loc) {
 
   if (type.isSignedInteger() || type.isUnsignedInteger())
-    return builder.create<ConstantIntOp>(loc, type, value);
+    return builder.create<ConstantIntOp>(loc, type,
+                                         cast<mlir::IntegerAttr>(value));
 
   if (arith::ConstantOp::isBuildableWith(value, type))
-    return builder.create<arith::ConstantOp>(loc, type, value);
+    return builder.create<arith::ConstantOp>(loc, type, cast<TypedAttr>(value));
 
   if (func::ConstantOp::isBuildableWith(value, type)) {
     return builder.create<func::ConstantOp>(loc, type,


### PR DESCRIPTION
Changes needed:

  * The CallOpInterface now requires a setCalleeFromCallable() method.

  * The builder create methods now requires typed attributes.