### PR TITLE
Don't build docs for arc-runtime

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -32,13 +32,6 @@ jobs:
           toolchain: nightly
           override: true
 
-    - name: Cache arc-runtime-docs
-      id: cache-arc-runtime-docs
-      uses: actions/cache@v2
-      with:
-        path: arc-docs/src/target
-        key: ${{ runner.os }}-cargo-${{ hashFiles('arc-runtime/**') }}
-
     - name: Cache arc-preprocessor
       id: cache-arc-preprocessor
       uses: actions/cache@v2
@@ -66,12 +59,6 @@ jobs:
       with:
         path: ~/.cargo/bin/zola
         key: ${{ runner.os }}-cargo-${{ env.ZOLA_VERSION }}
-
-    - name: Build arc-runtime-docs
-      if: steps.cache-arc-runtime-docs.outputs.cache-hit != 'true'
-      run: |
-        cargo +nightly doc --document-private-items --no-deps --target-dir=arc-docs/src/target --manifest-path=arc-runtime/Cargo.toml 
-        cargo +nightly doc --document-private-items --no-deps --target-dir=arc-docs/src/target --manifest-path=arc-runtime/macros/Cargo.toml 
 
     - name: Build arc-preprocessor
       if: steps.cache-arc-preprocessor.outputs.cache-hit != 'true'

--- a/arc-docs/src/dev/arc-runtime/mod.md
+++ b/arc-docs/src/dev/arc-runtime/mod.md
@@ -5,5 +5,3 @@ Arc-Runtime is a runtime library, for executing Arc-Lang programs, which focuses
 Arc-MLIR supports ahead-of-time standard compiler optimisations as well as logical and physical optimisations of streaming-relational operators. However, Arc-MLIR makes no assumptions of where programs will execute and what the input data will be. That is, all Arc-MLIR optimisations are based on the source code itself.
 
 Arc-Runtime supports runtime optimisations which might rely on information that is only known during execution. Streaming programs are expected to run for an indefinite duration and must therefore be able to adapt to changes in their environment. Among its responsibilities, Arc-Runtime must therefore be able to take care of specialisation, scheduling, and scaling decisions.
-
-For more information, see the [internal developer documentation of the Arc-Runtime](../../target/doc/arc_runtime/index.html).


### PR DESCRIPTION
They are broken, and the runtime will be replaced in a later PR so maybe it's best to just remove them.