### PR TITLE
LLVM Submodule update

### DIFF
--- a/arc-mlir/src/include/Arc/Arc.h
+++ b/arc-mlir/src/include/Arc/Arc.h
@@ -27,7 +27,7 @@
 #include <mlir/IR/Builders.h>
 #include <mlir/IR/BuiltinOps.h>
 #include <mlir/IR/Dialect.h>
-#include <mlir/IR/FunctionInterfaces.h>
+#include <mlir/Interfaces/FunctionInterfaces.h>
 #include <mlir/IR/Operation.h>
 #include <mlir/Interfaces/CallInterfaces.h>
 #include <mlir/Interfaces/InferTypeOpInterface.h>

--- a/arc-mlir/src/include/Rust/Rust.h
+++ b/arc-mlir/src/include/Rust/Rust.h
@@ -28,7 +28,7 @@
 #include <mlir/IR/Builders.h>
 #include <mlir/IR/BuiltinOps.h>
 #include <mlir/IR/Dialect.h>
-#include <mlir/IR/FunctionInterfaces.h>
+#include <mlir/Interfaces/FunctionInterfaces.h>
 #include <mlir/IR/Operation.h>
 #include <mlir/Interfaces/CallInterfaces.h>
 #include <mlir/Interfaces/ControlFlowInterfaces.h>

--- a/arc-mlir/src/include/Rust/Rust.td
+++ b/arc-mlir/src/include/Rust/Rust.td
@@ -25,7 +25,7 @@
 
 #ifndef OP_BASE
 include "../../mlir/include/mlir/IR/OpBase.td"
-include "../../mlir/include/mlir/IR/FunctionInterfaces.td"
+include "../../mlir/include/mlir/Interfaces/FunctionInterfaces.td"
 include "../../mlir/include/mlir/Interfaces/CallInterfaces.td"
 include "../../mlir/include/mlir/Interfaces/InferTypeOpInterface.td"
 include "../../mlir/include/mlir/Interfaces/SideEffectInterfaces.td"
@@ -221,6 +221,8 @@ def Rust_RustFuncOp : Rust_Op<"func",
       return getFunctionType().cast<FunctionType>().getResults();
     }
 
+    Region *getCallableRegion() { return &getBody(); }
+
     /// Hook for FunctionOpInterface verifier.
     LogicalResult verifyType();
 
@@ -256,6 +258,8 @@ def Rust_RustExtFuncOp : Rust_Op<"extfunc",
     ArrayRef<Type> getResultTypes() {
       return getFunctionType().cast<FunctionType>().getResults();
     }
+
+    Region *getCallableRegion() { return &getEmptyBody(); }
 
     /// Hook for FunctionOpInterface verifier.
     LogicalResult verifyType();

--- a/arc-mlir/src/lib/Arc/Dialect.cpp
+++ b/arc-mlir/src/lib/Arc/Dialect.cpp
@@ -119,8 +119,8 @@ OpFoldResult arc::AndOp::fold(FoldAdaptor operands) {
   if (getLhs() == getRhs())
     return getRhs();
 
-  return constFoldBinaryOp<IntegerAttr>(operands.getOperands(),
-                                        [](APInt a, APInt b) { return a & b; });
+  return constFoldBinaryOp<IntegerAttr, IntegerAttr::ValueType, void>(
+      operands.getOperands(), [](APInt a, APInt b) { return a & b; });
 }
 
 //===----------------------------------------------------------------------===//
