### PR TITLE
LLVM Submodule update

### DIFF
--- a/arc-mlir/src/tools/arc-mlir/CMakeLists.txt
+++ b/arc-mlir/src/tools/arc-mlir/CMakeLists.txt
@@ -1,9 +1,11 @@
 get_property(dialect_libs GLOBAL PROPERTY MLIR_DIALECT_LIBS)
 get_property(conversion_libs GLOBAL PROPERTY MLIR_CONVERSION_LIBS)
+get_property(extension_libs GLOBAL PROPERTY MLIR_EXTENSION_LIBS)
 
 set(LIBS
   ${dialect_libs}
   ${conversion_libs}
+  ${extension_libs}
   MLIRAffineAnalysis
   MLIRAffineTransformsTestPasses
   MLIRAnalysis

--- a/arc-mlir/src/tools/arc-mlir/Main.cpp
+++ b/arc-mlir/src/tools/arc-mlir/Main.cpp
@@ -40,6 +40,7 @@
 #include <mlir/IR/BuiltinOps.h>
 #include <mlir/IR/MLIRContext.h>
 #include <mlir/InitAllDialects.h>
+#include <mlir/InitAllExtensions.h>
 #include <mlir/InitAllPasses.h>
 #include <mlir/Parser/Parser.h>
 #include <mlir/Pass/Pass.h>
@@ -88,6 +89,7 @@ int main(int argc, char **argv) {
   registry.insert<scf::SCFDialect>();
   registry.insert<ArcDialect>();
   registry.insert<rust::RustDialect>();
+  registerAllExtensions(registry);
   arc::registerArcPasses();
 
   // Register any command line options.


### PR DESCRIPTION
Changes needed:

  * Link and register all extensions, required by upstream commit a5ef51d786f241cdd9d1bec62fbc2bf89a766b7d.