@@ -234,7 +234,7 @@ OpFoldResult DivIOp::fold(FoldAdaptor operands) {
   bool isUnsigned = getType().isUnsignedInteger();
   // Don't fold if it would overflow or if it requires a division by zero.
   bool overflowOrDiv0 = false;
-  auto result = constFoldBinaryOp<IntegerAttr>(
+  auto result = constFoldBinaryOp<IntegerAttr, IntegerAttr::ValueType, void>(
       operands.getOperands(), [&](APInt a, APInt b) {
         if (overflowOrDiv0 || !b) {
           overflowOrDiv0 = true;
@@ -439,7 +439,7 @@ OpFoldResult AddIOp::fold(FoldAdaptor operands) {
 
   bool isUnsigned = getType().isUnsignedInteger();
   bool overflowDetected = false;
-  auto result = constFoldBinaryOp<IntegerAttr>(
+  auto result = constFoldBinaryOp<IntegerAttr, IntegerAttr::ValueType, void>(
       operands.getOperands(), [&](APInt a, APInt b) {
         if (overflowDetected)
           return a;
@@ -466,7 +466,7 @@ OpFoldResult MulIOp::fold(FoldAdaptor operands) {
 
   // Don't fold if it would overflow
   bool overflow = false;
-  auto result = constFoldBinaryOp<IntegerAttr>(
+  auto result = constFoldBinaryOp<IntegerAttr, IntegerAttr::ValueType, void>(
       operands.getOperands(), [&](APInt a, APInt b) {
         if (overflow || !b) {
           overflow = true;
@@ -491,8 +491,8 @@ OpFoldResult arc::OrOp::fold(FoldAdaptor operands) {
   if (getLhs() == getRhs())
     return getRhs();
 
-  return constFoldBinaryOp<IntegerAttr>(operands.getOperands(),
-                                        [](APInt a, APInt b) { return a | b; });
+  return constFoldBinaryOp<IntegerAttr, IntegerAttr::ValueType, void>(
+      operands.getOperands(), [](APInt a, APInt b) { return a | b; });
 }
 
 //===----------------------------------------------------------------------===//
@@ -665,7 +665,7 @@ OpFoldResult SubIOp::fold(FoldAdaptor operands) {
 
   bool isUnsigned = getType().isUnsignedInteger();
   bool overflowDetected = false;
-  auto result = constFoldBinaryOp<IntegerAttr>(
+  auto result = constFoldBinaryOp<IntegerAttr, IntegerAttr::ValueType, void>(
       operands.getOperands(), [&](APInt a, APInt b) {
         if (overflowDetected)
           return a;
@@ -689,8 +689,8 @@ OpFoldResult arc::XOrOp::fold(FoldAdaptor operands) {
   if (getLhs() == getRhs())
     return Builder(getContext()).getZeroAttr(getType());
 
-  return constFoldBinaryOp<IntegerAttr>(operands.getOperands(),
-                                        [](APInt a, APInt b) { return a ^ b; });
+  return constFoldBinaryOp<IntegerAttr, IntegerAttr::ValueType, void>(
+      operands.getOperands(), [](APInt a, APInt b) { return a ^ b; });
 }
 
 //===----------------------------------------------------------------------===//

--- a/arc-mlir/src/tests/arc-to-rust/spawn.mlir
+++ b/arc-mlir/src/tests/arc-to-rust/spawn.mlir
@@ -26,7 +26,7 @@ module @arctorustspawn {
                     %out : !arc.stream.sink<si32>) {
        arc.spawn @id(%in, %out) : (!arc.stream.source<si32>,
                                    !arc.stream.sink<si32>) -> ()
-// CHECK: "rust.spawn"(%arg0, %arg1) {callee = @id} : (!rust<<i32>>, !rust<<i32>>) -> ()
+// CHECK: "rust.spawn"(%arg0, %arg1) <{callee = @id}> : (!rust<<i32>>, !rust<<i32>>) -> ()
        return
     }
 }

--- a/arc-runtime/macros/src/proc_macros.rs
+++ b/arc-runtime/macros/src/proc_macros.rs
@@ -194,8 +194,8 @@ pub fn wait(input: TokenStream) -> TokenStream {
 
 fn generate_wrapper(id: &syn::Ident) -> (pm2::TokenStream, impl Fn(syn::Expr) -> pm2::TokenStream) {
     let span = id.span().unwrap().start();
-    let line = span.line;
-    let column = span.column;
+    let line = span.line();
+    let column = span.column();
     let abstract_id: syn::Ident = new_id(format!("Wrapper_{}_{}", line, column));
     let concrete_id: syn::Ident = new_id(format!("ConcreteWrapper_{}_{}", line, column));
     let sharable_wrapper_mod_id = new_id(format!("sharable_{}", abstract_id));


### PR DESCRIPTION
Changes needed:

 * FunctionInterfaces.h has moved to the mlir/Interfaces/ directory.

 * FunctionOpInterface is now a subclass to CallableOpInterface, so getCallableRegion() has to be implemented for RustFuncOp and RustExtFuncOp.

 * The binop folder now supports poison, so we explicitly have to disable the poison support for our integer operations.